### PR TITLE
Document default timeout value in CLI help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Options:
   --json                         Output in JSON format for scripting
   --verbose                      Enable debug logging
   --profile <name>               OAuth profile for the server ("default" if not provided)
-  --timeout <seconds>            Request timeout in seconds
+  --timeout <seconds>            Request timeout in seconds (default: 60)
   --max-chars <n>                Truncate output to n characters (ignored in --json mode)
   --insecure                     Skip TLS certificate verification (for self-signed certs)
   -v, --version                  Output the version number

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -209,7 +209,7 @@ mcpc @apify skills-get <name> --raw    # print the SKILL.md markdown (pipe to a 
 --json                  # machine-readable, MCP-spec-shaped output (code mode)
 --verbose               # protocol-level debug logging (JSON-RPC, transport)
 --profile <name>        # OAuth profile to use ("default" if omitted)
---timeout <seconds>     # request timeout in seconds
+--timeout <seconds>     # request timeout in seconds (default: 60)
 --max-chars <n>         # truncate human-readable output to n chars (ignored with --json)
 --insecure              # skip TLS verification (self-signed certs only)
 ```

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -429,7 +429,7 @@ function createTopLevelProgram(): Command {
     .option('--json', 'Output in JSON format for scripting')
     .option('--verbose', 'Enable debug logging')
     .option('--profile <name>', 'OAuth profile for the server ("default" if not provided)')
-    .option('--timeout <seconds>', 'Request timeout in seconds')
+    .option('--timeout <seconds>', 'Request timeout in seconds (default: 60)')
     .option('--max-chars <n>', 'Truncate output to n characters (ignored in --json mode)')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .version(mcpcVersion, '-v, --version', 'Output the version number')
@@ -1456,7 +1456,7 @@ function createSessionProgram(): Command {
     .option('--json', 'Output in JSON format for scripting and code mode')
     .option('--verbose', 'Enable debug logging')
     .option('--profile <name>', 'OAuth profile override')
-    .option('--timeout <seconds>', 'Request timeout in seconds')
+    .option('--timeout <seconds>', 'Request timeout in seconds (default: 60)')
     .option('--max-chars <n>', 'Truncate output to n characters (ignored in --json mode)')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
     .addHelpText(

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -79,8 +79,8 @@ export interface McpClientOptions extends ClientOptions {
   logger?: Logger;
 
   /**
-   * Request timeout in milliseconds for MCP operations
-   * If not specified, uses SDK default (60 seconds)
+   * Request timeout in milliseconds for MCP operations.
+   * Defaults to DEFAULT_REQUEST_TIMEOUT_MS (60 seconds) when not specified.
    */
   requestTimeout?: number;
 }
@@ -91,6 +91,16 @@ export interface McpClientOptions extends ClientOptions {
 interface TransportWithTermination extends Transport {
   terminateSession?: () => Promise<void>;
 }
+
+/**
+ * Default request timeout in milliseconds (60 seconds).
+ *
+ * Pinned explicitly instead of relying on the MCP SDK's built-in default, so the
+ * documented `--timeout` default (shown as "default: 60" in the CLI help) stays
+ * accurate even if the SDK changes its own default. A config-file `timeout` or
+ * the `--timeout` flag overrides it (via the constructor / setRequestTimeout()).
+ */
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 /**
  * MCP Client wrapper class
@@ -104,7 +114,7 @@ export class McpClient implements IMcpClient {
   private mcpSessionId?: string;
   private transport?: TransportWithTermination;
   private hasConnected = false;
-  private requestTimeout?: number;
+  private requestTimeout: number = DEFAULT_REQUEST_TIMEOUT_MS;
   private cachedTools: Tool[] | null = null;
   private cachedToolsExpiresAt: number | null = null;
 
@@ -140,10 +150,12 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * Get request options with timeout if configured
+   * Request options applied to every SDK call. Always carries an explicit
+   * timeout (DEFAULT_REQUEST_TIMEOUT_MS unless overridden) so requests never
+   * fall back to the SDK's own default.
    */
-  private getRequestOptions(): { timeout?: number } | undefined {
-    return this.requestTimeout ? { timeout: this.requestTimeout } : undefined;
+  private getRequestOptions(): { timeout: number } {
+    return { timeout: this.requestTimeout };
   }
 
   /**


### PR DESCRIPTION
`mcpc --help` (and the README/SKILL.md) again shows the default for `--timeout`, and the value is now pinned in code so the docs can't silently drift.

PR #274 dropped the `(default: ...)` annotation with no stated reason (a reviewer flagged it but it merged unanswered). This restores it with the *correct* value — 60s — and makes the MCP client request that timeout explicitly instead of relying on the SDK's implicit default.

- Restore `(default: 60)` on `--timeout` in the top-level and session help
- Update README (regenerated) and `skills/mcpc/SKILL.md` to match
- Pin the request timeout to an explicit 60s default in `core/mcp-client.ts` (a config `timeout` or `--timeout` still overrides it)

Refs #274

https://claude.ai/code/session_01NWke6u9XKWjPS7nPi2mzBN