### PR TITLE
Tidy the agent-guide pointers in help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ MCP session commands (after connecting):
 
 Run "mcpc" without arguments to show active sessions and OAuth profiles.
 Run "mcpc --json" to get the same data as `{ sessions: [...], profiles: [...] }`.
-Run "mcpc help --skill" to print a full agent usage guide (mental model, workflows, examples).
+
+Agent guide: mcpc help --skill
 ```
 
 ### General actions

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Commands:
   clean [resources...]           Clean up mcpc data (sessions, profiles, logs, all)
   grep <pattern>                 Search tools and instructions across all active sessions
   x402 [subcommand] [args...]    Configure an x402 payment wallet (EXPERIMENTAL)
-  help [command] [subcommand]    Show help for a command, or the agent skill with --skill
+  help [command] [subcommand]    Show help for a command
 
 Options:
   --json                         Output in JSON format for scripting

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -38,8 +38,8 @@ fi
 TEMP_HELP=$(mktemp)
 TEMP_README=$(mktemp)
 
-# Get help output, remove the "Full docs:" line and trailing empty line
-node "$MCPC_CLI" --help | sed '/^Full docs:/d' | sed '${/^$/d;}' > "$TEMP_HELP"
+# Get help output, strip the self-referential docs URL (keep the agent-guide hint) and trailing empty line
+node "$MCPC_CLI" --help | sed 's/ *· *Full docs:.*//' | sed '${/^$/d;}' > "$TEMP_HELP"
 
 # Guard against capturing empty output, which would silently wipe the README block
 if [ ! -s "$TEMP_HELP" ]; then

--- a/scripts/update-readme.sh
+++ b/scripts/update-readme.sh
@@ -38,8 +38,8 @@ fi
 TEMP_HELP=$(mktemp)
 TEMP_README=$(mktemp)
 
-# Get help output, strip the self-referential docs URL (keep the agent-guide hint) and trailing empty line
-node "$MCPC_CLI" --help | sed 's/ *· *Full docs:.*//' | sed '${/^$/d;}' > "$TEMP_HELP"
+# Get help output, remove the self-referential "Full docs:" line (keep the agent-guide hint above it) and trailing empty line
+node "$MCPC_CLI" --help | sed '/^Full docs:/d' | sed '${/^$/d;}' > "$TEMP_HELP"
 
 # Guard against capturing empty output, which would silently wipe the README block
 if [ ! -s "$TEMP_HELP" ]; then

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -269,8 +269,7 @@ async function main(): Promise<void> {
       if (hasSessions) {
         console.log('To view server capabilities and tools, run: mcpc @session');
       }
-      console.log('For usage overview, run: mcpc help');
-      console.log('For the full agent skill, run: mcpc help --skill');
+      console.log('For usage and the agent guide, run: mcpc help [--skill]');
       console.log('');
     }
     await closeFileLogger();
@@ -463,9 +462,8 @@ ${chalk.bold('MCP session commands (after connecting):')}
 
 Run "mcpc" without arguments to show active sessions and OAuth profiles.
 Run "mcpc --json" to get the same data as \`{ sessions: [...], profiles: [...] }\`.
-Run "mcpc help --skill" to print a full agent usage guide (mental model, workflows, examples).
 
-Full docs: ${docsUrl}`
+Agent guide: mcpc help --skill   ·   Full docs: ${docsUrl}`
   );
 
   // connect command: mcpc connect [<server>] [@session]  (server optional — omit to auto-discover)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -872,7 +872,7 @@ ${jsonHelp('`[{ sessionName, tools?: Tool[], resources?: Resource[], prompts?: P
   // help command: mcpc help [command] (supports "help x402 sign"); --skill prints the agent guide
   program
     .command('help [command] [subcommand]')
-    .description('Show help for a command, or the agent skill with --skill')
+    .description('Show help for a command')
     .option('--skill', 'Print the agent skill (mental model, workflows, examples)')
     .action(async (cmdName?: string, subcommand?: string, opts?: { skill?: boolean }) => {
       if (opts?.skill) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -463,7 +463,8 @@ ${chalk.bold('MCP session commands (after connecting):')}
 Run "mcpc" without arguments to show active sessions and OAuth profiles.
 Run "mcpc --json" to get the same data as \`{ sessions: [...], profiles: [...] }\`.
 
-Agent guide: mcpc help --skill   ·   Full docs: ${docsUrl}`
+Agent guide: mcpc help --skill
+Full docs: ${docsUrl}`
   );
 
   // connect command: mcpc connect [<server>] [@session]  (server optional — omit to auto-discover)

--- a/test/e2e/suites/basic/help.test.sh
+++ b/test/e2e/suites/basic/help.test.sh
@@ -23,8 +23,7 @@ test_pass
 test_case "bare mcpc shows usage hint"
 run_mcpc
 assert_success
-assert_contains "$STDOUT" "mcpc help"
-assert_contains "$STDOUT" "mcpc help --skill"
+assert_contains "$STDOUT" "mcpc help [--skill]"
 test_pass
 
 # Test: --help points AI agents at the guide

--- a/test/unit/cli/readme-help.test.ts
+++ b/test/unit/cli/readme-help.test.ts
@@ -20,9 +20,9 @@ function getHelpOutput(): string {
     encoding: 'utf-8',
     env: { ...process.env, NO_COLOR: '1' },
   });
-  // Same filtering as update-readme.sh: remove "Full docs:" line and trailing empty lines
+  // Same filtering as update-readme.sh: strip the self-referential docs URL (keep the agent-guide hint) and trailing empty lines
   return stripAnsi(output)
-    .replace(/^Full docs:.*\n?/m, '')
+    .replace(/ *· *Full docs:.*$/m, '')
     .trimEnd();
 }
 

--- a/test/unit/cli/readme-help.test.ts
+++ b/test/unit/cli/readme-help.test.ts
@@ -20,9 +20,9 @@ function getHelpOutput(): string {
     encoding: 'utf-8',
     env: { ...process.env, NO_COLOR: '1' },
   });
-  // Same filtering as update-readme.sh: strip the self-referential docs URL (keep the agent-guide hint) and trailing empty lines
+  // Same filtering as update-readme.sh: remove the self-referential "Full docs:" line (keep the agent-guide hint above it) and trailing empty lines
   return stripAnsi(output)
-    .replace(/ *· *Full docs:.*$/m, '')
+    .replace(/^Full docs:.*\n?/m, '')
     .trimEnd();
 }
 


### PR DESCRIPTION
The agent-guide pointer (`mcpc help --skill`) was repeated across overlapping spots in the help output. Tidy them so it appears once, clearly, on each surface.

- bare `mcpc`: collapsed to one line — `For usage and the agent guide, run: mcpc help [--skill]`
- `mcpc --help` footer: terse `Agent guide: mcpc help --skill`, above `Full docs: <url>`
- `mcpc --help` command list: dropped the redundant `--skill` note from the `help` row (the footer already surfaces it)
- README embed kept in sync; `basic/help` e2e assertion updated

https://claude.ai/code/session_01RCP9vv4twSiVmH2zjaFmUR