### PR TITLE
Reorder tasks commands in help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ MCP session commands (after connecting):
   <@session> tools-list          List all server tools
   <@session> tools-get <name>    Get tool details and schema
   <@session> tools-call <name> [arg:=val ... | <json> | <stdin]
+  <@session> tasks-list
+  <@session> tasks-get <taskId>
+  <@session> tasks-result <taskId>
+  <@session> tasks-cancel <taskId>
   <@session> prompts-list
   <@session> prompts-get <name> [arg:=val ... | <json> | <stdin]
   <@session> resources-list
@@ -168,10 +172,6 @@ MCP session commands (after connecting):
   <@session> resources-templates-list
   <@session> skills-list
   <@session> skills-get <name> [--raw]
-  <@session> tasks-list
-  <@session> tasks-get <taskId>
-  <@session> tasks-result <taskId>
-  <@session> tasks-cancel <taskId>
   <@session> logging-set-level <level>
   <@session> ping
   <@session> logs [-n N] [--follow] [--since 1h]

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -444,6 +444,10 @@ ${chalk.bold('MCP session commands (after connecting):')}
   <@session> ${theme.cyan('tools-list')}          List all server tools
   <@session> ${theme.cyan('tools-get')} <name>    Get tool details and schema
   <@session> ${theme.cyan('tools-call')} <name> [arg:=val ... | <json> | <stdin]
+  <@session> ${theme.cyan('tasks-list')}
+  <@session> ${theme.cyan('tasks-get')} <taskId>
+  <@session> ${theme.cyan('tasks-result')} <taskId>
+  <@session> ${theme.cyan('tasks-cancel')} <taskId>
   <@session> ${theme.cyan('prompts-list')}
   <@session> ${theme.cyan('prompts-get')} <name> [arg:=val ... | <json> | <stdin]
   <@session> ${theme.cyan('resources-list')}
@@ -453,10 +457,6 @@ ${chalk.bold('MCP session commands (after connecting):')}
   <@session> ${theme.cyan('resources-templates-list')}
   <@session> ${theme.cyan('skills-list')}
   <@session> ${theme.cyan('skills-get')} <name> [--raw]
-  <@session> ${theme.cyan('tasks-list')}
-  <@session> ${theme.cyan('tasks-get')} <taskId>
-  <@session> ${theme.cyan('tasks-result')} <taskId>
-  <@session> ${theme.cyan('tasks-cancel')} <taskId>
   <@session> ${theme.cyan('logging-set-level')} <level>
   <@session> ${theme.cyan('ping')}
   <@session> ${theme.cyan('logs')} [-n N] [--follow] [--since 1h]


### PR DESCRIPTION
## Summary
Reorganized the MCP session commands help text to move task-related commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`) to appear immediately after tool commands and before prompt commands, providing a more logical grouping of related functionality.

## Changes
- Moved task commands from their previous position (after skills commands) to appear after tool commands in both `README.md` and `src/cli/index.ts`
- This groups all data manipulation commands (tools, tasks, prompts, resources) together, improving discoverability and help text organization

## Details
The reordering reflects a more intuitive command hierarchy where:
1. Tools (server capabilities)
2. **Tasks** (asynchronous operations) ← moved up
3. Prompts (prompt templates)
4. Resources (resource access)
5. Skills (skill definitions)
6. Logging and utility commands

This change is purely organizational and does not affect any functionality or command behavior.

https://claude.ai/code/session_01PDVMpg2KwBdFFPxm2QzYM1