### PR TITLE
Improve error handling in OAuth flows and fix Windows process exit

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -14,6 +14,7 @@ import type { CommandOptions, OutputMode } from '../../lib/types.js';
 import { deleteAuthProfiles } from '../../lib/auth/profiles.js';
 import { performOAuthFlow } from '../../lib/auth/oauth-flow.js';
 import { getServerHost, normalizeServerUrl, validateProfileName } from '../../lib/utils.js';
+import { closeProxy } from '../../lib/proxy.js';
 import { DEFAULT_AUTH_PROFILE, DEFAULT_CLIENT_METADATA_URL } from '../../lib/auth/oauth-utils.js';
 import type { OAuthClientCredentialsInfo } from '../../lib/auth/keychain.js';
 import {
@@ -168,6 +169,10 @@ export async function login(
     } else {
       console.error(formatOutput({ error: errorMessage }, 'json'));
     }
+    // `login` runs OAuth/token requests in this process, leaving idle keep-alive
+    // sockets in undici's pool. Drain them before the forced exit so the teardown
+    // doesn't trip a Windows libuv async-handle assertion onto stderr (see closeProxy).
+    await closeProxy();
     process.exit(4); // Authentication error
   }
 }

--- a/src/lib/auth/client-credentials.ts
+++ b/src/lib/auth/client-credentials.ts
@@ -153,6 +153,30 @@ function buildPinnedDiscoveryState(tokenEndpoint: string): OAuthDiscoveryState {
 }
 
 /**
+ * Build a human-readable reason from an error thrown by the SDK's token request.
+ *
+ * OAuth failures from the authorization server (e.g. a wrong client secret) arrive
+ * as an OAuthError subclass carrying a machine-readable `errorCode` such as
+ * `invalid_client`. When the server omits `error_description` the SDK leaves
+ * `error.message` empty, so fall back to that code rather than reporting a bare,
+ * empty reason. Non-OAuth errors fall back to their message or string form.
+ */
+export function describeAuthError(error: unknown): string {
+  if (error instanceof Error) {
+    const message = error.message.trim();
+    if (message) {
+      return message;
+    }
+    const code = (error as { errorCode?: unknown }).errorCode;
+    if (typeof code === 'string' && code) {
+      return code;
+    }
+    return error.name;
+  }
+  return String(error);
+}
+
+/**
  * Perform a one-off client-credentials token request to validate the supplied
  * material and learn the granted scopes. Uses the same SDK provider the bridge
  * uses at runtime, so a successful validation guarantees the session will connect.
@@ -185,7 +209,7 @@ async function validateClientCredentials(
     logger.debug('Client-credentials validation token request succeeded');
     return tokens.scope ? tokens.scope.split(' ') : undefined;
   } catch (error) {
-    throw new AuthError(`Client-credentials authentication failed: ${(error as Error).message}`);
+    throw new AuthError(`Client-credentials authentication failed: ${describeAuthError(error)}`);
   }
 }
 

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -78,13 +78,17 @@ export function proxyFetch(input: string | URL | Request, init?: RequestInit): P
  * raced against a short timeout so a stuck connection can never stall the CLI's
  * exit. Best-effort throughout: teardown errors (including a late rejection that
  * lands after the timeout wins) are ignored.
+ *
+ * The drain is only needed to avoid the Node/libuv exit crash on Windows. Some
+ * runtimes (e.g. Bun's undici shim) don't implement `destroy()` on the
+ * dispatcher and don't need the drain, so this no-ops where it's unavailable.
  */
 const CLOSE_TIMEOUT_MS = 100;
 
 export async function closeProxy(): Promise<void> {
   const agent = proxyAgent;
   proxyAgent = undefined;
-  if (!agent) {
+  if (!agent || typeof agent.destroy !== 'function') {
     return;
   }
   // Swallow any (possibly late) teardown error so it can't surface as an

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -61,3 +61,27 @@ export function proxyFetch(input: string | URL | Request, init?: RequestInit): P
     dispatcher: proxyAgent as unknown as NonNullable<RequestInit['dispatcher']>,
   });
 }
+
+/**
+ * Forcefully close the proxy dispatcher and all of its pooled connections.
+ *
+ * Call this right before a forced `process.exit()` on any path where the CLI
+ * process itself made HTTP requests (e.g. the `login` token/OAuth calls). Those
+ * requests leave idle keep-alive sockets in undici's connection pool; exiting
+ * while they are still open races libuv's handle teardown on Windows and aborts
+ * the process with an async-handle assertion (`uv_async_send` on a closing
+ * handle, `src\win\async.c`). That stray native abort message lands on stderr
+ * and corrupts otherwise-valid `--json` error output. Draining the pool first
+ * makes the subsequent exit clean. Best-effort: teardown errors are ignored.
+ */
+export async function closeProxy(): Promise<void> {
+  const agent = proxyAgent;
+  proxyAgent = undefined;
+  if (agent) {
+    try {
+      await agent.destroy();
+    } catch {
+      // Best-effort cleanup on the way out — nothing useful to do if it fails.
+    }
+  }
+}

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -72,16 +72,34 @@ export function proxyFetch(input: string | URL | Request, init?: RequestInit): P
  * the process with an async-handle assertion (`uv_async_send` on a closing
  * handle, `src\win\async.c`). That stray native abort message lands on stderr
  * and corrupts otherwise-valid `--json` error output. Draining the pool first
- * makes the subsequent exit clean. Best-effort: teardown errors are ignored.
+ * makes the subsequent exit clean.
+ *
+ * `destroy()` resolves near-instantly for idle keep-alive sockets, but it is
+ * raced against a short timeout so a stuck connection can never stall the CLI's
+ * exit. Best-effort throughout: teardown errors (including a late rejection that
+ * lands after the timeout wins) are ignored.
  */
+const CLOSE_TIMEOUT_MS = 100;
+
 export async function closeProxy(): Promise<void> {
   const agent = proxyAgent;
   proxyAgent = undefined;
-  if (agent) {
-    try {
-      await agent.destroy();
-    } catch {
-      // Best-effort cleanup on the way out — nothing useful to do if it fails.
+  if (!agent) {
+    return;
+  }
+  // Swallow any (possibly late) teardown error so it can't surface as an
+  // unhandled rejection when the timeout below wins the race.
+  const destroyed = agent.destroy().catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, CLOSE_TIMEOUT_MS);
+    timer.unref?.();
+  });
+  try {
+    await Promise.race([destroyed, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
     }
   }
 }

--- a/test/unit/lib/auth/client-credentials.test.ts
+++ b/test/unit/lib/auth/client-credentials.test.ts
@@ -11,10 +11,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { mkdtemp, writeFile, rm } from 'fs/promises';
 import { generateKeyPairSync } from 'crypto';
+import { InvalidClientError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import {
   validateKeyAlgorithm,
   resolvePrivateKeyPem,
   createClientCredentialsProvider,
+  describeAuthError,
   DEFAULT_KEY_ALGORITHM,
 } from '../../../../src/lib/auth/client-credentials.js';
 import { ClientError } from '../../../../src/lib/errors.js';
@@ -112,5 +114,33 @@ describe('createClientCredentialsProvider', () => {
   it('leaves discoveryState undefined when no token endpoint is pinned', () => {
     const provider = createClientCredentialsProvider({ clientId: 'svc', clientSecret: 's3cr3t' });
     expect(provider.discoveryState).toBeUndefined();
+  });
+});
+
+describe('describeAuthError', () => {
+  it('falls back to the OAuth error code when the message is empty', () => {
+    // A wrong client secret yields invalid_client with no error_description,
+    // so the SDK leaves the message empty — we must surface the code instead.
+    expect(describeAuthError(new InvalidClientError(''))).toBe('invalid_client');
+  });
+
+  it('prefers a non-empty error message over the code', () => {
+    expect(describeAuthError(new InvalidClientError('client authentication failed'))).toBe(
+      'client authentication failed'
+    );
+  });
+
+  it('uses the error message for plain errors', () => {
+    expect(describeAuthError(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back to the error name when message and code are absent', () => {
+    const err = new Error('');
+    err.name = 'WeirdError';
+    expect(describeAuthError(err)).toBe('WeirdError');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(describeAuthError('nope')).toBe('nope');
   });
 });


### PR DESCRIPTION
Follow-up to #281: the `basic/client-credentials` e2e test still failed on Windows when a login was rejected. This fixes the two remaining issues on that path.

- `login` now drains undici's connection pool (`closeProxy()`) before the forced `process.exit()`, so leftover keep-alive sockets no longer trip a Windows libuv async-handle assertion that corrupted `--json` error output.
- A rejected token request now reports the OAuth error code (e.g. `invalid_client`) instead of an empty reason when the server omits `error_description`.

Refs #281

https://claude.ai/code/session_01QRAGQAnBzFubSVw2dRiZrV