### PR TITLE
Add restart hint for disconnected sessions in list output

### DIFF
--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -192,6 +192,10 @@ export async function listSessionsAndAuthProfiles(options: {
           console.log(chalk.dim(`    ↳ run: mcpc ${session.name}`));
         } else if (status === 'expired') {
           console.log(chalk.dim(`    ↳ run: mcpc ${session.name} restart`));
+        } else if (status === 'disconnected') {
+          // Bridge is alive and auto-recovers when the server responds again;
+          // a restart forces a fresh connection if it stays stuck.
+          console.log(chalk.dim(`    ↳ run: mcpc ${session.name} restart`));
         }
       }
     }


### PR DESCRIPTION
The session list printed a recovery hint for `unauthorized`, `crashed`, and `expired` sessions but not for `disconnected` ones. A disconnected bridge is alive and auto-recovers when the server responds, but can stay stuck — so it now shows the same `↳ run: mcpc @<session> restart` hint, giving users and agents a clear next step.

https://claude.ai/code/session_016vssdMxCsNNhbHP3CSDfXx