### PR TITLE
Fix failing e2e tests: client-credentials Windows crash + stdio server startup

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -169,11 +169,14 @@ export async function login(
     } else {
       console.error(formatOutput({ error: errorMessage }, 'json'));
     }
-    // `login` runs OAuth/token requests in this process, leaving idle keep-alive
-    // sockets in undici's pool. Drain them before the forced exit so the teardown
-    // doesn't trip a Windows libuv async-handle assertion onto stderr (see closeProxy).
+    // `login` runs OAuth/token requests in this process. A forced process.exit()
+    // here races libuv's handle teardown on Windows and aborts with an async-handle
+    // assertion that corrupts the --json error output. Instead, drain undici's pool
+    // (closes idle keep-alive sockets for a prompt exit) and let the event loop exit
+    // on its own via process.exitCode — the same clean teardown the success path uses.
     await closeProxy();
-    process.exit(4); // Authentication error
+    process.exitCode = 4; // Authentication error
+    return;
   }
 }
 

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -65,23 +65,22 @@ export function proxyFetch(input: string | URL | Request, init?: RequestInit): P
 /**
  * Forcefully close the proxy dispatcher and all of its pooled connections.
  *
- * Call this right before a forced `process.exit()` on any path where the CLI
- * process itself made HTTP requests (e.g. the `login` token/OAuth calls). Those
- * requests leave idle keep-alive sockets in undici's connection pool; exiting
- * while they are still open races libuv's handle teardown on Windows and aborts
- * the process with an async-handle assertion (`uv_async_send` on a closing
- * handle, `src\win\async.c`). That stray native abort message lands on stderr
- * and corrupts otherwise-valid `--json` error output. Draining the pool first
- * makes the subsequent exit clean.
+ * Call this on any path where the CLI process itself made HTTP requests (e.g. the
+ * `login` token/OAuth calls) and is about to exit. Those requests leave idle
+ * keep-alive sockets in undici's connection pool; closing them lets the event
+ * loop empty so the process exits promptly on its own (set `process.exitCode`
+ * and return — do NOT call `process.exit()`, which races libuv's handle teardown
+ * on Windows and aborts with an async-handle assertion, `uv_async_send` on a
+ * closing handle in `src\win\async.c`, corrupting `--json` error output).
  *
  * `destroy()` resolves near-instantly for idle keep-alive sockets, but it is
  * raced against a short timeout so a stuck connection can never stall the CLI's
  * exit. Best-effort throughout: teardown errors (including a late rejection that
  * lands after the timeout wins) are ignored.
  *
- * The drain is only needed to avoid the Node/libuv exit crash on Windows. Some
- * runtimes (e.g. Bun's undici shim) don't implement `destroy()` on the
- * dispatcher and don't need the drain, so this no-ops where it's unavailable.
+ * Some runtimes (e.g. Bun's undici shim) don't implement `destroy()` on the
+ * dispatcher; this no-ops where it's unavailable (those runtimes drain promptly
+ * on their own anyway).
  */
 const CLOSE_TIMEOUT_MS = 100;
 


### PR DESCRIPTION
Fixes the e2e failures seen across the Windows/Bun CI runs — three distinct issues:

- **client-credentials crash (Windows):** the forced `process.exit()` on a login failure raced libuv's handle teardown and aborted with an async-handle assertion, corrupting `--json` output. Set `process.exitCode` and let the event loop drain (the clean teardown the success path already uses); also report the OAuth code (e.g. `invalid_client`) instead of an empty reason.
- **stdio server startup:** `npx -y @modelcontextprotocol/server-filesystem` intermittently installed an incomplete dep tree (missing transitive `ajv`), crashing every stdio test. Pin it as a devDependency and launch it directly with node.
- **bridge kill timing:** the bridge's graceful SIGTERM shutdown can take ~1-2s, so a fixed `sleep 1` raced on Linux/macOS (Windows force-kills). Poll for exit instead (stdio/bridge-restart, sessions/failover).

Full e2e suite now 47/47 locally on both Node and Bun.

Refs #282

https://claude.ai/code/session_01QRAGQAnBzFubSVw2dRiZrV