### PR TITLE
Implement resource subscriptions with file sync (resources-subscribe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `mcpc login --callback-host <host>` to set the host used in the OAuth callback redirect URI: `127.0.0.1` (default) or `localhost`, for servers whose pre-registered OAuth client only accepts the `localhost` form. The callback server itself still binds only to the loopback IP (#269).
+- `resources-read` can now save resources to a local file with `-o <file>` (binary-safe, decodes base64 `blob` content) and print bare content for piping with `--raw`. The default human view shows text content in a fenced block and summarizes binary content instead of dumping it to the terminal.
+
+### Changed
+
+- `resources-subscribe <uri> <file>` now keeps a local file in sync with the resource: it downloads the resource to `<file>` and the session bridge rewrites the file whenever the server announces a change (`notifications/resources/updated`). Subscriptions survive session restarts and are shown in `mcpc @<session>` output. `resources-unsubscribe` stops the syncing and keeps the file. Previously these commands only sent the subscribe/unsubscribe requests without acting on the notifications.
+- `resources-read --max-size <bytes>` was removed; the option was accepted but never enforced. Use `--max-chars` to limit human-readable output.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -549,7 +549,7 @@ On failure, the error message includes instructions on how to login. This ensure
 
 All state files are stored in `~/.mcpc/` directory (unless overridden by `MCPC_HOME_DIR` environment variable):
 
-- `~/.mcpc/sessions.json` - Active sessions with references to auth profiles and active async tasks (file-locked for concurrent access)
+- `~/.mcpc/sessions.json` - Active sessions with references to auth profiles, active async tasks, and resource subscriptions (file-locked for concurrent access)
 - `~/.mcpc/profiles.json` - Authentication profiles (OAuth metadata, scopes, expiry)
 - `~/.mcpc/bridges/` - Unix domain socket files for bridge processes
 - `~/.mcpc/logs/bridge-<session>.log` - Bridge process logs (max 10MB, 5 files)
@@ -678,6 +678,11 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 - **Notification Handling**: Full notification support in the bridge process
   - `tools/list_changed`, `resources/list_changed`, `prompts/list_changed` notifications
   - Automatic cache invalidation on list changes, timestamps tracked in `sessions.json`
+  - `resources/updated` notifications drive resource→file sync for `resources-subscribe`
+- **Resource Subscriptions**: `resources-subscribe <uri> <file>` keeps a local file in sync
+  - Bridge downloads the resource on subscribe and rewrites the file on each `notifications/resources/updated` (re-reads the resource; the notification carries no content)
+  - Subscriptions persisted in `sessions.json` (`resourceSubscriptions`), re-established and re-synced on bridge restart
+  - `resources-unsubscribe <uri>` stops the sync and keeps the file; sync state shown in `mcpc @session`
 - **Error Recovery**: Automatic recovery from failures
   - Bridge crash detection and automatic restart
   - Socket reconnection with preserved session state
@@ -695,7 +700,6 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 
 - **Package Resolution**: Find and run local MCP packages automatically
 - **Tab Completion**: Shell completions for commands, tool names, and resource URIs
-- **Resource File Output**: `-o <file>` flag for `resources-read` command
 
 ### 📋 Implementation Approach
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ MCP session commands (after connecting):
   <@session> prompts-list
   <@session> prompts-get <name> [arg:=val ... | <json> | <stdin]
   <@session> resources-list
-  <@session> resources-read <uri>
-  <@session> resources-subscribe <uri>
+  <@session> resources-read <uri> [-o <file> | --raw]
+  <@session> resources-subscribe <uri> <file>
   <@session> resources-unsubscribe <uri>
   <@session> resources-templates-list
   <@session> skills-list
@@ -926,14 +926,32 @@ Access server-provided data sources by URI:
 # List available resources
 mcpc @apify resources-list
 
-# Read a resource
+# Read a resource (pretty view; binary content is summarized, never dumped)
 mcpc @apify resources-read "file:///config.json"
 
-# Subscribe to resource changes
-mcpc @apify resources-subscribe "https://api.example.com/data"
+# Print just the content for piping
+mcpc @apify resources-read "file:///config.json" --raw | jq .
+
+# Save a resource to a local file (binary-safe, decodes base64 blobs)
+mcpc @apify resources-read "file:///logo.png" -o logo.png
 
 # List resource templates
 mcpc @apify resources-templates-list
+```
+
+Subscriptions keep a local file in sync with a server resource. On subscribe, mcpc downloads
+the resource to the file; afterwards the session bridge rewrites the file whenever the server
+sends a `notifications/resources/updated` notification for the URI (the bridge re-reads the
+resource, as the notification carries no content). Requires the server capability
+`resources.subscribe`; subscriptions are re-established automatically when the session
+reconnects or restarts, and are listed in `mcpc @session` output.
+
+```bash
+# Keep ./config.json in sync with the server resource
+mcpc @apify resources-subscribe "file:///config.json" ./config.json
+
+# Stop syncing — the local file is kept as-is
+mcpc @apify resources-unsubscribe "file:///config.json"
 ```
 
 #### Skills

--- a/docs/TODOs.md
+++ b/docs/TODOs.md
@@ -62,10 +62,6 @@ Syntax errors: mcpc call linear_list_issues instead of mcpc @linear tools-call l
 
 - Unify colors used across all helps and commands for: profile (violet), commands (turqois?), session, tool names, param names
 
-- Implement resources-subscribe/resources-unsubscribe, --o file command properly, --max-size
-  automatically update the -o file on changes, without it just keep track of changed files in
-  bridge process' cache, and report in resources-list/resources-read operatio
-
 - Add support for "mcpc close @session" and "mcpc restart @session" aliases - add info only to "mcpc help restart" or "mcpc 
   help close", no need to mention this in main --help
   

--- a/docs/claude-skill/SKILL.md
+++ b/docs/claude-skill/SKILL.md
@@ -130,9 +130,10 @@ mcpc --json @apify tools-call search-actors keywords:="scraper" \
 
 ```bash
 mcpc @apify resources-list
-mcpc @apify resources-read "file:///path/to/file"   # -o <file> to save, --max-size <bytes>
+mcpc @apify resources-read "file:///path/to/file"   # -o <file> to save (binary-safe), --raw to pipe
 mcpc @apify resources-templates-list
-mcpc @apify resources-subscribe <uri>               # and resources-unsubscribe <uri>
+mcpc @apify resources-subscribe <uri> <file>        # keep local <file> in sync with the resource
+mcpc @apify resources-unsubscribe <uri>             # stop syncing, keep the file
 
 mcpc @apify prompts-list
 mcpc @apify prompts-get <name> arg1:=value1         # same argument styles as tools-call

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -37,11 +37,13 @@ import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/
 import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
 import {
   LoggingMessageNotificationSchema,
+  ResourceUpdatedNotificationSchema,
   type Tool,
   type Resource,
   type Prompt,
   type Task,
 } from '@modelcontextprotocol/sdk/types.js';
+import { ResourceSyncManager } from './resource-sync.js';
 import type { TaskUpdate } from '../lib/types.js';
 import { createRequire } from 'module';
 const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.json') as {
@@ -115,6 +117,9 @@ class BridgeProcess {
 
   // Active async tasks (in-memory, also persisted to disk for crash recovery)
   private activeTasks: Map<string, Task> = new Map();
+
+  // Resource→file sync for resources-subscribe (created once the MCP client connects)
+  private resourceSync: ResourceSyncManager | null = null;
 
   // Promise to track when auth credentials are received (for startup sequencing)
   private authCredentialsReceived: Promise<void> | null = null;
@@ -436,6 +441,10 @@ class BridgeProcess {
         // Signal that MCP client is ready (unblocks pending requests)
         // Only signal after both MCP connection AND proxy server are ready
         this.mcpClientReadyResolver();
+
+        // Re-establish persisted resource subscriptions in the background —
+        // failures are recorded per subscription, never block startup
+        void this.restoreResourceSubscriptions();
       } catch (error) {
         // Signal that MCP connection or proxy startup failed (rejects pending requests with actual error)
         // Don't exit immediately - stay alive briefly so CLI can receive the error
@@ -666,6 +675,25 @@ class BridgeProcess {
         logger.info('[server log]', notification.params);
       });
 
+    // Resource→file sync (resources-subscribe): load persisted subscriptions and
+    // re-sync local files when the server announces a resource changed. Per the MCP
+    // spec the updated notification carries only the URI — the client re-reads.
+    const client = this.client;
+    this.resourceSync = new ResourceSyncManager({
+      readResource: (uri) => client.readResource(uri),
+      persist: (entries) =>
+        updateSession(this.options.sessionName, { resourceSubscriptions: entries }),
+      logger: createLogger('resource-sync'),
+    });
+    const sessionData = await getSession(this.options.sessionName);
+    this.resourceSync.load(sessionData?.resourceSubscriptions);
+    this.client
+      .getSDKClient()
+      .setNotificationHandler(ResourceUpdatedNotificationSchema, (notification) => {
+        logger.debug(`Resource updated notification: ${notification.params.uri}`);
+        this.resourceSync?.handleUpdated(notification.params.uri);
+      });
+
     // Update session with protocol version, MCP session ID, and lastSeenAt
     const serverDetails = await this.client.getServerDetails();
     const newMcpSessionId = this.client.getMcpSessionId();
@@ -732,6 +760,34 @@ class BridgeProcess {
         }
         logger.warn('Failed to pre-populate tools cache:', err);
       });
+    }
+  }
+
+  /**
+   * Re-establish resource subscriptions persisted in sessions.json after a
+   * bridge (re)start: re-subscribe on the server, then re-sync each local file
+   * since updates may have been missed while the bridge was down. Per-entry
+   * failures are recorded on the subscription (shown by `mcpc @session`) and
+   * never tear down the session.
+   */
+  private async restoreResourceSubscriptions(): Promise<void> {
+    const sync = this.resourceSync;
+    const client = this.client;
+    if (!sync || !client) return;
+    const entries = sync.list();
+    if (entries.length === 0) return;
+
+    logger.info(`Restoring ${entries.length} resource subscription(s)...`);
+    for (const entry of entries) {
+      try {
+        await client.subscribeResource(entry.uri);
+      } catch (error) {
+        const message = `Re-subscribe failed: ${(error as Error).message}`;
+        logger.warn(`${message} (${entry.uri})`);
+        await sync.recordError(entry.uri, message).catch(() => {});
+        continue;
+      }
+      await sync.resync(entry.uri);
     }
   }
 
@@ -1270,14 +1326,53 @@ class BridgeProcess {
         }
 
         case 'subscribeResource': {
-          const params = message.params as { uri: string };
-          result = await this.client.subscribeResource(params.uri);
+          // Subscribe + sync the resource to a local file: subscribe on the server,
+          // download the current content, then keep rewriting the file on
+          // notifications/resources/updated (see ResourceSyncManager).
+          const params = message.params as { uri: string; filePath: string };
+          if (!params?.uri || !params?.filePath) {
+            throw new ClientError('subscribeResource requires uri and filePath');
+          }
+          if (!this.resourceSync) {
+            throw new NetworkError('MCP client not connected');
+          }
+          const details = await this.client.getServerDetails();
+          if (!details.capabilities?.resources?.subscribe) {
+            throw new ClientError(
+              `Server does not support resource subscriptions (no resources.subscribe capability).\n` +
+                `To download the resource once instead, run:\n` +
+                `  mcpc ${this.options.sessionName} resources-read ${params.uri} -o <file>`
+            );
+          }
+          await this.client.subscribeResource(params.uri);
+          try {
+            result = await this.resourceSync.add(params.uri, params.filePath);
+          } catch (error) {
+            // Initial sync failed (bad path, unreadable resource) — roll back the
+            // server-side subscription so no orphaned subscription keeps notifying
+            await this.client.unsubscribeResource(params.uri).catch(() => {});
+            throw error;
+          }
           break;
         }
 
         case 'unsubscribeResource': {
           const params = message.params as { uri: string };
-          result = await this.client.unsubscribeResource(params.uri);
+          if (!this.resourceSync) {
+            throw new NetworkError('MCP client not connected');
+          }
+          // Remove the local subscription first (throws ClientError when unknown) —
+          // this alone guarantees the file stops being rewritten. The synced file is kept.
+          const entry = await this.resourceSync.remove(params.uri);
+          // Best-effort server-side unsubscribe; local sync is already stopped, so a
+          // server error (e.g. lost subscription state) must not fail the command.
+          await this.client.unsubscribeResource(params.uri).catch((error) => {
+            logger.warn(
+              `Server unsubscribe failed for ${params.uri} (local sync stopped anyway):`,
+              error
+            );
+          });
+          result = { uri: params.uri, file: entry.filePath };
           break;
         }
 

--- a/src/bridge/resource-sync.ts
+++ b/src/bridge/resource-sync.ts
@@ -1,0 +1,196 @@
+/**
+ * Resource→file sync for the bridge process.
+ *
+ * Tracks resource subscriptions created with `resources-subscribe <uri> <file>`.
+ * For each subscription the bridge keeps a local file in sync with the server
+ * resource: an initial download on subscribe, then a re-read + rewrite whenever
+ * the server sends `notifications/resources/updated` for the URI (per the MCP
+ * spec the notification carries no content — the client re-reads the resource).
+ *
+ * Subscriptions are persisted to sessions.json (via the injected `persist`
+ * callback) so they survive bridge restarts; the bridge re-subscribes and
+ * re-syncs on startup.
+ */
+
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ResourceSubscriptionEntry, ResourceSyncResult } from '../lib/types.js';
+import { selectResourceContent, writeResourceFile } from '../lib/resource-content.js';
+import { ClientError } from '../lib/errors.js';
+import type { Logger } from '../lib/logger.js';
+
+/**
+ * Dependencies injected by the bridge (kept as callbacks for testability)
+ */
+export interface ResourceSyncManagerOptions {
+  /** Read a resource from the MCP server (bridge wires this to McpClient.readResource) */
+  readResource: (uri: string) => Promise<ReadResourceResult>;
+  /** Persist the full subscriptions map (bridge wires this to updateSession) */
+  persist: (entries: Record<string, ResourceSubscriptionEntry>) => Promise<void>;
+  logger: Logger;
+}
+
+export class ResourceSyncManager {
+  private entries = new Map<string, ResourceSubscriptionEntry>();
+  // In-flight sync per URI, with a coalescing flag for updates arriving mid-sync:
+  // any number of notifications during a sync collapse into exactly one follow-up sync.
+  private inFlight = new Map<string, Promise<void>>();
+  private pendingResync = new Set<string>();
+
+  constructor(private options: ResourceSyncManagerOptions) {}
+
+  /**
+   * Load persisted subscriptions (from sessions.json) on bridge startup.
+   * Does not touch the server or the files — see resync() for that.
+   */
+  load(entries: Record<string, ResourceSubscriptionEntry> | undefined): void {
+    if (!entries) return;
+    for (const [uri, entry] of Object.entries(entries)) {
+      this.entries.set(uri, { ...entry });
+    }
+  }
+
+  list(): ResourceSubscriptionEntry[] {
+    return [...this.entries.values()];
+  }
+
+  has(uri: string): boolean {
+    return this.entries.has(uri);
+  }
+
+  /**
+   * Register a subscription and perform the initial sync.
+   * On initial sync failure, throws without registering anything (the caller
+   * rolls back the server-side subscription).
+   * Re-subscribing an already-subscribed URI just changes the target file.
+   */
+  async add(uri: string, filePath: string): Promise<ResourceSyncResult> {
+    const result = await this.syncToFile(uri, filePath);
+    const now = new Date().toISOString();
+    this.entries.set(uri, {
+      uri,
+      filePath,
+      subscribedAt: this.entries.get(uri)?.subscribedAt ?? now,
+      lastSyncedAt: now,
+    });
+    await this.persist();
+    return result;
+  }
+
+  /**
+   * Remove a subscription; the synced file is kept as-is.
+   * @returns the removed entry (so callers can report the kept file path)
+   * @throws ClientError when the URI has no active subscription
+   */
+  async remove(uri: string): Promise<ResourceSubscriptionEntry> {
+    const entry = this.entries.get(uri);
+    if (!entry) {
+      const active = this.list().map((e) => e.uri);
+      throw new ClientError(
+        `No active subscription for ${uri}.` +
+          (active.length > 0
+            ? `\nActive subscriptions:\n${active.map((u) => `  ${u}`).join('\n')}`
+            : ' This session has no resource subscriptions.')
+      );
+    }
+    this.entries.delete(uri);
+    this.pendingResync.delete(uri);
+    await this.persist();
+    return entry;
+  }
+
+  /**
+   * Handle a `notifications/resources/updated` notification: re-sync the file
+   * in the background. Notifications for unsubscribed URIs are ignored; bursts
+   * of notifications coalesce into at most one queued re-sync.
+   */
+  handleUpdated(uri: string): void {
+    if (!this.entries.has(uri)) {
+      this.options.logger.debug(`Ignoring resources/updated for unsubscribed URI: ${uri}`);
+      return;
+    }
+    if (this.inFlight.has(uri)) {
+      this.pendingResync.add(uri);
+      return;
+    }
+    this.startSync(uri);
+  }
+
+  /**
+   * Re-sync a subscribed resource now, recording lastError/lastSyncedAt on the
+   * entry instead of throwing. Used on bridge startup after re-subscribing.
+   */
+  async resync(uri: string): Promise<void> {
+    await this.runSync(uri);
+  }
+
+  /**
+   * Record a subscription-level error (e.g. re-subscribe rejected by the server
+   * after a bridge restart) so `mcpc @session` can surface it.
+   */
+  async recordError(uri: string, message: string): Promise<void> {
+    const entry = this.entries.get(uri);
+    if (!entry) return;
+    entry.lastError = message;
+    await this.persist();
+  }
+
+  /**
+   * Wait until all in-flight (and coalesced follow-up) syncs settle.
+   * @internal for tests
+   */
+  async waitForIdle(): Promise<void> {
+    while (this.inFlight.size > 0) {
+      await Promise.allSettled([...this.inFlight.values()]);
+    }
+  }
+
+  private startSync(uri: string): void {
+    const promise = this.runSync(uri).finally(() => {
+      this.inFlight.delete(uri);
+      // An update arrived while syncing — run one more sync to pick it up
+      if (this.pendingResync.delete(uri) && this.entries.has(uri)) {
+        this.startSync(uri);
+      }
+    });
+    this.inFlight.set(uri, promise);
+  }
+
+  private async runSync(uri: string): Promise<void> {
+    const entry = this.entries.get(uri);
+    if (!entry) return;
+    try {
+      const result = await this.syncToFile(uri, entry.filePath);
+      entry.lastSyncedAt = new Date().toISOString();
+      delete entry.lastError;
+      this.options.logger.info(
+        `Resource synced: ${uri} -> ${entry.filePath} (${result.bytes} bytes)`
+      );
+    } catch (error) {
+      entry.lastError = (error as Error).message;
+      this.options.logger.warn(`Failed to sync resource ${uri} to ${entry.filePath}:`, error);
+    }
+    await this.persist().catch((error) => {
+      this.options.logger.warn('Failed to persist resource subscriptions:', error);
+    });
+  }
+
+  private async syncToFile(uri: string, filePath: string): Promise<ResourceSyncResult> {
+    const result = await this.options.readResource(uri);
+    const content = selectResourceContent(result, uri);
+    await writeResourceFile(filePath, content.data);
+    return {
+      uri,
+      file: filePath,
+      bytes: content.data.length,
+      ...(content.mimeType && { mimeType: content.mimeType }),
+    };
+  }
+
+  private async persist(): Promise<void> {
+    const record: Record<string, ResourceSubscriptionEntry> = {};
+    for (const [uri, entry] of this.entries) {
+      record[uri] = entry;
+    }
+    await this.options.persist(record);
+  }
+}

--- a/src/cli/commands/resources.ts
+++ b/src/cli/commands/resources.ts
@@ -2,8 +2,12 @@
  * Resources command handlers
  */
 
-import { formatOutput, formatSuccess } from '../output.js';
+import chalk from 'chalk';
+import { formatOutput, formatSuccess, formatWarning, formatResourceContents } from '../output.js';
 import { withMcpClient } from '../helpers.js';
+import { resolvePath } from '../../lib/utils.js';
+import { selectResourceContent, writeResourceFile } from '../../lib/resource-content.js';
+import { ClientError } from '../../lib/errors.js';
 import type { CommandOptions } from '../../lib/types.js';
 
 /**
@@ -58,7 +62,13 @@ export async function listResourceTemplates(
 }
 
 /**
- * Get a resource by URI
+ * Read a resource by URI.
+ *
+ * Output modes:
+ * - default (human): pretty view; binary (blob) content is summarized, never dumped
+ * - --raw: bare content to stdout for piping; binary requires a redirect (or -o)
+ * - -o <file>: save the content to a file, decoding base64 blobs to bytes
+ * - --json: full MCP ReadResourceResult (with -o: a small summary object instead)
  */
 export async function getResource(
   target: string,
@@ -66,33 +76,74 @@ export async function getResource(
   options: CommandOptions & {
     output?: string;
     raw?: boolean;
-    maxSize?: number;
   }
 ): Promise<void> {
-  await withMcpClient(target, options, async (client, _context) => {
+  // --raw output must stay bare for piping — suppress the [session] prefix line
+  const clientOptions = options.raw && !options.output ? { ...options, hideTarget: true } : options;
+
+  await withMcpClient(target, clientOptions, async (client, _context) => {
     const result = await client.readResource(uri);
 
-    // If output file is specified, write to file
+    // -o/--output: write the resource to a local file (binary-safe)
     if (options.output) {
-      // TODO: Write resource contents to file
-      throw new Error('--output flag not implemented yet');
-    }
+      const filePath = resolvePath(options.output);
+      const content = selectResourceContent(result, uri);
+      await writeResourceFile(filePath, content.data);
 
-    // If raw mode, output just the content
-    if (options.raw && result.contents.length > 0) {
-      const firstContent = result.contents[0];
-      if (firstContent) {
-        if ('text' in firstContent && firstContent.text) {
-          console.log(firstContent.text);
-        } else if ('blob' in firstContent && firstContent.blob) {
-          console.log(firstContent.blob);
+      const mimeSuffix = content.mimeType ? `, ${content.mimeType}` : '';
+      if (options.outputMode === 'json') {
+        console.log(
+          formatOutput(
+            {
+              uri,
+              file: filePath,
+              bytes: content.data.length,
+              ...(content.mimeType && { mimeType: content.mimeType }),
+            },
+            'json'
+          )
+        );
+      } else {
+        console.log(
+          formatSuccess(`Saved ${uri} to ${filePath} (${content.data.length} bytes${mimeSuffix})`)
+        );
+        if (content.totalContents > 1) {
+          console.log(
+            formatWarning(
+              `Resource returned ${content.totalContents} content items; saved only ${content.uri}. Use --json to see all items.`
+            )
+          );
         }
       }
       return;
     }
 
+    // --json: full MCP result (takes precedence over --raw, same as skills-get)
+    if (options.outputMode === 'json') {
+      console.log(formatOutput(result, 'json'));
+      return;
+    }
+
+    // --raw: bare content for piping
+    if (options.raw) {
+      const content = selectResourceContent(result, uri);
+      if (content.binary) {
+        if (process.stdout.isTTY) {
+          throw new ClientError(
+            `Binary content (${content.mimeType || 'unknown type'}, ${content.data.length} bytes) would mess up the terminal.\n` +
+              `Redirect stdout (mcpc ${target} resources-read ${uri} --raw > file) or save with -o <file>.`
+          );
+        }
+        process.stdout.write(content.data);
+      } else {
+        console.log(content.data.toString('utf-8'));
+      }
+      return;
+    }
+
     console.log(
-      formatOutput(result, options.outputMode, {
+      formatResourceContents(uri, result, {
+        sessionName: target,
         ...(options.maxChars && { maxChars: options.maxChars }),
       })
     );
@@ -100,26 +151,41 @@ export async function getResource(
 }
 
 /**
- * Subscribe to resource updates
+ * Subscribe to a resource and keep a local file in sync with it.
+ *
+ * Downloads the resource to the file now; afterwards the session bridge rewrites
+ * the file whenever the server sends notifications/resources/updated for the URI
+ * (per the MCP spec the notification carries no content, so the bridge re-reads).
  */
 export async function subscribeResource(
   target: string,
   uri: string,
+  file: string,
   options: CommandOptions
 ): Promise<void> {
+  // Resolve against the CLI's cwd — the bridge process has a different cwd
+  const filePath = resolvePath(file);
+
   await withMcpClient(target, options, async (client, _context) => {
-    await client.subscribeResource(uri);
+    const result = await client.subscribeResource(uri, filePath);
 
     if (options.outputMode === 'human') {
+      const mimeSuffix = result.mimeType ? `, ${result.mimeType}` : '';
       console.log(formatSuccess(`Subscribed to resource: ${uri}`));
+      console.log(`  Synced to ${result.file} (${result.bytes} bytes${mimeSuffix})`);
+      console.log(chalk.dim('  The file is updated automatically while the session is connected.'));
+      console.log(chalk.dim(`  ↳ check sync status: mcpc ${target}`));
+      console.log(
+        chalk.dim(`  ↳ stop syncing (keeps the file): mcpc ${target} resources-unsubscribe ${uri}`)
+      );
     } else {
-      console.log(formatOutput({ subscribed: true, uri }, 'json'));
+      console.log(formatOutput({ subscribed: true, ...result }, 'json'));
     }
   });
 }
 
 /**
- * Unsubscribe from resource updates
+ * Stop syncing a subscribed resource. The synced local file is kept as-is.
  */
 export async function unsubscribeResource(
   target: string,
@@ -127,12 +193,13 @@ export async function unsubscribeResource(
   options: CommandOptions
 ): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
-    await client.unsubscribeResource(uri);
+    const result = await client.unsubscribeResource(uri);
 
     if (options.outputMode === 'human') {
       console.log(formatSuccess(`Unsubscribed from resource: ${uri}`));
+      console.log(`  File kept: ${result.file}`);
     } else {
-      console.log(formatOutput({ unsubscribed: true, uri }, 'json'));
+      console.log(formatOutput({ unsubscribed: true, ...result }, 'json'));
     }
   });
 }

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -21,6 +21,7 @@ import {
   formatError,
   formatSessionLine,
   formatServerDetails,
+  formatTimeAgo,
   theme,
 } from '../output.js';
 import { withMcpClient, resolveAuthProfile } from '../helpers.js';
@@ -43,6 +44,9 @@ import { createLogger } from '../../lib/logger.js';
 import { getBridgeLogPath } from '../../lib/log-reader.js';
 
 const logger = createLogger('sessions');
+
+// Re-exported for existing importers (moved to output.ts so formatServerDetails can use it)
+export { formatTimeAgo } from '../output.js';
 
 /**
  * Map the internal `connectionMode` enum to the public `--json` `stateless` field:
@@ -118,33 +122,6 @@ export function formatBridgeStatus(status: DisplayStatus): { dot: string; text: 
     case 'expired':
       return { dot: theme.red('○'), text: theme.red('expired') };
   }
-}
-
-/**
- * Format time ago in human-friendly way
- */
-export function formatTimeAgo(isoDate: string | undefined): string {
-  if (!isoDate) return '';
-
-  const date = new Date(isoDate);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSecs = Math.floor(diffMs / 1000);
-  const diffMins = Math.floor(diffSecs / 60);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
-
-  if (diffSecs < 60) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays === 1) return 'yesterday';
-  if (diffDays < 7) return `${diffDays} days ago`;
-  if (diffDays < 30) {
-    const weeks = Math.floor(diffDays / 7);
-    return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
-  }
-  const months = Math.floor(diffDays / 30);
-  return `${months} ${months === 1 ? 'month' : 'months'} ago`;
 }
 
 /**
@@ -325,8 +302,13 @@ export async function showServerDetails(
     const cachedToolsResult = await client.listAllTools();
     const tools = cachedToolsResult.tools;
 
+    // Active resource→file syncs (resources-subscribe), maintained by the bridge
+    // in sessions.json — read from disk, no server round-trip needed
+    const sessionData = target.startsWith('@') ? await getSession(target) : undefined;
+    const resourceSubscriptions = Object.values(sessionData?.resourceSubscriptions ?? {});
+
     if (options.outputMode === 'human') {
-      console.log(formatServerDetails(serverDetails, target, tools));
+      console.log(formatServerDetails(serverDetails, target, tools, resourceSubscriptions));
     } else {
       // JSON output MUST match MCP InitializeResult structure!
       // See https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult
@@ -357,6 +339,7 @@ export async function showServerDetails(
               server,
               ...statelessField(connectionMode),
               ...(logPath && { logPath }),
+              ...(resourceSubscriptions.length > 0 && { resourceSubscriptions }),
             },
             protocolVersion,
             capabilities,
@@ -449,7 +432,7 @@ export async function restartSession(
       console.log(formatSuccess(`Session ${name} restarted`));
       console.log(
         chalk.dim(
-          'Note: previous session state was lost (e.g. added tools, resource subscriptions, async tasks)'
+          'Note: previous session state was lost (e.g. added tools, async tasks); resource subscriptions are re-established automatically'
         )
       );
     }

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -304,7 +304,10 @@ export async function getSkill(
 ): Promise<void> {
   const uri = resolveSkillUri(name);
 
-  await withMcpClient(target, options, async (client) => {
+  // --raw output must stay bare for piping — suppress the [session] prefix line
+  const clientOptions = options.raw ? { ...options, hideTarget: true } : options;
+
+  await withMcpClient(target, clientOptions, async (client) => {
     const result = await client.readResource(uri);
 
     if (options.outputMode === 'json') {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -3,7 +3,9 @@
  * Provides target resolution and MCP client management
  */
 
-import type { IMcpClient, OutputMode, ServerConfig } from '../lib/types.js';
+import type { OutputMode, ServerConfig } from '../lib/types.js';
+// Type-only import — the runtime module is still loaded lazily inside withMcpClient
+import type { SessionClient } from '../lib/session-client.js';
 import { ClientError } from '../lib/errors.js';
 import { normalizeServerUrl, isValidSessionName, getServerHost } from '../lib/utils.js';
 import { setVerbose, createLogger } from '../lib/logger.js';
@@ -144,6 +146,9 @@ export interface McpClientContext {
  * Execute an operation with an MCP client via a named session
  * The target must be a valid session name (starts with @)
  *
+ * The callback receives the concrete SessionClient (which implements IMcpClient),
+ * so session-only operations like resource subscriptions are available too.
+ *
  * @param target - Session name (e.g. @apify)
  * @param options - CLI options (verbose, outputMode, etc.)
  * @param callback - Async function that receives the connected client and context
@@ -156,7 +161,7 @@ export async function withMcpClient<T>(
     hideTarget?: boolean;
     timeout?: number;
   },
-  callback: (client: IMcpClient, context: McpClientContext) => Promise<T>
+  callback: (client: SessionClient, context: McpClientContext) => Promise<T>
 ): Promise<T> {
   if (!isValidSessionName(target)) {
     throw new ClientError(

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -445,8 +445,8 @@ ${chalk.bold('MCP session commands (after connecting):')}
   <@session> ${theme.cyan('prompts-list')}
   <@session> ${theme.cyan('prompts-get')} <name> [arg:=val ... | <json> | <stdin]
   <@session> ${theme.cyan('resources-list')}
-  <@session> ${theme.cyan('resources-read')} <uri>
-  <@session> ${theme.cyan('resources-subscribe')} <uri>
+  <@session> ${theme.cyan('resources-read')} <uri> [-o <file> | --raw]
+  <@session> ${theme.cyan('resources-subscribe')} <uri> <file>
   <@session> ${theme.cyan('resources-unsubscribe')} <uri>
   <@session> ${theme.cyan('resources-templates-list')}
   <@session> ${theme.cyan('skills-list')}
@@ -1177,36 +1177,59 @@ ${toolsCallCombinedJsonHelp}`
   program
     .command('resources-read <uri>')
     .description('Read an MCP resource by URI.')
-    .option('-o, --output <file>', 'Write resource to file')
-    .option('--max-size <bytes>', 'Maximum resource size in bytes')
+    .option('-o, --output <file>', 'Save the resource to a file (decodes binary content)')
+    .option('--raw', 'Print only the resource content, suitable for piping')
     .addHelpText(
       'after',
-      jsonHelp(
-        '`ReadResourceResult` object',
-        '`{ contents: [{ uri, mimeType?, text? | blob? }] }`',
-        `${SCHEMA_BASE}#readresourceresult`
-      )
+      `
+${chalk.bold('Output:')}
+  Default: pretty view; binary (blob) content is summarized, never dumped.
+  --raw prints the bare content (binary requires a redirect or -o).
+  -o <file> saves the content; base64 \`blob\` data is decoded to bytes.
+  If the server returns multiple content items, --raw and -o use the item
+  matching <uri> (or the first one) — use --json to get all items.
+${jsonHelp(
+  '`ReadResourceResult` object',
+  '`{ contents: [{ uri, mimeType?, text? | blob? }] }`',
+  `${SCHEMA_BASE}#readresourceresult`
+)}
+  With \`-o\`: \`{ uri, file, bytes, mimeType? }\` summary instead.
+`
     )
     .action(async (uri, options, command) => {
       await resources.getResource(session, uri, {
         output: options.output,
-        maxSize: options.maxSize,
+        ...(options.raw && { raw: true }),
         ...getOptionsFromCommand(command),
       });
     });
 
   program
-    .command('resources-subscribe <uri>')
-    .description('Subscribe to MCP resource updates.')
-    .addHelpText('after', jsonHelp('`{ subscribed: true, uri: string }`'))
-    .action(async (uri, _options, command) => {
-      await resources.subscribeResource(session, uri, getOptionsFromCommand(command));
+    .command('resources-subscribe <uri> <file>')
+    .description('Subscribe to an MCP resource and keep a local file in sync with it.')
+    .addHelpText(
+      'after',
+      `
+${chalk.bold('Behavior:')}
+  Downloads the resource to <file> now; afterwards the session bridge rewrites
+  the file whenever the server announces a change for <uri> (the MCP
+  notifications/resources/updated flow). Requires the server capability
+  \`resources.subscribe\` — check with \`mcpc ${session}\`. Subscriptions are
+  re-established automatically when the session reconnects or restarts.
+  Subscribing to the same <uri> again just changes the target <file>.
+
+${chalk.bold('Example:')}
+  mcpc ${session} resources-subscribe file:///app/config.json ./config.json
+${jsonHelp('`{ subscribed: true, uri, file, bytes, mimeType? }`')}`
+    )
+    .action(async (uri, file, _options, command) => {
+      await resources.subscribeResource(session, uri, file, getOptionsFromCommand(command));
     });
 
   program
     .command('resources-unsubscribe <uri>')
-    .description('Unsubscribe from MCP resource updates.')
-    .addHelpText('after', jsonHelp('`{ unsubscribed: true, uri: string }`'))
+    .description('Stop syncing a subscribed MCP resource (keeps the local file).')
+    .addHelpText('after', jsonHelp('`{ unsubscribed: true, uri, file }`'))
     .action(async (uri, _options, command) => {
       await resources.unsubscribeResource(session, uri, getOptionsFromCommand(command));
     });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -22,6 +22,7 @@ import type {
   ServerDetails,
   Task,
   CallToolResult,
+  ResourceSubscriptionEntry,
 } from '../lib/types.js';
 import { extractAllTextContent } from './tool-result.js';
 import { getSession } from '../lib/sessions.js';
@@ -712,6 +713,33 @@ export function formatToolCallExample(tool: Tool, sessionName?: string): string 
 }
 
 /**
+ * Format time ago in human-friendly way
+ */
+export function formatTimeAgo(isoDate: string | undefined): string {
+  if (!isoDate) return '';
+
+  const date = new Date(isoDate);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffSecs = Math.floor(diffMs / 1000);
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+  if (diffDays < 30) {
+    const weeks = Math.floor(diffDays / 7);
+    return `${weeks} ${weeks === 1 ? 'week' : 'weeks'} ago`;
+  }
+  const months = Math.floor(diffDays / 30);
+  return `${months} ${months === 1 ? 'month' : 'months'} ago`;
+}
+
+/**
  * Format a list of resources with Markdown-like display
  */
 export function formatResources(resources: Resource[]): string {
@@ -823,6 +851,61 @@ export function formatResourceTemplateDetail(template: ResourceTemplate): string
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Format the contents of a `resources/read` result for human display
+ * (the default `resources-read` view). Text content is shown in a fenced
+ * block; binary (blob) content is summarized — never dumped to the terminal.
+ */
+export function formatResourceContents(
+  requestedUri: string,
+  result: ReadResourceResult,
+  options?: { sessionName?: string; maxChars?: number }
+): string {
+  const lines: string[] = [];
+
+  if (result.contents.length === 0) {
+    lines.push(chalk.gray('(resource returned no contents)'));
+  }
+
+  result.contents.forEach((item, index) => {
+    if (index > 0) {
+      lines.push('');
+      lines.push(chalk.dim('---'));
+    }
+
+    lines.push(`${chalk.bold('Resource:')} ${inBackticks(item.uri || requestedUri)}`);
+    if (item.mimeType) {
+      lines.push(`${chalk.bold('MIME type:')} ${theme.yellow(item.mimeType)}`);
+    }
+
+    if ('text' in item && typeof item.text === 'string') {
+      lines.push('');
+      lines.push(chalk.gray('````'));
+      lines.push(item.text);
+      lines.push(chalk.gray('````'));
+    } else if ('blob' in item && typeof item.blob === 'string') {
+      const bytes = Buffer.from(item.blob, 'base64').length;
+      const target = options?.sessionName || '<@session>';
+      lines.push(`${chalk.bold('Size:')} ${bytes} bytes (binary)`);
+      lines.push('');
+      lines.push(chalk.gray('(binary content not shown)'));
+      lines.push(
+        chalk.dim(
+          `  ↳ save to a file: mcpc ${target} resources-read ${item.uri || requestedUri} -o <file>`
+        )
+      );
+    } else {
+      lines.push(chalk.gray('(no content)'));
+    }
+  });
+
+  let output = lines.join('\n');
+  if (options?.maxChars) {
+    output = truncateOutput(output, options.maxChars);
+  }
+  return output;
 }
 
 /**
@@ -1509,7 +1592,8 @@ export function formatJsonError(error: Error, code: number): string {
 export function formatServerDetails(
   details: ServerDetails,
   target: string,
-  tools?: Tool[]
+  tools?: Tool[],
+  resourceSubscriptions?: ResourceSubscriptionEntry[]
 ): string {
   const lines: string[] = [];
   const bullet = chalk.dim('*');
@@ -1609,6 +1693,20 @@ export function formatServerDetails(
     lines.push('');
   }
 
+  // Active resource→file syncs created with resources-subscribe
+  if (resourceSubscriptions && resourceSubscriptions.length > 0) {
+    lines.push(chalk.bold('Resource subscriptions:'));
+    for (const sub of resourceSubscriptions) {
+      const status = sub.lastError
+        ? theme.red(`sync failing: ${sub.lastError}`)
+        : sub.lastSyncedAt
+          ? chalk.dim(`synced ${formatTimeAgo(sub.lastSyncedAt)}`)
+          : chalk.dim('not synced yet');
+      lines.push(`${bullet} ${inBackticks(sub.uri)} → ${sub.filePath} (${status})`);
+    }
+    lines.push('');
+  }
+
   // Tools list (from bridge cache, no extra server call)
   if (tools && tools.length > 0) {
     lines.push(formatToolsCompact(tools, { sessionName: target }));
@@ -1628,7 +1726,10 @@ export function formatServerDetails(
 
   if (capabilities?.resources) {
     commands.push(`${bullet} ${bt}mcpc ${target} resources-list${bt}`);
-    commands.push(`${bullet} ${bt}mcpc ${target} resources-read <uri>${bt}`);
+    commands.push(`${bullet} ${bt}mcpc ${target} resources-read <uri> [-o <file>]${bt}`);
+    if (capabilities.resources.subscribe) {
+      commands.push(`${bullet} ${bt}mcpc ${target} resources-subscribe <uri> <file>${bt}`);
+    }
   }
 
   // Surface skills commands when the server advertises the extension, OR

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -82,7 +82,6 @@ const OPTIONS_WITH_VALUES = [
   '--callback-port',
   '-o',
   '--output',
-  '--max-size',
   '--amount',
   '--expiry',
 ];

--- a/src/lib/resource-content.ts
+++ b/src/lib/resource-content.ts
@@ -1,0 +1,115 @@
+/**
+ * Helpers for materializing MCP resource contents (`resources/read` results):
+ * selecting which content item to use, decoding text/blob payloads to bytes,
+ * and writing them to local files atomically.
+ *
+ * Shared by the CLI (`resources-read -o`, `--raw`) and the bridge process
+ * (resource subscription sync) so both produce byte-identical files.
+ */
+
+import { stat, unlink, writeFile } from 'fs/promises';
+import { basename, dirname, isAbsolute, join } from 'path';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { atomicRename, ensureDir } from './utils.js';
+import { ClientError, ServerError } from './errors.js';
+
+/**
+ * A resource content item decoded to bytes, ready to print or write.
+ */
+export interface DecodedResourceContent {
+  /** URI of the selected content item (may differ from the requested URI). */
+  uri: string;
+  /** MIME type of the content, if provided by the server. */
+  mimeType?: string;
+  /** Decoded payload: UTF-8 bytes for `text` items, base64-decoded bytes for `blob` items. */
+  data: Buffer;
+  /** True when the item carried base64 `blob` (binary) content rather than `text`. */
+  binary: boolean;
+  /** Total number of content items in the result the item was selected from. */
+  totalContents: number;
+}
+
+/**
+ * Select and decode a single content item from a `resources/read` result.
+ *
+ * A read MAY return multiple content items (e.g. a directory URI expanding to
+ * several files). For single-file materialization we pick the item whose `uri`
+ * matches the requested URI, falling back to the first item. Callers that need
+ * every item should consume the raw `ReadResourceResult` instead (`--json`).
+ *
+ * @throws ServerError when the result has no contents or an item carries neither `text` nor `blob`
+ */
+export function selectResourceContent(
+  result: ReadResourceResult,
+  requestedUri: string
+): DecodedResourceContent {
+  const first = result.contents[0];
+  if (!first) {
+    throw new ServerError(`Resource ${requestedUri} returned no contents`);
+  }
+
+  const item = result.contents.find((c) => c.uri === requestedUri) ?? first;
+
+  let data: Buffer;
+  let binary: boolean;
+  if ('blob' in item && typeof item.blob === 'string') {
+    data = Buffer.from(item.blob, 'base64');
+    binary = true;
+  } else if ('text' in item && typeof item.text === 'string') {
+    data = Buffer.from(item.text, 'utf-8');
+    binary = false;
+  } else {
+    throw new ServerError(`Resource ${requestedUri} returned a content item with no text or blob`);
+  }
+
+  return {
+    uri: item.uri || requestedUri,
+    ...(item.mimeType && { mimeType: item.mimeType }),
+    data,
+    binary,
+    totalContents: result.contents.length,
+  };
+}
+
+/**
+ * Write resource content to a local file atomically (temp file + rename),
+ * creating parent directories as needed. Overwrites an existing file — the
+ * target is a materialized copy of the resource, not user-authored data.
+ *
+ * @param filePath - Absolute target path (callers resolve user input against
+ *   their own cwd first — the bridge process has a different cwd than the CLI)
+ * @throws ClientError when the path is not absolute or points at a directory
+ */
+export async function writeResourceFile(filePath: string, data: Buffer): Promise<void> {
+  if (!isAbsolute(filePath)) {
+    throw new ClientError(`Resource target path must be absolute: ${filePath}`);
+  }
+
+  // A directory at the target path cannot be replaced by rename — fail clearly.
+  try {
+    const existing = await stat(filePath);
+    if (existing.isDirectory()) {
+      throw new ClientError(`Resource target path is a directory: ${filePath}`);
+    }
+  } catch (error) {
+    if (error instanceof ClientError) {
+      throw error;
+    }
+    // ENOENT and friends: the write below surfaces any real problem
+  }
+
+  // User-chosen data directory, not mcpc state — standard permissions (umask
+  // applies), not the 0700 default reserved for ~/.mcpc internals
+  const dir = dirname(filePath);
+  await ensureDir(dir, 0o777);
+
+  // Temp file in the same directory so rename never crosses filesystems
+  const tempFile = join(dir, `.${basename(filePath)}.${process.pid}.${Date.now()}.tmp`);
+  try {
+    await writeFile(tempFile, data);
+    await atomicRename(tempFile, filePath);
+  } catch (error) {
+    await unlink(tempFile).catch(() => {});
+    throw error;
+  }
+}

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -26,6 +26,8 @@ import type {
   GetTaskResult,
   ListTasksResult,
   CancelTaskResult,
+  ResourceSyncResult,
+  ResourceUnsubscribeResult,
 } from './types.js';
 import type { ListResourceTemplatesResult } from '@modelcontextprotocol/sdk/types.js';
 import { BridgeClient } from './bridge-client.js';
@@ -208,22 +210,37 @@ export class SessionClient implements IMcpClient {
     );
   }
 
-  async subscribeResource(uri: string): Promise<void> {
+  /**
+   * Subscribe to a resource and keep a local file in sync with it.
+   * The bridge performs an initial download to filePath and rewrites the file
+   * whenever the server sends notifications/resources/updated for the URI.
+   *
+   * @param filePath - Absolute target path (resolve user input in the CLI —
+   *   the bridge process has a different cwd)
+   */
+  async subscribeResource(uri: string, filePath: string): Promise<ResourceSyncResult> {
     return this.withRetry(
       () =>
-        this.bridgeClient
-          .request('subscribeResource', { uri }, this.requestTimeout)
-          .then(() => undefined),
+        this.bridgeClient.request(
+          'subscribeResource',
+          { uri, filePath },
+          this.requestTimeout
+        ) as Promise<ResourceSyncResult>,
       'subscribeResource'
     );
   }
 
-  async unsubscribeResource(uri: string): Promise<void> {
+  /**
+   * Stop syncing a subscribed resource. The synced file is kept as-is.
+   */
+  async unsubscribeResource(uri: string): Promise<ResourceUnsubscribeResult> {
     return this.withRetry(
       () =>
-        this.bridgeClient
-          .request('unsubscribeResource', { uri }, this.requestTimeout)
-          .then(() => undefined),
+        this.bridgeClient.request(
+          'unsubscribeResource',
+          { uri },
+          this.requestTimeout
+        ) as Promise<ResourceUnsubscribeResult>,
       'unsubscribeResource'
     );
   }
@@ -475,7 +492,7 @@ export async function createSessionClient(
  */
 export async function withSessionClient<T>(
   sessionName: string,
-  callback: (client: IMcpClient) => Promise<T>,
+  callback: (client: SessionClient) => Promise<T>,
   options?: { timeout?: number }
 ): Promise<T> {
   const client = await createSessionClient(sessionName, options?.timeout);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -177,6 +177,7 @@ export interface SessionData {
   proxy?: ProxyConfig; // Proxy server configuration (if enabled)
   notifications?: SessionNotifications; // Last list change notification timestamps
   activeTasks?: Record<string, ActiveTaskEntry>; // Active async tasks for crash recovery
+  resourceSubscriptions?: Record<string, ResourceSubscriptionEntry>; // Resource→file syncs, keyed by URI
   // Timestamps (ISO 8601 strings)
   createdAt: string; // When the session was created
   lastSeenAt?: string; // Last successful server response (ping, command, etc.)
@@ -190,6 +191,38 @@ export interface ActiveTaskEntry {
   taskId: string;
   toolName: string;
   createdAt: string;
+}
+
+/**
+ * A resource subscription that keeps a local file in sync with a server resource.
+ * Created by `resources-subscribe <uri> <file>`. The bridge re-reads the resource
+ * and rewrites the file whenever the server sends `notifications/resources/updated`.
+ * Persisted in sessions.json so subscriptions survive bridge restarts.
+ */
+export interface ResourceSubscriptionEntry {
+  uri: string;
+  filePath: string; // Absolute path of the local sync target
+  subscribedAt: string; // ISO 8601
+  lastSyncedAt?: string; // ISO 8601 — last successful file write
+  lastError?: string; // Last sync/re-subscribe failure (cleared on next success)
+}
+
+/**
+ * Result of subscribing a resource to a local file (returned by the bridge)
+ */
+export interface ResourceSyncResult {
+  uri: string;
+  file: string; // Absolute path of the local sync target
+  bytes: number; // Size of the synced content in bytes
+  mimeType?: string;
+}
+
+/**
+ * Result of unsubscribing a resource (returned by the bridge; the file is kept)
+ */
+export interface ResourceUnsubscribeResult {
+  uri: string;
+  file: string; // Absolute path of the local file that is kept
 }
 
 /**
@@ -399,8 +432,9 @@ export interface IMcpClient {
   listResources(cursor?: string): Promise<ListResourcesResult>;
   listResourceTemplates(cursor?: string): Promise<ListResourceTemplatesResult>;
   readResource(uri: string): Promise<ReadResourceResult>;
-  subscribeResource(uri: string): Promise<void>;
-  unsubscribeResource(uri: string): Promise<void>;
+  // Note: resource subscriptions (resources-subscribe/-unsubscribe) are not part of this
+  // interface — they sync files via the persistent bridge process and live on SessionClient.
+  // McpClient keeps the raw protocol ops (subscribeResource/unsubscribeResource) for the bridge.
   listPrompts(cursor?: string): Promise<ListPromptsResult>;
   getPrompt(name: string, args?: Record<string, string>): Promise<GetPromptResult>;
   setLoggingLevel(level: LoggingLevel): Promise<void>;

--- a/test/e2e/lib/framework.sh
+++ b/test/e2e/lib/framework.sh
@@ -873,6 +873,24 @@ server_notify_resources_changed() {
   curl -s -X POST "$TEST_SERVER_URL/control/notify-resources-changed" >/dev/null
 }
 
+# Server control: bump test://dynamic/counter and notify subscribed sessions
+# Prints the new counter value as JSON: {"counter":N}
+server_bump_counter() {
+  curl -s -X POST "$TEST_SERVER_URL/control/bump-counter"
+}
+
+# Server control: send resources/updated for a URI to ALL sessions
+# (regardless of server-side subscription state — exercises client filtering)
+server_notify_resource_updated() {
+  local uri="${1:-test://dynamic/counter}"
+  curl -s -X POST "$TEST_SERVER_URL/control/notify-resource-updated?uri=$uri" >/dev/null
+}
+
+# Server control: get resource URIs subscribed per session (JSON)
+server_get_subscriptions() {
+  curl -s "$TEST_SERVER_URL/control/get-subscriptions"
+}
+
 # Add server cleanup to trap
 _original_cleanup=$(trap -p EXIT | sed "s/trap -- '\(.*\)' EXIT/\1/")
 trap 'stop_test_server; '"$_original_cleanup" EXIT

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -21,8 +21,11 @@
  *   GET  /health - health check
  *   GET  /control/get-deleted-sessions - list session IDs that received DELETE
  *   GET  /control/get-active-sessions - list active MCP session IDs
+ *   GET  /control/get-subscriptions - resource URIs subscribed per session
  *   POST /control/fail-next?count=N - fail next N MCP requests
  *   POST /control/expire-session - expire current session
+ *   POST /control/bump-counter - increment test://dynamic/counter + notify subscribers
+ *   POST /control/notify-resource-updated?uri=U - send resources/updated to all sessions
  *   POST /control/reset - reset all control state
  */
 
@@ -33,6 +36,8 @@ import {
   ListToolsRequestSchema,
   ListResourcesRequestSchema,
   ReadResourceRequestSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
   ListPromptsRequestSchema,
   GetPromptRequestSchema,
   ListResourceTemplatesRequestSchema,
@@ -61,6 +66,15 @@ const SKILLS_NO_INDEX = process.env.SKILLS_NO_INDEX === 'true';
 let failNextCount = 0;
 let sessionExpired = false;
 const deletedSessions: string[] = [];
+
+// Mutable counter resource state (bumped via /control/bump-counter)
+let counterValue = 0;
+
+// Deterministic binary payload for test://static/binary (not valid UTF-8)
+const BINARY_PAYLOAD = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xfc, 0xfd, 0xfe, 0xff]);
+
+// Resource URIs subscribed per MCP server instance (resources/subscribe)
+const serverSubscriptions = new WeakMap<Server, Set<string>>();
 
 // Test data
 const TOOLS = [
@@ -166,6 +180,18 @@ const RESOURCES = [
     name: 'Current Time',
     description: 'Returns current timestamp',
     mimeType: 'text/plain',
+  },
+  {
+    uri: 'test://dynamic/counter',
+    name: 'Counter Resource',
+    description: 'Mutable counter for subscription tests (bump via /control/bump-counter)',
+    mimeType: 'text/plain',
+  },
+  {
+    uri: 'test://static/binary',
+    name: 'Binary Resource',
+    description: 'A small binary test resource (blob content)',
+    mimeType: 'application/octet-stream',
   },
 ];
 
@@ -640,6 +666,24 @@ function createMcpServer(): Server {
         };
       }
 
+      if (uri === 'test://dynamic/counter') {
+        return {
+          contents: [{ uri, mimeType: 'text/plain', text: `counter=${counterValue}` }],
+        };
+      }
+
+      if (uri === 'test://static/binary') {
+        return {
+          contents: [
+            {
+              uri,
+              mimeType: 'application/octet-stream',
+              blob: BINARY_PAYLOAD.toString('base64'),
+            },
+          ],
+        };
+      }
+
       // Skill resources (SEP-2640). May include the well-known
       // skill://index.json plus per-skill SKILL.md files.
       const skillContent = SKILL_CONTENTS[uri];
@@ -651,6 +695,36 @@ function createMcpServer(): Server {
 
       throw new Error(`Resource not found: ${uri}`);
     });
+
+    // Resource subscriptions (resources/subscribe, resources/unsubscribe).
+    // Subscribed URIs are tracked per server instance so control endpoints can
+    // send notifications/resources/updated to the right sessions.
+    const subscribedUris = new Set<string>();
+    server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { uri } = request.params;
+      const known = [...RESOURCES, ...SKILLS_RESOURCES].some((r) => r.uri === uri);
+      if (!known) {
+        throw new Error(`Resource not found: ${uri}`);
+      }
+      subscribedUris.add(uri);
+      return {};
+    });
+
+    server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      subscribedUris.delete(request.params.uri);
+      return {};
+    });
+    serverSubscriptions.set(server, subscribedUris);
   } // end if (!NO_RESOURCES)
 
   // Prompts (only register handlers if capability is enabled)
@@ -742,6 +816,16 @@ async function main() {
           res.end(JSON.stringify({ activeSessions: Array.from(transports.keys()) }));
           return;
         }
+        if (action === 'get-subscriptions') {
+          // Resource URIs subscribed per active MCP session
+          const subscriptions: Record<string, string[]> = {};
+          for (const [sessionId, server] of mcpServers) {
+            subscriptions[sessionId] = Array.from(serverSubscriptions.get(server) ?? []);
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ subscriptions }));
+          return;
+        }
         res.writeHead(404);
         res.end('Unknown control action');
         return;
@@ -772,6 +856,7 @@ async function main() {
           failNextCount = 0;
           sessionExpired = false;
           deletedSessions.length = 0;
+          counterValue = 0;
           res.writeHead(200);
           res.end('State reset');
           return;
@@ -793,6 +878,32 @@ async function main() {
           res.writeHead(200);
           res.end('Sent resources/list_changed notification');
           return;
+
+        case 'bump-counter': {
+          // Increment the counter resource and notify sessions subscribed to it
+          counterValue++;
+          const uri = 'test://dynamic/counter';
+          await Promise.all(
+            [...mcpServers.values()]
+              .filter((s) => serverSubscriptions.get(s)?.has(uri))
+              .map((s) => s.sendResourceUpdated({ uri }).catch(() => {}))
+          );
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ counter: counterValue }));
+          return;
+        }
+
+        case 'notify-resource-updated': {
+          // Fault injection: send notifications/resources/updated to ALL sessions,
+          // regardless of server-side subscription state (exercises client filtering)
+          const uri = url.searchParams.get('uri') || 'test://dynamic/counter';
+          await Promise.all(
+            [...mcpServers.values()].map((s) => s.sendResourceUpdated({ uri }).catch(() => {}))
+          );
+          res.writeHead(200);
+          res.end(`Sent resources/updated for ${uri}`);
+          return;
+        }
 
         default:
           res.writeHead(404);

--- a/test/e2e/suites/basic/resources.test.sh
+++ b/test/e2e/suites/basic/resources.test.sh
@@ -54,7 +54,7 @@ run_mcpc --json "$SESSION" resources-list
 assert_success
 assert_json_valid "$STDOUT"
 assert_json "$STDOUT" '. | type == "array"'
-assert_json "$STDOUT" '. | length == 3'
+assert_json "$STDOUT" '. | length == 5'
 test_pass
 
 test_case "resources-list --json contains expected fields"
@@ -109,6 +109,86 @@ test_pass
 test_case "resources-read unknown resource fails"
 run_mcpc "$SESSION" resources-read "test://nonexistent"
 assert_failure
+test_pass
+
+# =============================================================================
+# Test: resources-read binary content, --raw, and -o (file output)
+# =============================================================================
+
+# Expected bytes of test://static/binary (base64 AAECA/z9/v8=)
+EXPECTED_BIN="$TEST_TMP/expected-binary.bin"
+printf '\x00\x01\x02\x03\xfc\xfd\xfe\xff' > "$EXPECTED_BIN"
+
+test_case "resources-read binary resource shows summary, not raw bytes"
+run_mcpc "$SESSION" resources-read "test://static/binary"
+assert_success
+assert_contains "$STDOUT" "application/octet-stream"
+assert_contains "$STDOUT" "binary"
+assert_contains "$STDOUT" "8 bytes"
+# The base64 payload must not be dumped into the pretty view
+if [[ "$STDOUT" == *"AAECA/z9/v8="* ]]; then
+  test_fail "binary content should not be printed in human mode"
+  exit 1
+fi
+test_pass
+
+test_case "resources-read --raw prints bare text content"
+run_mcpc "$SESSION" resources-read "test://static/hello" --raw
+assert_success
+assert_eq "$STDOUT" "Hello, World!" "raw output should be the exact content"
+test_pass
+
+test_case "resources-read --raw pipes binary bytes when stdout is not a TTY"
+# Bypass run_mcpc: binary output contains NUL bytes that bash variables drop
+OUT_RAW="$TEST_TMP/binary-raw.bin"
+set +e
+$MCPC "$SESSION" resources-read "test://static/binary" --raw > "$OUT_RAW" 2>/dev/null
+RAW_EXIT=$?
+set -e
+assert_eq "$RAW_EXIT" "0" "raw binary read should succeed when stdout is redirected"
+if ! cmp -s "$EXPECTED_BIN" "$OUT_RAW"; then
+  test_fail "piped raw binary output should match the decoded blob bytes"
+  exit 1
+fi
+test_pass
+
+test_case "resources-read -o saves text resource to file"
+OUT_TEXT="$TEST_TMP/hello-resource.txt"
+run_mcpc "$SESSION" resources-read "test://static/hello" -o "$OUT_TEXT"
+assert_success
+assert_contains "$STDOUT" "Saved"
+assert_file_exists "$OUT_TEXT"
+assert_eq "$(cat "$OUT_TEXT")" "Hello, World!" "saved file should contain the resource text"
+test_pass
+
+test_case "resources-read -o decodes binary blob to exact bytes"
+OUT_BIN="$TEST_TMP/binary-resource.bin"
+run_mcpc "$SESSION" resources-read "test://static/binary" -o "$OUT_BIN"
+assert_success
+assert_file_exists "$OUT_BIN"
+if ! cmp -s "$EXPECTED_BIN" "$OUT_BIN"; then
+  test_fail "saved binary file should match the decoded blob bytes"
+  exit 1
+fi
+test_pass
+
+test_case "resources-read -o --json prints summary object"
+OUT_JSON="$TEST_TMP/hello-resource2.txt"
+run_mcpc --json "$SESSION" resources-read "test://static/hello" -o "$OUT_JSON"
+assert_success
+assert_json_valid "$STDOUT"
+assert_json "$STDOUT" '.uri == "test://static/hello"'
+assert_json "$STDOUT" '.bytes == 13'
+assert_json "$STDOUT" '.mimeType == "text/plain"'
+assert_json "$STDOUT" '.file | length > 0'
+assert_file_exists "$OUT_JSON"
+test_pass
+
+test_case "resources-read -o creates parent directories"
+OUT_NESTED="$TEST_TMP/nested/dir/resource.txt"
+run_mcpc "$SESSION" resources-read "test://static/hello" -o "$OUT_NESTED"
+assert_success
+assert_file_exists "$OUT_NESTED"
 test_pass
 
 # =============================================================================

--- a/test/e2e/suites/sessions/pagination.test.sh
+++ b/test/e2e/suites/sessions/pagination.test.sh
@@ -44,10 +44,12 @@ test_pass
 test_case "resources-list fetches all pages"
 run_xmcpc "$SESSION" resources-list
 assert_success
-# Server has 3 resources
+# Server has 5 resources
 assert_contains "$STDOUT" "Hello Resource"
 assert_contains "$STDOUT" "JSON Resource"
 assert_contains "$STDOUT" "Current Time"
+assert_contains "$STDOUT" "Counter Resource"
+assert_contains "$STDOUT" "Binary Resource"
 test_pass
 
 # Test: resources-list --json returns all resources
@@ -56,7 +58,7 @@ run_xmcpc "$SESSION" resources-list --json
 assert_success
 # Returns array directly
 resource_count=$(echo "$STDOUT" | jq 'length')
-assert_eq "$resource_count" "3" "should have all 3 resources"
+assert_eq "$resource_count" "5" "should have all 5 resources"
 test_pass
 
 # Test: prompts-list fetches all pages

--- a/test/e2e/suites/sessions/resource-sync.test.sh
+++ b/test/e2e/suites/sessions/resource-sync.test.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+# Test: Resource subscription file sync (resources-subscribe / resources-unsubscribe)
+# The bridge downloads the subscribed resource to a local file and rewrites it
+# whenever the server sends notifications/resources/updated for the URI.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "sessions/resource-sync"
+
+# Start test server
+start_test_server
+
+SESSION=$(session_name "rsync")
+COUNTER_URI="test://dynamic/counter"
+SYNC_FILE="$TEST_TMP/counter-sync.txt"
+
+# Wait (up to timeout secs) for a file to contain exactly the expected line
+wait_for_file_content() {
+  local path="$1"
+  local expected="$2"
+  local timeout="${3:-10}"
+  local i
+  for ((i = 0; i < timeout * 10; i++)); do
+    if [[ -f "$path" ]] && grep -qx "$expected" "$path" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+# Wait (up to timeout secs) until the server tracks a subscription for the URI
+wait_for_server_subscription() {
+  local uri="$1"
+  local timeout="${2:-10}"
+  local i
+  for ((i = 0; i < timeout * 10; i++)); do
+    if [[ "$(server_get_subscriptions)" == *"$uri"* ]]; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+test_case "setup: create session"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+test_pass
+
+# =============================================================================
+# Test: resources-subscribe
+# =============================================================================
+
+test_case "resources-subscribe without file argument fails"
+run_mcpc "$SESSION" resources-subscribe "$COUNTER_URI"
+assert_failure
+assert_contains "$STDERR" "file"
+test_pass
+
+test_case "resources-subscribe downloads initial content"
+run_mcpc "$SESSION" resources-subscribe "$COUNTER_URI" "$SYNC_FILE"
+assert_success
+assert_contains "$STDOUT" "Subscribed"
+assert_file_exists "$SYNC_FILE"
+assert_eq "$(cat "$SYNC_FILE")" "counter=0" "initial sync should download current content"
+test_pass
+
+test_case "server records the subscription"
+if ! wait_for_server_subscription "$COUNTER_URI" 5; then
+  test_fail "server should track the subscription: $(server_get_subscriptions)"
+  exit 1
+fi
+test_pass
+
+test_case "session info shows the subscription"
+run_mcpc --json "$SESSION"
+assert_success
+assert_json "$STDOUT" "._mcpc.resourceSubscriptions[0].uri == \"$COUNTER_URI\""
+assert_json "$STDOUT" '._mcpc.resourceSubscriptions[0].filePath | length > 0'
+test_pass
+
+test_case "session info human output lists the subscription"
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "Resource subscriptions:"
+assert_contains "$STDOUT" "$COUNTER_URI"
+test_pass
+
+# =============================================================================
+# Test: resources/updated notifications re-sync the file
+# =============================================================================
+
+test_case "resources/updated notification re-syncs the file"
+server_bump_counter >/dev/null
+if ! wait_for_file_content "$SYNC_FILE" "counter=1"; then
+  test_fail "file should be re-synced to counter=1 (got: $(cat "$SYNC_FILE" 2>/dev/null))"
+  exit 1
+fi
+test_pass
+
+test_case "subsequent updates keep syncing"
+server_bump_counter >/dev/null
+if ! wait_for_file_content "$SYNC_FILE" "counter=2"; then
+  test_fail "file should be re-synced to counter=2 (got: $(cat "$SYNC_FILE" 2>/dev/null))"
+  exit 1
+fi
+test_pass
+
+test_case "updated notifications for unsubscribed URIs are ignored"
+# Fault injection: notify about an unrelated URI; the synced file must not change
+server_notify_resource_updated "test://static/hello"
+sleep 1
+assert_eq "$(cat "$SYNC_FILE")" "counter=2" "file should be unchanged"
+test_pass
+
+# =============================================================================
+# Test: subscriptions survive a session restart
+# =============================================================================
+
+test_case "subscription survives session restart"
+run_mcpc "$SESSION" restart
+assert_success
+# The bridge re-subscribes and re-syncs in the background after reconnecting
+if ! wait_for_server_subscription "$COUNTER_URI" 10; then
+  test_fail "subscription should be re-established on the server after restart"
+  exit 1
+fi
+server_bump_counter >/dev/null
+if ! wait_for_file_content "$SYNC_FILE" "counter=3"; then
+  test_fail "file should keep syncing after restart (got: $(cat "$SYNC_FILE" 2>/dev/null))"
+  exit 1
+fi
+test_pass
+
+# =============================================================================
+# Test: resources-unsubscribe
+# =============================================================================
+
+test_case "resources-unsubscribe stops syncing and keeps the file"
+run_mcpc "$SESSION" resources-unsubscribe "$COUNTER_URI"
+assert_success
+assert_contains "$STDOUT" "Unsubscribed"
+assert_contains "$STDOUT" "File kept"
+assert_file_exists "$SYNC_FILE"
+test_pass
+
+test_case "server subscription is removed"
+SUBS_JSON=$(server_get_subscriptions)
+if [[ "$SUBS_JSON" == *"$COUNTER_URI"* ]]; then
+  test_fail "server should no longer track the subscription: $SUBS_JSON"
+  exit 1
+fi
+test_pass
+
+test_case "no more syncing after unsubscribe"
+server_bump_counter >/dev/null
+# Even fault-injected updated notifications must be ignored now
+server_notify_resource_updated "$COUNTER_URI"
+sleep 1.5
+assert_eq "$(cat "$SYNC_FILE")" "counter=3" "file should keep the last synced content"
+test_pass
+
+test_case "unsubscribe without subscription fails with guidance"
+run_mcpc "$SESSION" resources-unsubscribe "$COUNTER_URI"
+assert_failure
+assert_contains "$STDERR" "No active subscription"
+test_pass
+
+# =============================================================================
+# Test: error handling and JSON mode
+# =============================================================================
+
+test_case "subscribe to unknown resource fails and rolls back"
+run_mcpc "$SESSION" resources-subscribe "test://nonexistent" "$TEST_TMP/never.txt"
+assert_failure
+assert_file_not_exists "$TEST_TMP/never.txt"
+test_pass
+
+test_case "subscribe --json returns sync summary"
+JSON_SYNC_FILE="$TEST_TMP/counter-json.txt"
+run_mcpc --json "$SESSION" resources-subscribe "$COUNTER_URI" "$JSON_SYNC_FILE"
+assert_success
+assert_json_valid "$STDOUT"
+assert_json "$STDOUT" '.subscribed == true'
+assert_json "$STDOUT" ".uri == \"$COUNTER_URI\""
+assert_json "$STDOUT" '.bytes > 0'
+assert_json "$STDOUT" '.mimeType == "text/plain"'
+assert_file_exists "$JSON_SYNC_FILE"
+test_pass
+
+test_case "unsubscribe --json returns kept file path"
+run_mcpc --json "$SESSION" resources-unsubscribe "$COUNTER_URI"
+assert_success
+assert_json_valid "$STDOUT"
+assert_json "$STDOUT" '.unsubscribed == true'
+assert_json "$STDOUT" '.file | length > 0'
+assert_file_exists "$JSON_SYNC_FILE"
+test_pass
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+test_case "cleanup: close session"
+run_mcpc "$SESSION" close
+assert_success
+_SESSIONS_CREATED=("${_SESSIONS_CREATED[@]/$SESSION}")
+test_pass
+
+test_done

--- a/test/unit/bridge/resource-sync.test.ts
+++ b/test/unit/bridge/resource-sync.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Unit tests for the bridge's ResourceSyncManager (resource→file sync)
+ */
+
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { ResourceSyncManager } from '../../../src/bridge/resource-sync.js';
+import type { ResourceSubscriptionEntry } from '../../../src/lib/types.js';
+import { ClientError } from '../../../src/lib/errors.js';
+import { createNoOpLogger } from '../../../src/lib/logger.js';
+
+const URI = 'test://resource';
+
+function textResult(text: string): ReadResourceResult {
+  return { contents: [{ uri: URI, mimeType: 'text/plain', text }] };
+}
+
+interface Harness {
+  manager: ResourceSyncManager;
+  reads: string[];
+  persisted: Record<string, ResourceSubscriptionEntry>[];
+  setContent: (text: string) => void;
+  failReads: (message: string | null) => void;
+  setReadDelay: (ms: number) => void;
+}
+
+function createHarness(initialContent = 'v1'): Harness {
+  let content = initialContent;
+  let failMessage: string | null = null;
+  let readDelay = 0;
+  const reads: string[] = [];
+  const persisted: Record<string, ResourceSubscriptionEntry>[] = [];
+
+  const manager = new ResourceSyncManager({
+    readResource: async (uri) => {
+      reads.push(uri);
+      if (readDelay > 0) {
+        await new Promise((resolve) => setTimeout(resolve, readDelay));
+      }
+      if (failMessage) {
+        throw new Error(failMessage);
+      }
+      return textResult(content);
+    },
+    persist: async (entries) => {
+      persisted.push(structuredClone(entries));
+    },
+    logger: createNoOpLogger(),
+  });
+
+  return {
+    manager,
+    reads,
+    persisted,
+    setContent: (text) => {
+      content = text;
+    },
+    failReads: (message) => {
+      failMessage = message;
+    },
+    setReadDelay: (ms) => {
+      readDelay = ms;
+    },
+  };
+}
+
+describe('ResourceSyncManager', () => {
+  let dir: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mcpc-resource-sync-'));
+    filePath = join(dir, 'synced.txt');
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('add() performs the initial sync and persists the entry', async () => {
+    const h = createHarness('hello');
+    const result = await h.manager.add(URI, filePath);
+
+    expect(result).toEqual({ uri: URI, file: filePath, bytes: 5, mimeType: 'text/plain' });
+    expect(await readFile(filePath, 'utf-8')).toBe('hello');
+    expect(h.manager.has(URI)).toBe(true);
+    expect(h.persisted.at(-1)?.[URI]?.filePath).toBe(filePath);
+    expect(h.persisted.at(-1)?.[URI]?.lastSyncedAt).toBeDefined();
+  });
+
+  it('add() throws and registers nothing when the initial sync fails', async () => {
+    const h = createHarness();
+    h.failReads('read refused');
+
+    await expect(h.manager.add(URI, filePath)).rejects.toThrow('read refused');
+    expect(h.manager.has(URI)).toBe(false);
+    expect(h.persisted).toHaveLength(0);
+  });
+
+  it('handleUpdated() re-syncs the file with new content', async () => {
+    const h = createHarness('v1');
+    await h.manager.add(URI, filePath);
+
+    h.setContent('v2');
+    h.manager.handleUpdated(URI);
+    await h.manager.waitForIdle();
+
+    expect(await readFile(filePath, 'utf-8')).toBe('v2');
+    expect(h.persisted.at(-1)?.[URI]?.lastSyncedAt).toBeDefined();
+  });
+
+  it('handleUpdated() ignores unsubscribed URIs', async () => {
+    const h = createHarness();
+    h.manager.handleUpdated('test://unknown');
+    await h.manager.waitForIdle();
+    expect(h.reads).toHaveLength(0);
+  });
+
+  it('coalesces bursts of update notifications into at most one follow-up sync', async () => {
+    const h = createHarness('v1');
+    await h.manager.add(URI, filePath);
+    expect(h.reads).toHaveLength(1);
+
+    h.setReadDelay(30);
+    h.setContent('v2');
+    h.manager.handleUpdated(URI);
+    h.manager.handleUpdated(URI);
+    h.manager.handleUpdated(URI);
+    await h.manager.waitForIdle();
+
+    // 1 initial read + 1 in-flight sync + 1 coalesced follow-up = 3
+    expect(h.reads).toHaveLength(3);
+    expect(await readFile(filePath, 'utf-8')).toBe('v2');
+  });
+
+  it('records lastError when a re-sync fails and clears it on the next success', async () => {
+    const h = createHarness('v1');
+    await h.manager.add(URI, filePath);
+
+    h.failReads('boom');
+    h.manager.handleUpdated(URI);
+    await h.manager.waitForIdle();
+    expect(h.persisted.at(-1)?.[URI]?.lastError).toContain('boom');
+    // File keeps the last good content
+    expect(await readFile(filePath, 'utf-8')).toBe('v1');
+
+    h.failReads(null);
+    h.setContent('v2');
+    h.manager.handleUpdated(URI);
+    await h.manager.waitForIdle();
+    expect(h.persisted.at(-1)?.[URI]?.lastError).toBeUndefined();
+    expect(await readFile(filePath, 'utf-8')).toBe('v2');
+  });
+
+  it('remove() deletes the entry, persists, and keeps the file', async () => {
+    const h = createHarness('keep me');
+    await h.manager.add(URI, filePath);
+
+    const removed = await h.manager.remove(URI);
+    expect(removed.filePath).toBe(filePath);
+    expect(h.manager.has(URI)).toBe(false);
+    expect(h.persisted.at(-1)).toEqual({});
+    expect(await readFile(filePath, 'utf-8')).toBe('keep me');
+
+    // Updates after removal are ignored
+    h.manager.handleUpdated(URI);
+    await h.manager.waitForIdle();
+    expect(h.reads).toHaveLength(1);
+  });
+
+  it('remove() throws ClientError for unknown URIs and lists active subscriptions', async () => {
+    const h = createHarness();
+    await h.manager.add(URI, filePath);
+
+    await expect(h.manager.remove('test://unknown')).rejects.toThrow(ClientError);
+    await expect(h.manager.remove('test://unknown')).rejects.toThrow(URI);
+  });
+
+  it('add() for an already-subscribed URI re-targets the file', async () => {
+    const h = createHarness('v1');
+    await h.manager.add(URI, filePath);
+
+    const otherPath = join(dir, 'other.txt');
+    await h.manager.add(URI, otherPath);
+    expect(await readFile(otherPath, 'utf-8')).toBe('v1');
+    expect(h.manager.list()).toHaveLength(1);
+    expect(h.manager.list()[0]?.filePath).toBe(otherPath);
+  });
+
+  it('load() restores persisted entries and resync() refreshes the file', async () => {
+    const h = createHarness('restored');
+    const entry: ResourceSubscriptionEntry = {
+      uri: URI,
+      filePath,
+      subscribedAt: new Date().toISOString(),
+    };
+    h.manager.load({ [URI]: entry });
+
+    expect(h.manager.has(URI)).toBe(true);
+    await h.manager.resync(URI);
+    expect(await readFile(filePath, 'utf-8')).toBe('restored');
+  });
+
+  it('recordError() stores the error on the entry', async () => {
+    const h = createHarness();
+    await h.manager.add(URI, filePath);
+
+    await h.manager.recordError(URI, 'Re-subscribe failed: nope');
+    expect(h.persisted.at(-1)?.[URI]?.lastError).toBe('Re-subscribe failed: nope');
+  });
+});

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -42,6 +42,7 @@ import {
   formatServerDetails,
   formatResources,
   formatResourceDetail,
+  formatResourceContents,
   formatResourceTemplates,
   formatResourceTemplateDetail,
   formatPrompts,
@@ -1163,9 +1164,64 @@ describe('formatServerDetails', () => {
     // Should show resources with subscribe feature
     expect(output).toContain('resources (supports subscribe)');
 
-    // Should show resources commands
+    // Should show resources commands, including subscribe (capability present)
     expect(output).toContain('mcpc @res resources-list');
     expect(output).toContain('mcpc @res resources-read');
+    expect(output).toContain('mcpc @res resources-subscribe <uri> <file>');
+  });
+
+  it('should not list resources-subscribe command without the subscribe capability', () => {
+    const details: ServerDetails = {
+      capabilities: {
+        resources: { listChanged: true },
+      },
+      serverInfo: { name: 'Resource Server', version: '2.0.0' },
+    };
+
+    const output = formatServerDetails(details, '@res');
+
+    expect(output).toContain('mcpc @res resources-read');
+    expect(output).not.toContain('resources-subscribe');
+  });
+
+  it('should list active resource subscriptions with sync status', () => {
+    const details: ServerDetails = {
+      capabilities: { resources: { subscribe: true } },
+      serverInfo: { name: 'Resource Server', version: '2.0.0' },
+    };
+    const subscriptions = [
+      {
+        uri: 'test://config',
+        filePath: '/tmp/config.json',
+        subscribedAt: new Date().toISOString(),
+        lastSyncedAt: new Date().toISOString(),
+      },
+      {
+        uri: 'test://broken',
+        filePath: '/tmp/broken.json',
+        subscribedAt: new Date().toISOString(),
+        lastError: 'Re-subscribe failed: nope',
+      },
+    ];
+
+    const output = formatServerDetails(details, '@res', undefined, subscriptions);
+
+    expect(output).toContain('Resource subscriptions:');
+    expect(output).toContain('test://config');
+    expect(output).toContain('/tmp/config.json');
+    expect(output).toContain('synced just now');
+    expect(output).toContain('sync failing: Re-subscribe failed: nope');
+  });
+
+  it('should omit the resource subscriptions section when there are none', () => {
+    const details: ServerDetails = {
+      capabilities: { resources: { subscribe: true } },
+      serverInfo: { name: 'Resource Server', version: '2.0.0' },
+    };
+
+    const output = formatServerDetails(details, '@res', undefined, []);
+
+    expect(output).not.toContain('Resource subscriptions:');
   });
 
   it('should format empty instructions as no Instructions section', () => {
@@ -1364,6 +1420,70 @@ describe('formatResourceDetail', () => {
     expect(output).not.toContain('MIME type:');
     // No description section when description is missing
     expect(output).not.toContain('Description:');
+  });
+});
+
+describe('formatResourceContents', () => {
+  it('shows text content in a fenced block with metadata', () => {
+    const result = {
+      contents: [{ uri: 'test://hello', mimeType: 'text/plain', text: 'Hello, World!' }],
+    };
+
+    const output = formatResourceContents('test://hello', result);
+
+    expect(output).toContain('Resource: `test://hello`');
+    expect(output).toContain('MIME type: text/plain');
+    expect(output).toContain('````');
+    expect(output).toContain('Hello, World!');
+  });
+
+  it('summarizes binary content instead of dumping it', () => {
+    const blob = Buffer.from([0, 1, 2, 255]).toString('base64');
+    const result = {
+      contents: [{ uri: 'test://bin', mimeType: 'image/png', blob }],
+    };
+
+    const output = formatResourceContents('test://bin', result, { sessionName: '@s' });
+
+    expect(output).toContain('Resource: `test://bin`');
+    expect(output).toContain('MIME type: image/png');
+    expect(output).toContain('4 bytes (binary)');
+    expect(output).toContain('(binary content not shown)');
+    expect(output).toContain('mcpc @s resources-read test://bin -o <file>');
+    expect(output).not.toContain(blob);
+  });
+
+  it('separates multiple content items', () => {
+    const result = {
+      contents: [
+        { uri: 'test://a', text: 'first' },
+        { uri: 'test://b', text: 'second' },
+      ],
+    };
+
+    const output = formatResourceContents('test://a', result);
+
+    expect(output).toContain('test://a');
+    expect(output).toContain('test://b');
+    expect(output).toContain('first');
+    expect(output).toContain('second');
+    expect(output).toContain('---');
+  });
+
+  it('handles empty contents', () => {
+    const output = formatResourceContents('test://empty', { contents: [] });
+    expect(output).toContain('(resource returned no contents)');
+  });
+
+  it('truncates output with maxChars', () => {
+    const result = {
+      contents: [{ uri: 'test://long', text: 'x'.repeat(5000) }],
+    };
+
+    const output = formatResourceContents('test://long', result, { maxChars: 100 });
+
+    expect(output.length).toBeLessThan(400);
+    expect(output).toContain('truncated');
   });
 });
 

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -342,7 +342,6 @@ describe('optionTakesValue', () => {
     expect(optionTakesValue('--client-secret')).toBe(true);
     expect(optionTakesValue('-o')).toBe(true);
     expect(optionTakesValue('--output')).toBe(true);
-    expect(optionTakesValue('--max-size')).toBe(true);
     expect(optionTakesValue('--amount')).toBe(true);
     expect(optionTakesValue('--expiry')).toBe(true);
   });
@@ -420,9 +419,9 @@ describe('validateOptions', () => {
     expect(() => validateOptions(['login', 'mcp.apify.com', '--scope', 'read'])).not.toThrow();
     // --amount, --expiry for x402 sign
     expect(() => validateOptions(['x402', 'sign', 'data', '--amount', '1.0'])).not.toThrow();
-    // -o/--output, --max-size for resources-read
+    // -o/--output for resources-read
     expect(() =>
-      validateOptions(['@session', 'resources-read', 'uri', '-o', 'out.txt', '--max-size', '1024'])
+      validateOptions(['@session', 'resources-read', 'uri', '-o', 'out.txt'])
     ).not.toThrow();
   });
 

--- a/test/unit/lib/resource-content.test.ts
+++ b/test/unit/lib/resource-content.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for resource content selection/decoding and file writing
+ */
+
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import { selectResourceContent, writeResourceFile } from '../../../src/lib/resource-content.js';
+import { ClientError, ServerError } from '../../../src/lib/errors.js';
+
+describe('selectResourceContent', () => {
+  it('decodes a single text content item', () => {
+    const result: ReadResourceResult = {
+      contents: [{ uri: 'test://a', mimeType: 'text/plain', text: 'hello' }],
+    };
+    const content = selectResourceContent(result, 'test://a');
+    expect(content.uri).toBe('test://a');
+    expect(content.mimeType).toBe('text/plain');
+    expect(content.binary).toBe(false);
+    expect(content.data.toString('utf-8')).toBe('hello');
+    expect(content.totalContents).toBe(1);
+  });
+
+  it('decodes a base64 blob content item to bytes', () => {
+    const bytes = Buffer.from([0x00, 0x01, 0xfe, 0xff]);
+    const result: ReadResourceResult = {
+      contents: [
+        { uri: 'test://bin', mimeType: 'application/octet-stream', blob: bytes.toString('base64') },
+      ],
+    };
+    const content = selectResourceContent(result, 'test://bin');
+    expect(content.binary).toBe(true);
+    expect(Buffer.compare(content.data, bytes)).toBe(0);
+  });
+
+  it('prefers the content item matching the requested URI', () => {
+    const result: ReadResourceResult = {
+      contents: [
+        { uri: 'test://other', text: 'other' },
+        { uri: 'test://wanted', text: 'wanted' },
+      ],
+    };
+    const content = selectResourceContent(result, 'test://wanted');
+    expect(content.uri).toBe('test://wanted');
+    expect(content.data.toString('utf-8')).toBe('wanted');
+    expect(content.totalContents).toBe(2);
+  });
+
+  it('falls back to the first content item when no URI matches', () => {
+    const result: ReadResourceResult = {
+      contents: [
+        { uri: 'test://first', text: 'first' },
+        { uri: 'test://second', text: 'second' },
+      ],
+    };
+    const content = selectResourceContent(result, 'test://nomatch');
+    expect(content.uri).toBe('test://first');
+  });
+
+  it('throws ServerError when the result has no contents', () => {
+    expect(() => selectResourceContent({ contents: [] }, 'test://x')).toThrow(ServerError);
+  });
+
+  it('throws ServerError when a content item has neither text nor blob', () => {
+    const result = { contents: [{ uri: 'test://x' }] } as unknown as ReadResourceResult;
+    expect(() => selectResourceContent(result, 'test://x')).toThrow(ServerError);
+  });
+
+  it('treats text content with mimeType missing as text', () => {
+    const result: ReadResourceResult = { contents: [{ uri: 'test://a', text: 'no mime' }] };
+    const content = selectResourceContent(result, 'test://a');
+    expect(content.mimeType).toBeUndefined();
+    expect(content.binary).toBe(false);
+  });
+});
+
+describe('writeResourceFile', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'mcpc-resource-content-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes data to the target file', async () => {
+    const target = join(dir, 'out.txt');
+    await writeResourceFile(target, Buffer.from('content'));
+    expect(await readFile(target, 'utf-8')).toBe('content');
+  });
+
+  it('writes binary data byte-exact', async () => {
+    const target = join(dir, 'out.bin');
+    const bytes = Buffer.from([0x00, 0x01, 0x02, 0xff]);
+    await writeResourceFile(target, bytes);
+    expect(Buffer.compare(await readFile(target), bytes)).toBe(0);
+  });
+
+  it('overwrites an existing file', async () => {
+    const target = join(dir, 'out.txt');
+    await writeFile(target, 'old');
+    await writeResourceFile(target, Buffer.from('new'));
+    expect(await readFile(target, 'utf-8')).toBe('new');
+  });
+
+  it('creates missing parent directories', async () => {
+    const target = join(dir, 'nested', 'deeper', 'out.txt');
+    await writeResourceFile(target, Buffer.from('nested'));
+    expect(await readFile(target, 'utf-8')).toBe('nested');
+  });
+
+  it('rejects relative paths', async () => {
+    await expect(writeResourceFile('relative/out.txt', Buffer.from('x'))).rejects.toThrow(
+      ClientError
+    );
+  });
+
+  it('rejects a target path that is a directory', async () => {
+    const target = join(dir, 'subdir');
+    await mkdir(target);
+    await expect(writeResourceFile(target, Buffer.from('x'))).rejects.toThrow(ClientError);
+  });
+
+  it('leaves no temp files behind on success', async () => {
+    const target = join(dir, 'out.txt');
+    await writeResourceFile(target, Buffer.from('content'));
+    const { readdir } = await import('fs/promises');
+    const files = await readdir(dir);
+    expect(files).toEqual(['out.txt']);
+  });
+});


### PR DESCRIPTION
## Summary

Implements the `resources-subscribe` and `resources-unsubscribe` commands, allowing users to keep local files in sync with MCP server resources. When a resource is subscribed, the bridge downloads it to a local file and automatically re-syncs whenever the server sends `notifications/resources/updated` notifications. Subscriptions persist across bridge restarts.

## Key Changes

**Core Resource Sync Infrastructure:**
- Added `ResourceSyncManager` (`src/bridge/resource-sync.ts`) to track subscriptions and coordinate file syncing
  - Handles initial download on subscribe, re-syncing on server notifications
  - Coalesces burst notifications into at most one follow-up sync
  - Records per-subscription errors and sync timestamps
  - Persists subscriptions to `sessions.json` for crash recovery
- Added `selectResourceContent()` and `writeResourceFile()` helpers (`src/lib/resource-content.ts`) for materializing MCP resource contents
  - Selects appropriate content item from multi-item responses
  - Decodes text and base64 blob payloads to bytes
  - Writes atomically (temp file + rename) with parent directory creation

**CLI Commands:**
- Implemented `resources-subscribe <uri> <file>` command to subscribe and sync a resource to a local file
- Implemented `resources-unsubscribe <uri>` command to remove subscriptions (keeps the synced file)
- Enhanced `resources-read` command with:
  - `-o/--output <file>` flag to save resource content to a file (binary-safe)
  - `--raw` flag to print bare content suitable for piping
  - Proper handling of binary (blob) content — summarized in human mode, never dumped

**Bridge Integration:**
- Wired `ResourceSyncManager` into bridge process to handle `notifications/resources/updated`
- Added `restoreResourceSubscriptions()` to re-establish persisted subscriptions on bridge startup
- Subscriptions survive bridge restarts and session reconnections

**Session Data & Output:**
- Added `resourceSubscriptions` field to `SessionData` for persistence
- Added `ResourceSubscriptionEntry` type with URI, file path, timestamps, and error tracking
- Enhanced `formatServerDetails()` to show active subscriptions with sync status
- Added `formatResourceContents()` for pretty-printing resource read results
- Added `formatTimeAgo()` helper for human-friendly timestamp display

**Test Coverage:**
- Comprehensive unit tests for `ResourceSyncManager` (coalescing, error handling, persistence)
- Unit tests for resource content selection and file writing
- E2E test suite (`resource-sync.test.sh`) covering subscribe/unsubscribe, notifications, restarts, and error cases
- Test server enhancements: mutable counter resource, binary resource, subscription tracking, and control endpoints

## Notable Implementation Details

- **Notification Coalescing**: Multiple `resources/updated` notifications arriving during an in-flight sync are collapsed into exactly one queued follow-up sync, preventing thrashing on rapid updates
- **Error Resilience**: Sync failures are recorded per subscription without blocking other operations; the file retains its last good content
- **Atomic Writes**: Resource files are written atomically (temp file + rename) to prevent corruption
- **Backward Compatibility**: Sessions without subscriptions work unchanged; the `resourceSubscriptions` field is optional in `SessionData`

https://claude.ai/code/session_01HWY3cK2NAURyyQRxDDjoBY