### PR TITLE
Fix OAuth error reporting and session restart cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The hosted OAuth Client ID Metadata Document now includes the required `client_id` property, so authorization servers that validate CIMD documents per spec no longer reject `mcpc login` with the default client identity (#271).
 - Sessions no longer hang on macOS under the Bun runtime (e.g. when connecting with `--proxy-bearer-token`, or auto-reconnecting a crashed session). The bridge now runs under the same runtime as the CLI, so OS-keychain items the CLI stored are read back under the same application identity; previously a Bun CLI paired with a Node bridge produced a cross-binary keychain read, which macOS gates with an access prompt that blocks in non-interactive contexts. A Bun user also no longer needs Node installed for the bridge to start.
+- OAuth login failures now report the authorization server's actual error (e.g. `invalid_client`) instead of an opaque `[object Response]` message, and no longer crash the process on Windows when a token request is rejected.
+- `mcpc <session> restart` now terminates the previous MCP session on the server before reconnecting, so the old session and its resource subscriptions are no longer left orphaned (previously leaked on Windows).
 
 ## [0.3.1] - 2026-06-08
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -614,7 +614,7 @@ class BridgeProcess {
         // McpClient caches tools in-memory after the first listAllTools call
         return this.client?.getCachedTools()?.find((t: Tool) => t.name === name);
       };
-      customFetch = createX402FetchMiddleware(proxyFetch as FetchLike, {
+      customFetch = createX402FetchMiddleware(proxyFetch, {
         wallet,
         getToolByName,
         paymentCache: this.x402PaymentCache,

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -377,9 +377,13 @@ export async function restartSession(
       console.log(theme.yellow(`Restarting session ${name}...`));
     }
 
-    // Stop the bridge (even if it's alive)
+    // Stop the bridge (even if it's alive). Graceful so the old bridge sends an HTTP DELETE
+    // to terminate its MCP session before exiting: an explicit restart starts a *fresh*
+    // session (see the note below), so the previous server-side session must be released
+    // rather than orphaned. On Windows SIGTERM is an immediate kill, so graceful mode sends
+    // an IPC shutdown first; on Unix SIGTERM already triggers graceful shutdown.
     try {
-      await stopBridge(name);
+      await stopBridge(name, { graceful: true });
     } catch {
       // Bridge may already be stopped
     }

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -126,8 +126,7 @@ export function createStreamableHttpTransport(
   // Explicitly pass proxy-aware fetch so the MCP SDK transport respects
   // HTTP_PROXY/HTTPS_PROXY env vars (its internal fetch ignores the global dispatcher).
   // Custom fetch (e.g. x402 middleware) takes priority if provided.
-  const fetchFn =
-    options.fetch ?? (proxyFetch as NonNullable<StreamableHTTPClientTransportOptions['fetch']>);
+  const fetchFn = options.fetch ?? proxyFetch;
 
   const transport = new StreamableHTTPClientTransport(new URL(url), {
     reconnectionOptions: defaultReconnectionOptions,

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -363,8 +363,9 @@ export async function stopBridge(
     try {
       if (process.platform === 'win32') {
         // On Windows, SIGTERM calls TerminateProcess (immediate kill, no cleanup).
-        // For graceful shutdown (closeSession), send IPC message first so bridge
-        // can send HTTP DELETE. For restart, just kill immediately.
+        // For graceful shutdown (closeSession / explicit restart), send an IPC message
+        // first so the bridge can send HTTP DELETE to terminate its MCP session before
+        // exiting. Without it the server-side session (and its subscriptions) is orphaned.
         if (options?.graceful) {
           const socketPath = getSocketPath(sessionName, session.pid);
           const shutdownOk = await sendBridgeShutdown(socketPath);

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -13,12 +13,7 @@
  *    EnvHttpProxyAgent dispatcher, for use in code that bypasses the global dispatcher.
  */
 
-import {
-  EnvHttpProxyAgent,
-  setGlobalDispatcher,
-  fetch as undiciFetch,
-  type Dispatcher,
-} from 'undici';
+import { EnvHttpProxyAgent, setGlobalDispatcher, type Dispatcher } from 'undici';
 
 let proxyAgent: Dispatcher | undefined;
 
@@ -44,13 +39,25 @@ export function initProxy(options?: { insecure?: boolean }): void {
  * (e.g., MCP SDK transport, OAuth calls).
  *
  * Falls back to a default EnvHttpProxyAgent if initProxy() was not called.
+ *
+ * Note: this uses the *global* `fetch`, not undici's exported `fetch`, passing the
+ * proxy dispatcher via the `dispatcher` init option (which the global fetch honors).
+ * undici's exported fetch returns its own `Response` class, which is NOT an instance of
+ * the global `Response`. Consumers that branch on `input instanceof Response` — notably
+ * the MCP SDK's OAuth error parser — then mis-handle the result: they skip reading the
+ * body, stringify the Response object to "[object Response]", and leave the undici body
+ * stream unconsumed (which crashes the process on exit on Windows). Returning a global
+ * `Response` keeps those checks working and the body properly drained.
  */
-export function proxyFetch(
-  input: Parameters<typeof undiciFetch>[0],
-  init?: Parameters<typeof undiciFetch>[1]
-): ReturnType<typeof undiciFetch> {
+export function proxyFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
   if (!proxyAgent) {
     proxyAgent = new EnvHttpProxyAgent();
   }
-  return undiciFetch(input, { ...init, dispatcher: proxyAgent });
+  // The cast bridges the type-only version skew between the runtime `undici` package's
+  // Dispatcher and the `undici-types` Dispatcher baked into @types/node's global fetch;
+  // EnvHttpProxyAgent is a valid dispatcher for the global fetch at runtime.
+  return fetch(input, {
+    ...init,
+    dispatcher: proxyAgent as unknown as NonNullable<RequestInit['dispatcher']>,
+  });
 }


### PR DESCRIPTION
Fixes two Windows-only e2e failures (`basic/client-credentials` and `sessions/resource-sync`).

- `proxyFetch` now uses the global `fetch` (with a `dispatcher` option) instead of undici's exported `fetch`, so it returns a global `Response`. The MCP SDK's OAuth error parser branches on `instanceof Response`; with undici's class it skipped the body, printed `[object Response]`, and left the stream unconsumed — crashing the process on exit on Windows. OAuth failures now report the server's real error (e.g. `invalid_client`).
- `mcpc <session> restart` now stops the old bridge gracefully so it sends an HTTP DELETE; the previous MCP session and its subscriptions are no longer orphaned on the server (Windows — Unix already did this via SIGTERM).

https://claude.ai/code/session_01Y6VczheK9na269mw3Bo466