### PR TITLE
[WIP] Add --auto-restart option to automatically recover expired sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `--no-auto-restart` option for `connect` command to disable automatic bridge restart on crash (default: auto-restart enabled)
 - x402 payments are now also sent via the MCP `_meta["x402/payment"]` field on `tools/call` requests, in addition to the existing HTTP `PAYMENT-SIGNATURE` header — servers can choose which mechanism to consume
 - `_meta` parameter threaded through the full tool call chain (`IMcpClient`, `SessionClient`, bridge IPC, `McpClient`) for forward compatibility
 - `mcpc login` now falls back to accepting a pasted callback URL when the browser cannot be opened (e.g. headless servers, containers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--auto-restart` option for `connect` command to automatically restart the bridge on crash; without this flag, crashed bridges require manual restart via `mcpc @session restart`
+- `--auto-restart` option for `connect` command to automatically restart expired sessions (server rejected session ID) instead of requiring manual `mcpc @session restart`
 - x402 payments are now also sent via the MCP `_meta["x402/payment"]` field on `tools/call` requests, in addition to the existing HTTP `PAYMENT-SIGNATURE` header — servers can choose which mechanism to consume
 - `_meta` parameter threaded through the full tool call chain (`IMcpClient`, `SessionClient`, bridge IPC, `McpClient`) for forward compatibility
 - `mcpc login` now falls back to accepting a pasted callback URL when the browser cannot be opened (e.g. headless servers, containers)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `--auto-restart` help text now clarifies that restarting loses session state
 - **Breaking:** CLI syntax redesigned to command-first style. All commands now start with a verb; MCP operations require a named session.
 
   | Before                                        | After                                                      |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--no-auto-restart` option for `connect` command to disable automatic bridge restart on crash (default: auto-restart enabled)
+- `--auto-restart` option for `connect` command to automatically restart the bridge on crash; without this flag, crashed bridges require manual restart via `mcpc @session restart`
 - x402 payments are now also sent via the MCP `_meta["x402/payment"]` field on `tools/call` requests, in addition to the existing HTTP `PAYMENT-SIGNATURE` header — servers can choose which mechanism to consume
 - `_meta` parameter threaded through the full tool call chain (`IMcpClient`, `SessionClient`, bridge IPC, `McpClient`) for forward compatibility
 - `mcpc login` now falls back to accepting a pasted callback URL when the browser cannot be opened (e.g. headless servers, containers)

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -30,7 +30,12 @@ import {
   consolidateSessions,
   getSession,
 } from '../../lib/sessions.js';
-import { startBridge, StartBridgeOptions, stopBridge } from '../../lib/bridge-manager.js';
+import {
+  startBridge,
+  StartBridgeOptions,
+  stopBridge,
+  restartBridge,
+} from '../../lib/bridge-manager.js';
 import {
   storeKeychainSessionHeaders,
   storeKeychainProxyBearerToken,
@@ -595,86 +600,31 @@ export async function restartSession(
   options: { outputMode: OutputMode; verbose?: boolean }
 ): Promise<void> {
   try {
-    // Get existing session
+    // Verify session exists
     const session = await getSession(name);
-
     if (!session) {
       throw new ClientError(`Session not found: ${name}`);
+    }
+
+    if (!session.server) {
+      throw new ClientError(`Session ${name} has no server configuration`);
     }
 
     if (options.outputMode === 'human') {
       console.log(chalk.yellow(`Restarting session ${name}...`));
     }
 
-    // Stop the bridge (even if it's alive)
-    try {
-      await stopBridge(name);
-    } catch {
-      // Bridge may already be stopped
-    }
-
-    // Get server config from session
-    const serverConfig = session.server;
-    if (!serverConfig) {
-      throw new ClientError(`Session ${name} has no server configuration`);
-    }
-
-    // Load headers from keychain if present
-    const { readKeychainSessionHeaders } = await import('../../lib/auth/keychain.js');
-    const headers = await readKeychainSessionHeaders(name);
-
-    // Start bridge process
-    const bridgeOptions: StartBridgeOptions = {
-      sessionName: name,
-      serverConfig: { ...serverConfig, ...(headers && { headers }) },
+    // Delegate to restartBridge with freshSession=true to create a clean MCP session
+    // and re-discover auth profiles (handles the case where user ran `mcpc login` after connect)
+    await restartBridge(name, {
+      freshSession: true,
       verbose: options.verbose || false,
-    };
+      resolveProfile: async (serverUrl, sessionName) => {
+        return resolveAuthProfile(serverUrl, serverUrl, undefined, { sessionName });
+      },
+    });
 
-    if (headers) {
-      bridgeOptions.headers = headers;
-    }
-
-    // Resolve auth profile: use stored profile, or auto-detect a "default" profile.
-    // This handles the case where user creates a session without auth, then later runs
-    // `mcpc login <server>` to create a default profile, and restarts the session.
-    const hasExplicitAuthHeader = headers?.Authorization !== undefined;
-    let profileName = session.profileName;
-    if (!profileName && serverConfig.url && !hasExplicitAuthHeader) {
-      profileName = await resolveAuthProfile(serverConfig.url, serverConfig.url, undefined, {
-        sessionName: name,
-      });
-      if (profileName) {
-        logger.debug(`Discovered auth profile "${profileName}" for session ${name}`);
-        await updateSession(name, { profileName });
-      }
-    }
-
-    if (profileName) {
-      bridgeOptions.profileName = profileName;
-    }
-
-    if (session.proxy) {
-      bridgeOptions.proxyConfig = session.proxy;
-    }
-
-    if (session.x402) {
-      bridgeOptions.x402 = session.x402;
-    }
-
-    if (session.insecure) {
-      bridgeOptions.insecure = session.insecure;
-    }
-
-    // NOTE: Do NOT pass mcpSessionId on explicit restart.
-    // Explicit restart should create a fresh session, not try to resume the old one.
-    // Session resumption is only attempted on automatic bridge restart (when bridge crashes
-    // and CLI detects it). If server rejects the session ID, session is marked as expired.
-
-    const { pid } = await startBridge(bridgeOptions);
-
-    // Update session with new bridge PID and clear any expired/crashed status
-    await updateSession(name, { pid, status: 'active' });
-    logger.debug(`Session ${name} restarted with bridge PID: ${pid}`);
+    logger.debug(`Session ${name} restarted successfully`);
 
     // Success message
     if (options.outputMode === 'human') {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -234,7 +234,7 @@ export async function connectSession(
     ...(proxyConfig && { proxy: proxyConfig }),
     ...(options.x402 && { x402: true }),
     ...(options.insecure && { insecure: true }),
-    ...(options.autoRestart === false && { autoRestart: false }),
+    ...(options.autoRestart && { autoRestart: true }),
   };
 
   if (isReconnect) {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -88,6 +88,7 @@ export async function connectSession(
     proxyBearerToken?: string;
     x402?: boolean;
     insecure?: boolean;
+    autoRestart?: boolean;
   }
 ): Promise<void> {
   // Validate session name
@@ -233,6 +234,7 @@ export async function connectSession(
     ...(proxyConfig && { proxy: proxyConfig }),
     ...(options.x402 && { x402: true }),
     ...(options.insecure && { insecure: true }),
+    ...(options.autoRestart === false && { autoRestart: false }),
   };
 
   if (isReconnect) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -375,7 +375,7 @@ Full docs: ${docsUrl}`
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')
-    .option('--auto-restart', 'Automatically restart bridge on crash (default: no restart)')
+    .option('--auto-restart', 'Automatically restart session when it expires')
     .addHelpText(
       'after',
       `

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -375,7 +375,7 @@ Full docs: ${docsUrl}`
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')
-    .option('--auto-restart', 'Automatically restart session when it expires')
+    .option('--auto-restart', 'Automatically restart session when it expires (loses state)')
     .addHelpText(
       'after',
       `

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -375,6 +375,7 @@ Full docs: ${docsUrl}`
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')
+    .option('--no-auto-restart', 'Disable automatic bridge restart on crash')
     .addHelpText(
       'after',
       `
@@ -421,6 +422,7 @@ Server formats:
           proxyBearerToken: opts.proxyBearerToken,
           x402: opts.x402,
           ...(globalOpts.insecure && { insecure: true }),
+          ...(!opts.autoRestart && { autoRestart: false }),
         });
       } else {
         await sessions.connectSession(server, sessionName, {
@@ -430,6 +432,7 @@ Server formats:
           proxyBearerToken: opts.proxyBearerToken,
           x402: opts.x402,
           ...(globalOpts.insecure && { insecure: true }),
+          ...(!opts.autoRestart && { autoRestart: false }),
         });
       }
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -375,7 +375,7 @@ Full docs: ${docsUrl}`
     .option('--proxy <[host:]port>', 'Start proxy MCP server for session')
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--x402', 'Enable x402 auto-payment using the configured wallet')
-    .option('--no-auto-restart', 'Disable automatic bridge restart on crash')
+    .option('--auto-restart', 'Automatically restart bridge on crash (default: no restart)')
     .addHelpText(
       'after',
       `
@@ -422,7 +422,7 @@ Server formats:
           proxyBearerToken: opts.proxyBearerToken,
           x402: opts.x402,
           ...(globalOpts.insecure && { insecure: true }),
-          ...(!opts.autoRestart && { autoRestart: false }),
+          ...(opts.autoRestart && { autoRestart: true }),
         });
       } else {
         await sessions.connectSession(server, sessionName, {
@@ -432,7 +432,7 @@ Server formats:
           proxyBearerToken: opts.proxyBearerToken,
           x402: opts.x402,
           ...(globalOpts.insecure && { insecure: true }),
-          ...(!opts.autoRestart && { autoRestart: false }),
+          ...(opts.autoRestart && { autoRestart: true }),
         });
       }
     });

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -44,47 +44,30 @@ import { getWallet } from './wallets.js';
 
 const logger = createLogger('bridge-manager');
 
+type SessionErrorKind = 'expired' | 'unauthorized' | 'unknown';
+
 /**
- * Classify a bridge health check error as session expiry or auth failure and throw.
- * Session expiry (404/session-not-found) is checked first since it's more specific
- * than auth errors (401/403/unauthorized). Does nothing if neither pattern matches.
- *
- * When autoRestart is true, session expiry is marked but not thrown — the caller
- * is expected to handle the restart. Returns 'expired' in this case.
+ * Classify a bridge health check error and update session status accordingly.
+ * Never throws — callers decide how to handle each classification.
  */
-async function classifyAndThrowSessionError(
+async function classifySessionError(
   sessionName: string,
-  session: { server: ServerConfig; autoRestart?: boolean },
-  errorMessage: string,
-  originalError?: Error
-): Promise<'expired' | void> {
+  errorMessage: string
+): Promise<SessionErrorKind> {
+  // Session expiry (404/session-not-found) checked first — more specific than auth errors (401/403)
   if (isSessionExpiredError(errorMessage)) {
     await updateSession(sessionName, { status: 'expired' }).catch((e) =>
       logger.warn(`Failed to mark session ${sessionName} as expired:`, e)
     );
-
-    if (session.autoRestart) {
-      logger.debug(`Session ${sessionName} expired, auto-restart enabled — deferring to caller`);
-      return 'expired';
-    }
-
-    const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
-    throw new ClientError(
-      `Session ${sessionName} expired (server rejected session ID). ` +
-        `Use "mcpc ${sessionName} restart" to start a new session. ` +
-        `For details, check logs at ${logPath}`
-    );
+    return 'expired';
   }
   if (isAuthenticationError(errorMessage)) {
     await updateSession(sessionName, { status: 'unauthorized' }).catch((e) =>
       logger.warn(`Failed to mark session ${sessionName} as unauthorized:`, e)
     );
-    const target = session.server.url || session.server.command || sessionName;
-    throw createServerAuthError(target, {
-      sessionName,
-      ...(originalError && { originalError }),
-    });
+    return 'unauthorized';
   }
+  return 'unknown';
 }
 
 // Get the path to the bridge executable
@@ -589,14 +572,14 @@ async function autoRestartExpiredBridge(
     return socketPath;
   }
 
-  // Auto-restart failed - classify the error (omit autoRestart to prevent retry loop)
+  // Auto-restart failed
   const errorMsg = result.error?.message || 'unknown error';
-  await classifyAndThrowSessionError(
-    sessionName,
-    { server: session.server },
-    errorMsg,
-    result.error
-  );
+  const kind = await classifySessionError(sessionName, errorMsg);
+
+  if (kind === 'unauthorized') {
+    const target = session.server.url || session.server.command || sessionName;
+    throw createServerAuthError(target, { sessionName, originalError: result.error });
+  }
 
   const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
   throw new ClientError(
@@ -647,20 +630,27 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     // Not healthy - check error type
     if (result.error) {
       const errorMessage = result.error.message || '';
-      const classification = await classifyAndThrowSessionError(
-        sessionName,
-        session,
-        errorMessage,
-        result.error
-      );
-      if (classification === 'expired') {
+      const kind = await classifySessionError(sessionName, errorMessage);
+
+      if (kind === 'expired' && session.autoRestart) {
         await stopBridge(sessionName).catch(() => {});
         return autoRestartExpiredBridge(sessionName, session, 'detected during health check');
+      }
+      if (kind === 'expired') {
+        const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+        throw new ClientError(
+          `Session ${sessionName} expired (server rejected session ID). ` +
+            `Use "mcpc ${sessionName} restart" to start a new session. ` +
+            `For details, check logs at ${logPath}`
+        );
+      }
+      if (kind === 'unauthorized') {
+        const target = session.server.url || session.server.command || sessionName;
+        throw createServerAuthError(target, { sessionName, originalError: result.error });
       }
       if (result.error instanceof NetworkError) {
         logger.debug(`Bridge process alive but socket not responding for ${sessionName}`);
       } else {
-        // Other MCP errors - propagate
         throw new ClientError(
           `Bridge for ${sessionName} failed to connect to MCP server: ${result.error.message}`
         );
@@ -680,11 +670,23 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     return socketPath;
   }
 
-  // Not healthy after restart - classify the error
+  // Not healthy after restart - classify and throw
   const errorMsg = result.error?.message || 'unknown error';
-  await classifyAndThrowSessionError(sessionName, session, errorMsg, result.error);
+  const kind = await classifySessionError(sessionName, errorMsg);
 
-  // Other errors - provide detailed error with log path
+  if (kind === 'expired') {
+    const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+    throw new ClientError(
+      `Session ${sessionName} expired (server rejected session ID). ` +
+        `Use "mcpc ${sessionName} restart" to start a new session. ` +
+        `For details, check logs at ${logPath}`
+    );
+  }
+  if (kind === 'unauthorized') {
+    const target = session.server.url || session.server.command || sessionName;
+    throw createServerAuthError(target, { sessionName, originalError: result.error });
+  }
+
   const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
   throw new ClientError(
     `Bridge for ${sessionName} failed after restart: ${errorMsg}. ` +

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -297,15 +297,39 @@ export async function stopBridge(sessionName: string): Promise<void> {
   // Full cleanup happens in closeSession().
 }
 
+export interface RestartBridgeOptions {
+  /**
+   * When true, creates a fresh MCP session (no session ID resumption) and
+   * re-discovers auth profiles. Used for explicit user-initiated restarts.
+   * When false (default), attempts to resume the existing MCP session.
+   */
+  freshSession?: boolean;
+  /** Verbose logging flag passed to the bridge process */
+  verbose?: boolean;
+  /**
+   * Optional callback to resolve an auth profile name for the session.
+   * Only called when freshSession is true and the session has no stored profile.
+   * This allows the CLI layer to inject its own profile resolution logic.
+   */
+  resolveProfile?: (serverUrl: string, sessionName: string) => Promise<string | undefined>;
+}
+
 /**
  * Restart a bridge process for a session
- * Used for automatic recovery when connection to bridge fails
+ * Used for automatic recovery when connection to bridge fails, and also
+ * for explicit user-initiated restarts (with freshSession: true).
  *
  * Headers persist in keychain across bridge restarts, so they are
  * retrieved here and passed to startBridge() which sends them via IPC.
  */
-export async function restartBridge(sessionName: string): Promise<StartBridgeResult> {
-  logger.debug(`Trying to restart bridge for ${sessionName}...`);
+export async function restartBridge(
+  sessionName: string,
+  options: RestartBridgeOptions = {}
+): Promise<StartBridgeResult> {
+  const { freshSession = false, verbose, resolveProfile } = options;
+  logger.debug(
+    `Trying to restart bridge for ${sessionName}${freshSession ? ' (fresh session)' : ''}...`
+  );
 
   const session = await getSession(sessionName);
 
@@ -340,24 +364,42 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
     logger.debug(`Retrieved ${expectedHeaderKeys.length} headers from keychain for failover`);
   }
 
-  // Start a new bridge, preserving auth profile, proxy config, MCP session ID, and wallet
+  // Start a new bridge, preserving auth profile, proxy config, and wallet
   const bridgeOptions: StartBridgeOptions = {
     sessionName,
     serverConfig: serverConfig,
+    ...(verbose !== undefined && { verbose }),
   };
   if (headers) {
     bridgeOptions.headers = headers;
   }
-  if (session.profileName) {
-    bridgeOptions.profileName = session.profileName;
+
+  // Resolve auth profile: use stored profile, or re-discover via callback on fresh restart
+  let profileName = session.profileName;
+  if (freshSession && !profileName && serverConfig.url && resolveProfile) {
+    const hasExplicitAuthHeader = headers?.Authorization !== undefined;
+    if (!hasExplicitAuthHeader) {
+      profileName = await resolveProfile(serverConfig.url, sessionName);
+      if (profileName) {
+        logger.debug(`Discovered auth profile "${profileName}" for session ${sessionName}`);
+        await updateSession(sessionName, { profileName });
+      }
+    }
   }
+  if (profileName) {
+    bridgeOptions.profileName = profileName;
+  }
+
   if (session.proxy) {
     bridgeOptions.proxyConfig = session.proxy;
   }
-  if (session.mcpSessionId) {
+
+  // Only attempt MCP session resumption on automatic restarts (not fresh restarts)
+  if (!freshSession && session.mcpSessionId) {
     bridgeOptions.mcpSessionId = session.mcpSessionId;
     logger.debug(`Using saved MCP session ID for resumption: ${session.mcpSessionId}`);
   }
+
   if (session.x402) {
     bridgeOptions.x402 = session.x402;
     logger.debug('Using saved x402 flag');
@@ -369,8 +411,8 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
 
   const { pid } = await startBridge(bridgeOptions);
 
-  // Update session with new PID
-  await updateSession(sessionName, { pid });
+  // Update session with new PID and clear any expired/crashed status
+  await updateSession(sessionName, { pid, status: 'active' });
 
   logger.debug(`Bridge restarted for ${sessionName} with PID: ${pid}`);
 
@@ -525,6 +567,44 @@ async function checkBridgeHealth(socketPath: string): Promise<BridgeHealthResult
  * @returns The socket path of the healthy bridge
  * @throws ClientError if bridge cannot be made healthy
  */
+/**
+ * Auto-restart an expired session's bridge and verify health.
+ * Shared by both the "already expired" and "expired during health check" code paths.
+ *
+ * @returns The socket path if the restart succeeded
+ * @throws ClientError if the restart failed (with autoRestart disabled for retry to prevent loops)
+ */
+async function autoRestartExpiredBridge(
+  sessionName: string,
+  session: { server: ServerConfig },
+  context: string
+): Promise<string> {
+  logger.debug(`Session ${sessionName} expired (${context}), auto-restarting...`);
+  await restartBridge(sessionName);
+
+  const socketPath = getSocketPath(sessionName);
+  const result = await checkBridgeHealth(socketPath);
+  if (result.healthy) {
+    logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
+    return socketPath;
+  }
+
+  // Auto-restart failed - classify the error (omit autoRestart to prevent retry loop)
+  const errorMsg = result.error?.message || 'unknown error';
+  await classifyAndThrowSessionError(
+    sessionName,
+    { server: session.server },
+    errorMsg,
+    result.error
+  );
+
+  const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+  throw new ClientError(
+    `Session ${sessionName} failed to auto-restart after expiry: ${errorMsg}. ` +
+      `For details, check logs at ${logPath}`
+  );
+}
+
 export async function ensureBridgeReady(sessionName: string): Promise<string> {
   const session = await getSession(sessionName);
 
@@ -539,32 +619,7 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
 
   if (session.status === 'expired') {
     if (session.autoRestart) {
-      logger.debug(`Session ${sessionName} expired, auto-restarting...`);
-      // Clear expired status so restartBridge can proceed
-      await updateSession(sessionName, { status: 'active' });
-      await restartBridge(sessionName);
-
-      const socketPath = getSocketPath(sessionName);
-      const result = await checkBridgeHealth(socketPath);
-      if (result.healthy) {
-        logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
-        return socketPath;
-      }
-
-      // Auto-restart failed - classify the error (omit autoRestart to prevent retry loop)
-      const errorMsg = result.error?.message || 'unknown error';
-      await classifyAndThrowSessionError(
-        sessionName,
-        { server: session.server },
-        errorMsg,
-        result.error
-      );
-
-      const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
-      throw new ClientError(
-        `Session ${sessionName} failed to auto-restart after expiry: ${errorMsg}. ` +
-          `For details, check logs at ${logPath}`
-      );
+      return autoRestartExpiredBridge(sessionName, session, 'status was expired');
     }
 
     throw new ClientError(
@@ -599,32 +654,8 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
         result.error
       );
       if (classification === 'expired') {
-        // Auto-restart handles expiry below via the shared restart path
-        logger.debug(`Session ${sessionName} expired during health check, auto-restarting...`);
         await stopBridge(sessionName).catch(() => {});
-        await updateSession(sessionName, { status: 'active' });
-        await restartBridge(sessionName);
-
-        const retryResult = await checkBridgeHealth(socketPath);
-        if (retryResult.healthy) {
-          logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
-          return socketPath;
-        }
-
-        const retryMsg = retryResult.error?.message || 'unknown error';
-        // On retry failure, don't loop — pass autoRestart=false equivalent by using a plain session
-        await classifyAndThrowSessionError(
-          sessionName,
-          { server: session.server },
-          retryMsg,
-          retryResult.error
-        );
-
-        const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
-        throw new ClientError(
-          `Session ${sessionName} failed to auto-restart after expiry: ${retryMsg}. ` +
-            `For details, check logs at ${logPath}`
-        );
+        return autoRestartExpiredBridge(sessionName, session, 'detected during health check');
       }
       if (result.error instanceof NetworkError) {
         logger.debug(`Bridge process alive but socket not responding for ${sessionName}`);

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -567,12 +567,13 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     logger.debug(`Bridge process not alive for ${sessionName}, will try to restart it`);
   }
 
-  // Bridge not healthy - check if auto-restart is disabled
-  if (session.autoRestart === false) {
+  // Bridge not healthy - only auto-restart if explicitly enabled
+  if (session.autoRestart !== true) {
     const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
     throw new ClientError(
-      `Bridge for ${sessionName} is not running (auto-restart is disabled).\n` +
+      `Bridge for ${sessionName} is not running.\n` +
         `To restart manually, run: mcpc ${sessionName} restart\n` +
+        `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${sessionName}\n` +
         `For details, check logs at ${logPath}`
     );
   }

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -567,6 +567,16 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     logger.debug(`Bridge process not alive for ${sessionName}, will try to restart it`);
   }
 
+  // Bridge not healthy - check if auto-restart is disabled
+  if (session.autoRestart === false) {
+    const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+    throw new ClientError(
+      `Bridge for ${sessionName} is not running (auto-restart is disabled).\n` +
+        `To restart manually, run: mcpc ${sessionName} restart\n` +
+        `For details, check logs at ${logPath}`
+    );
+  }
+
   // Bridge not healthy - restart it
   await restartBridge(sessionName);
 

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -48,17 +48,26 @@ const logger = createLogger('bridge-manager');
  * Classify a bridge health check error as session expiry or auth failure and throw.
  * Session expiry (404/session-not-found) is checked first since it's more specific
  * than auth errors (401/403/unauthorized). Does nothing if neither pattern matches.
+ *
+ * When autoRestart is true, session expiry is marked but not thrown — the caller
+ * is expected to handle the restart. Returns 'expired' in this case.
  */
 async function classifyAndThrowSessionError(
   sessionName: string,
-  session: { server: ServerConfig },
+  session: { server: ServerConfig; autoRestart?: boolean },
   errorMessage: string,
   originalError?: Error
-): Promise<void> {
+): Promise<'expired' | void> {
   if (isSessionExpiredError(errorMessage)) {
     await updateSession(sessionName, { status: 'expired' }).catch((e) =>
       logger.warn(`Failed to mark session ${sessionName} as expired:`, e)
     );
+
+    if (session.autoRestart) {
+      logger.debug(`Session ${sessionName} expired, auto-restart enabled — deferring to caller`);
+      return 'expired';
+    }
+
     const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
     throw new ClientError(
       `Session ${sessionName} expired (server rejected session ID). ` +
@@ -529,11 +538,41 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
   }
 
   if (session.status === 'expired') {
+    if (session.autoRestart) {
+      logger.debug(`Session ${sessionName} expired, auto-restarting...`);
+      // Clear expired status so restartBridge can proceed
+      await updateSession(sessionName, { status: 'active' });
+      await restartBridge(sessionName);
+
+      const socketPath = getSocketPath(sessionName);
+      const result = await checkBridgeHealth(socketPath);
+      if (result.healthy) {
+        logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
+        return socketPath;
+      }
+
+      // Auto-restart failed - classify the error (omit autoRestart to prevent retry loop)
+      const errorMsg = result.error?.message || 'unknown error';
+      await classifyAndThrowSessionError(
+        sessionName,
+        { server: session.server },
+        errorMsg,
+        result.error
+      );
+
+      const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+      throw new ClientError(
+        `Session ${sessionName} failed to auto-restart after expiry: ${errorMsg}. ` +
+          `For details, check logs at ${logPath}`
+      );
+    }
+
     throw new ClientError(
       `Session ${sessionName} has expired. ` +
         `The MCP server indicated the session is no longer valid.\n` +
         `To restart the session, run: mcpc ${sessionName} restart\n` +
-        `To remove the expired session, run: mcpc ${sessionName} close`
+        `To remove the expired session, run: mcpc ${sessionName} close\n` +
+        `To enable automatic restarts on expiry, recreate with: mcpc connect --auto-restart <server> ${sessionName}`
     );
   }
 
@@ -553,7 +592,40 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     // Not healthy - check error type
     if (result.error) {
       const errorMessage = result.error.message || '';
-      await classifyAndThrowSessionError(sessionName, session, errorMessage, result.error);
+      const classification = await classifyAndThrowSessionError(
+        sessionName,
+        session,
+        errorMessage,
+        result.error
+      );
+      if (classification === 'expired') {
+        // Auto-restart handles expiry below via the shared restart path
+        logger.debug(`Session ${sessionName} expired during health check, auto-restarting...`);
+        await stopBridge(sessionName).catch(() => {});
+        await updateSession(sessionName, { status: 'active' });
+        await restartBridge(sessionName);
+
+        const retryResult = await checkBridgeHealth(socketPath);
+        if (retryResult.healthy) {
+          logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
+          return socketPath;
+        }
+
+        const retryMsg = retryResult.error?.message || 'unknown error';
+        // On retry failure, don't loop — pass autoRestart=false equivalent by using a plain session
+        await classifyAndThrowSessionError(
+          sessionName,
+          { server: session.server },
+          retryMsg,
+          retryResult.error
+        );
+
+        const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
+        throw new ClientError(
+          `Session ${sessionName} failed to auto-restart after expiry: ${retryMsg}. ` +
+            `For details, check logs at ${logPath}`
+        );
+      }
       if (result.error instanceof NetworkError) {
         logger.debug(`Bridge process alive but socket not responding for ${sessionName}`);
       } else {
@@ -565,17 +637,6 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
     }
   } else {
     logger.debug(`Bridge process not alive for ${sessionName}, will try to restart it`);
-  }
-
-  // Bridge not healthy - only auto-restart if explicitly enabled
-  if (session.autoRestart !== true) {
-    const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
-    throw new ClientError(
-      `Bridge for ${sessionName} is not running.\n` +
-        `To restart manually, run: mcpc ${sessionName} restart\n` +
-        `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${sessionName}\n` +
-        `For details, check logs at ${logPath}`
-    );
   }
 
   // Bridge not healthy - restart it

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -394,8 +394,11 @@ export async function restartBridge(
 
   const { pid } = await startBridge(bridgeOptions);
 
-  // Update session with new PID and clear any expired/crashed status
-  await updateSession(sessionName, { pid, status: 'active' });
+  // Update session with new PID.
+  // For fresh restarts (explicit user action), set status to active immediately.
+  // For automatic restarts (crash recovery), leave status unchanged — the caller
+  // (ensureBridgeReady) verifies health and classifies errors before updating status.
+  await updateSession(sessionName, { pid, ...(freshSession && { status: 'active' }) });
 
   logger.debug(`Bridge restarted for ${sessionName} with PID: ${pid}`);
 
@@ -568,17 +571,21 @@ async function autoRestartExpiredBridge(
   const socketPath = getSocketPath(sessionName);
   const result = await checkBridgeHealth(socketPath);
   if (result.healthy) {
+    await updateSession(sessionName, { status: 'active' });
     logger.debug(`Session ${sessionName} auto-restarted successfully after expiry`);
     return socketPath;
   }
 
-  // Auto-restart failed
+  // Auto-restart failed — classify the new error
   const errorMsg = result.error?.message || 'unknown error';
   const kind = await classifySessionError(sessionName, errorMsg);
 
   if (kind === 'unauthorized') {
     const target = session.server.url || session.server.command || sessionName;
-    throw createServerAuthError(target, { sessionName, originalError: result.error });
+    throw createServerAuthError(target, {
+      sessionName,
+      ...(result.error && { originalError: result.error }),
+    });
   }
 
   const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;
@@ -666,6 +673,7 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
   // Try getServerDetails on restarted bridge (blocks until MCP connected)
   const result = await checkBridgeHealth(socketPath);
   if (result.healthy) {
+    await updateSession(sessionName, { status: 'active' });
     logger.debug(`Bridge for ${sessionName} passed health check`);
     return socketPath;
   }
@@ -684,7 +692,10 @@ export async function ensureBridgeReady(sessionName: string): Promise<string> {
   }
   if (kind === 'unauthorized') {
     const target = session.server.url || session.server.command || sessionName;
-    throw createServerAuthError(target, { sessionName, originalError: result.error });
+    throw createServerAuthError(target, {
+      sessionName,
+      ...(result.error && { originalError: result.error }),
+    });
   }
 
   const logPath = `${getLogsDir()}/bridge-${sessionName}.log`;

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -35,7 +35,6 @@ import { BridgeClient } from './bridge-client.js';
 import { ensureBridgeReady, restartBridge } from './bridge-manager.js';
 import { NetworkError } from './errors.js';
 import { getSocketPath, getLogsDir, generateRequestId } from './utils.js';
-import { getSession } from './sessions.js';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('session-client');
@@ -48,13 +47,11 @@ export class SessionClient extends EventEmitter implements IMcpClient {
   private bridgeClient: BridgeClient;
   private sessionName: string;
   private requestTimeout?: number; // Per-request timeout in seconds
-  private autoRestart: boolean; // Whether to auto-restart bridge on crash
 
-  constructor(sessionName: string, bridgeClient: BridgeClient, autoRestart = false) {
+  constructor(sessionName: string, bridgeClient: BridgeClient) {
     super();
     this.sessionName = sessionName;
     this.bridgeClient = bridgeClient;
-    this.autoRestart = autoRestart;
     this.setupNotificationForwarding();
   }
 
@@ -97,17 +94,6 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
         err.message = `${err.message}. For details, check logs at ${logPath}`;
         throw error;
-      }
-
-      // Only auto-restart if explicitly enabled
-      if (!this.autoRestart) {
-        const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
-        throw new NetworkError(
-          `Bridge for ${this.sessionName} connection failed.\n` +
-            `To restart manually, run: mcpc ${this.sessionName} restart\n` +
-            `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${this.sessionName}\n` +
-            `For details, check logs at ${logPath}`
-        );
       }
 
       logger.debug(`Socket error during ${operationName}, will restart bridge...`);
@@ -337,17 +323,6 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         throw error;
       }
 
-      // Only auto-restart if explicitly enabled
-      if (!this.autoRestart) {
-        const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
-        throw new NetworkError(
-          `Bridge for ${this.sessionName} connection failed.\n` +
-            `To restart manually, run: mcpc ${this.sessionName} restart\n` +
-            `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${this.sessionName}\n` +
-            `For details, check logs at ${logPath}`
-        );
-      }
-
       logger.debug(`Socket error during callToolWithTask, will restart bridge...`);
       await this.bridgeClient.close();
       await restartBridge(this.sessionName);
@@ -471,16 +446,12 @@ export async function createSessionClient(sessionName: string): Promise<SessionC
   // Ensure bridge is healthy (may restart it)
   const socketPath = await ensureBridgeReady(sessionName);
 
-  // Load session to check autoRestart setting
-  const session = await getSession(sessionName);
-  const autoRestart = session?.autoRestart === true;
-
   // Connect to the healthy bridge
   const bridgeClient = new BridgeClient(socketPath);
   await bridgeClient.connect();
 
-  logger.debug(`Created SessionClient for ${sessionName} (autoRestart: ${autoRestart})`);
-  return new SessionClient(sessionName, bridgeClient, autoRestart);
+  logger.debug(`Created SessionClient for ${sessionName}`);
+  return new SessionClient(sessionName, bridgeClient);
 }
 
 /**

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -35,6 +35,7 @@ import { BridgeClient } from './bridge-client.js';
 import { ensureBridgeReady, restartBridge } from './bridge-manager.js';
 import { NetworkError } from './errors.js';
 import { getSocketPath, getLogsDir, generateRequestId } from './utils.js';
+import { getSession } from './sessions.js';
 import { createLogger } from './logger.js';
 
 const logger = createLogger('session-client');
@@ -47,11 +48,13 @@ export class SessionClient extends EventEmitter implements IMcpClient {
   private bridgeClient: BridgeClient;
   private sessionName: string;
   private requestTimeout?: number; // Per-request timeout in seconds
+  private autoRestart: boolean; // Whether to auto-restart bridge on crash
 
-  constructor(sessionName: string, bridgeClient: BridgeClient) {
+  constructor(sessionName: string, bridgeClient: BridgeClient, autoRestart = true) {
     super();
     this.sessionName = sessionName;
     this.bridgeClient = bridgeClient;
+    this.autoRestart = autoRestart;
     this.setupNotificationForwarding();
   }
 
@@ -94,6 +97,16 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
         err.message = `${err.message}. For details, check logs at ${logPath}`;
         throw error;
+      }
+
+      // If auto-restart is disabled, don't retry
+      if (!this.autoRestart) {
+        const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
+        throw new NetworkError(
+          `Bridge for ${this.sessionName} connection failed (auto-restart is disabled).\n` +
+            `To restart manually, run: mcpc ${this.sessionName} restart\n` +
+            `For details, check logs at ${logPath}`
+        );
       }
 
       logger.debug(`Socket error during ${operationName}, will restart bridge...`);
@@ -323,6 +336,16 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         throw error;
       }
 
+      // If auto-restart is disabled, don't retry
+      if (!this.autoRestart) {
+        const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
+        throw new NetworkError(
+          `Bridge for ${this.sessionName} connection failed (auto-restart is disabled).\n` +
+            `To restart manually, run: mcpc ${this.sessionName} restart\n` +
+            `For details, check logs at ${logPath}`
+        );
+      }
+
       logger.debug(`Socket error during callToolWithTask, will restart bridge...`);
       await this.bridgeClient.close();
       await restartBridge(this.sessionName);
@@ -446,12 +469,16 @@ export async function createSessionClient(sessionName: string): Promise<SessionC
   // Ensure bridge is healthy (may restart it)
   const socketPath = await ensureBridgeReady(sessionName);
 
+  // Load session to check autoRestart setting
+  const session = await getSession(sessionName);
+  const autoRestart = session?.autoRestart !== false;
+
   // Connect to the healthy bridge
   const bridgeClient = new BridgeClient(socketPath);
   await bridgeClient.connect();
 
-  logger.debug(`Created SessionClient for ${sessionName}`);
-  return new SessionClient(sessionName, bridgeClient);
+  logger.debug(`Created SessionClient for ${sessionName} (autoRestart: ${autoRestart})`);
+  return new SessionClient(sessionName, bridgeClient, autoRestart);
 }
 
 /**

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -50,7 +50,7 @@ export class SessionClient extends EventEmitter implements IMcpClient {
   private requestTimeout?: number; // Per-request timeout in seconds
   private autoRestart: boolean; // Whether to auto-restart bridge on crash
 
-  constructor(sessionName: string, bridgeClient: BridgeClient, autoRestart = true) {
+  constructor(sessionName: string, bridgeClient: BridgeClient, autoRestart = false) {
     super();
     this.sessionName = sessionName;
     this.bridgeClient = bridgeClient;
@@ -99,12 +99,13 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         throw error;
       }
 
-      // If auto-restart is disabled, don't retry
+      // Only auto-restart if explicitly enabled
       if (!this.autoRestart) {
         const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
         throw new NetworkError(
-          `Bridge for ${this.sessionName} connection failed (auto-restart is disabled).\n` +
+          `Bridge for ${this.sessionName} connection failed.\n` +
             `To restart manually, run: mcpc ${this.sessionName} restart\n` +
+            `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${this.sessionName}\n` +
             `For details, check logs at ${logPath}`
         );
       }
@@ -336,12 +337,13 @@ export class SessionClient extends EventEmitter implements IMcpClient {
         throw error;
       }
 
-      // If auto-restart is disabled, don't retry
+      // Only auto-restart if explicitly enabled
       if (!this.autoRestart) {
         const logPath = `${getLogsDir()}/bridge-${this.sessionName}.log`;
         throw new NetworkError(
-          `Bridge for ${this.sessionName} connection failed (auto-restart is disabled).\n` +
+          `Bridge for ${this.sessionName} connection failed.\n` +
             `To restart manually, run: mcpc ${this.sessionName} restart\n` +
+            `To enable automatic restarts, recreate with: mcpc connect --auto-restart <server> ${this.sessionName}\n` +
             `For details, check logs at ${logPath}`
         );
       }
@@ -471,7 +473,7 @@ export async function createSessionClient(sessionName: string): Promise<SessionC
 
   // Load session to check autoRestart setting
   const session = await getSession(sessionName);
-  const autoRestart = session?.autoRestart !== false;
+  const autoRestart = session?.autoRestart === true;
 
   // Connect to the healthy bridge
   const bridgeClient = new BridgeClient(socketPath);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,7 +136,7 @@ export interface SessionData {
   profileName?: string; // Name of auth profile (for OAuth servers)
   x402?: boolean; // x402 auto-payment enabled for this session
   insecure?: boolean; // Skip TLS certificate verification
-  autoRestart?: boolean; // Auto-restart bridge on crash (default: true)
+  autoRestart?: boolean; // Auto-restart bridge on crash (default: false)
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
   mcpSessionId?: string; // Server-assigned MCP session ID for resumption (Streamable HTTP only)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,6 +136,7 @@ export interface SessionData {
   profileName?: string; // Name of auth profile (for OAuth servers)
   x402?: boolean; // x402 auto-payment enabled for this session
   insecure?: boolean; // Skip TLS certificate verification
+  autoRestart?: boolean; // Auto-restart bridge on crash (default: true)
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
   mcpSessionId?: string; // Server-assigned MCP session ID for resumption (Streamable HTTP only)


### PR DESCRIPTION
## Summary
This PR adds an `--auto-restart` option to the `connect` command that enables automatic recovery when MCP server sessions expire, eliminating the need for manual `mcpc @session restart` commands.

## Key Changes

- **New CLI option**: Added `--auto-restart` flag to the `connect` command that persists the setting in session configuration
- **Session expiry handling**: Modified `classifyAndThrowSessionError()` to return `'expired'` when `autoRestart` is enabled, allowing callers to handle recovery instead of throwing immediately
- **Auto-recovery logic**: Enhanced `ensureBridgeReady()` to detect expired sessions and automatically:
  - Stop the existing bridge process
  - Restart the bridge
  - Verify health after restart
  - Fall back to error handling if restart fails
- **Dual recovery paths**: Implemented auto-restart handling both for:
  - Sessions already marked as expired (checked at start of `ensureBridgeReady()`)
  - Sessions that expire during health checks (detected via return value from `classifyAndThrowSessionError()`)
- **Error prevention**: When auto-restart fails, the code avoids infinite loops by passing `autoRestart=false` equivalent to error classification on retry
- **User guidance**: Updated error messages to inform users about the `--auto-restart` option for enabling automatic recovery

## Implementation Details

- The `autoRestart` flag is stored in `SessionData` and passed through the session configuration
- Auto-restart is only attempted once per health check cycle to prevent infinite retry loops
- Failed auto-restarts still provide detailed error messages with log file paths for debugging
- The feature gracefully degrades — if auto-restart fails, users get clear instructions on manual recovery options

https://claude.ai/code/session_01JguVLhdg3mmrejPXf9RehX