### PR TITLE
Improve x402 wallet UX: bare command shows info, deprecate info subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `mcpc x402` (with no subcommand) now shows your wallet info and funding QR code instead of the command help. Run `mcpc help x402` for the full command reference. The `mcpc x402 info` subcommand is deprecated in favor of bare `mcpc x402` and will be removed in a future release.
+
 ## [0.4.0] - 2026-06-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -736,8 +736,8 @@ mcpc x402 init
 # Or import an existing wallet from a private key
 mcpc x402 import <private-key>
 
-# Show wallet address and creation date
-mcpc x402 info
+# Show wallet address, balances, and a funding QR code
+mcpc x402
 
 # Remove the wallet
 mcpc x402 remove

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -14,6 +14,7 @@ import {
   formatInfo,
   formatWarning,
   formatJson,
+  jsonHelp,
   theme,
 } from '../output.js';
 import { getWallet, saveWallet, removeWallet } from '../../lib/wallets.js';
@@ -377,7 +378,8 @@ ${chalk.bold('sign options:')}
   --amount <usd>         Override amount in USD (for upto: max authorization cap)
   --expiry <seconds>     Override expiry in seconds
   --scheme <preference>  Payment scheme: auto (default), upto, or exact
-  --no-approve           Skip the upto Permit2 allowance check & auto-approval`
+  --no-approve           Skip the upto Permit2 allowance check & auto-approval
+${jsonHelp('`{ address, createdAt, balances: { eth, usdc } | null }` (null if no wallet)')}`
     );
 
   const resolveOutputMode = (cmd: Command): OutputMode => {
@@ -393,7 +395,8 @@ ${chalk.bold('sign options:')}
 
   program
     .command('init')
-    .description('Create a new x402 wallet')
+    .description('Create a new x402 wallet (generates a random private key)')
+    .addHelpText('after', jsonHelp('`{ address }`'))
     .action(async (_opts, cmd) => {
       await initWallet({ outputMode: resolveOutputMode(cmd) });
     });
@@ -401,6 +404,7 @@ ${chalk.bold('sign options:')}
   program
     .command('import <private-key>')
     .description('Import an existing wallet from a private key')
+    .addHelpText('after', jsonHelp('`{ address }`'))
     .action(async (privateKey, _opts, cmd) => {
       await importWallet({ privateKey, outputMode: resolveOutputMode(cmd) });
     });
@@ -410,6 +414,10 @@ ${chalk.bold('sign options:')}
   program
     .command('info', { hidden: true })
     .description('Show wallet info (deprecated: use "mcpc x402")')
+    .addHelpText(
+      'after',
+      jsonHelp('`{ address, createdAt, balances: { eth, usdc } | null }` (null if no wallet)')
+    )
     .action(async (_opts, cmd) => {
       const outputMode = resolveOutputMode(cmd);
       if (outputMode !== 'json') {
@@ -425,13 +433,16 @@ ${chalk.bold('sign options:')}
   program
     .command('remove')
     .description('Remove the wallet')
+    .addHelpText('after', jsonHelp('`{ removed: true }`'))
     .action(async (_opts, cmd) => {
       await removeWalletCmd({ outputMode: resolveOutputMode(cmd) });
     });
 
   program
     .command('sign <payment-required>')
-    .description('Sign a payment using the wallet')
+    .description(
+      'Sign a payment from a base64 PAYMENT-REQUIRED header and print the PAYMENT-SIGNATURE header to stdout'
+    )
     .helpOption('-h, --help', 'Display help')
     .option(
       '--amount <usd>',
@@ -442,6 +453,14 @@ ${chalk.bold('sign options:')}
     .option(
       '--no-approve',
       'For the upto scheme: skip the on-chain Permit2 allowance check & auto-approval'
+    )
+    .addHelpText(
+      'after',
+      `
+Signs the given base64-encoded PAYMENT-REQUIRED header offline using the configured
+wallet and prints the resulting PAYMENT-SIGNATURE header (plus an MCP config snippet)
+to stdout. Useful for pre-signing payments or integrating with other MCP clients.
+${jsonHelp('`{ paymentSignature, from, to, amount, amountAtomicUnits, network, expiresAt }`')}`
     )
     .action(
       async (

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -145,7 +145,10 @@ async function importWallet(options: {
 
 const USDC_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
 
-async function walletInfo(options: { outputMode: OutputMode }): Promise<void> {
+async function walletInfo(options: {
+  outputMode: OutputMode;
+  showUsageHint?: boolean;
+}): Promise<void> {
   const wallet = await getWallet();
 
   if (!wallet) {
@@ -153,6 +156,9 @@ async function walletInfo(options: { outputMode: OutputMode }): Promise<void> {
       console.log(formatJson(null));
     } else {
       console.log(formatInfo('No wallet configured. Create one with: mcpc x402 init'));
+      if (options.showUsageHint) {
+        console.log(chalk.dim('  ↳ for usage information, run: mcpc help x402'));
+      }
     }
     return;
   }
@@ -208,6 +214,10 @@ async function walletInfo(options: { outputMode: OutputMode }): Promise<void> {
     console.log(`  ${chalk.bold('Balances')}       ${theme.red('Failed to fetch')}`);
   }
   await printAddressQrCode(wallet.address);
+  if (options.showUsageHint) {
+    console.log('');
+    console.log(chalk.dim('  ↳ for usage information, run: mcpc help x402'));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -366,6 +376,12 @@ ${chalk.bold('sign options:')}
     return opts.json ? 'json' : 'human';
   };
 
+  // Bare "mcpc x402" (no subcommand): show wallet info (or how to create one) plus a
+  // usage hint. Use "mcpc help x402" / "mcpc x402 --help" for the full command reference.
+  program.action(async (_opts, cmd: Command) => {
+    await walletInfo({ outputMode: resolveOutputMode(cmd), showUsageHint: true });
+  });
+
   program
     .command('init')
     .description('Create a new x402 wallet')
@@ -380,11 +396,21 @@ ${chalk.bold('sign options:')}
       await importWallet({ privateKey, outputMode: resolveOutputMode(cmd) });
     });
 
+  // Deprecated: "mcpc x402 info" is superseded by bare "mcpc x402".
+  // Hidden from help; emits a warning and will be removed in a future release.
   program
-    .command('info')
-    .description('Show wallet info')
+    .command('info', { hidden: true })
+    .description('Show wallet info (deprecated: use "mcpc x402")')
     .action(async (_opts, cmd) => {
-      await walletInfo({ outputMode: resolveOutputMode(cmd) });
+      const outputMode = resolveOutputMode(cmd);
+      if (outputMode !== 'json') {
+        console.error(
+          formatWarning(
+            '"mcpc x402 info" is deprecated and will be removed in a future release. Run "mcpc x402" instead.'
+          )
+        );
+      }
+      await walletInfo({ outputMode });
     });
 
   program
@@ -425,12 +451,6 @@ ${chalk.bold('sign options:')}
         });
       }
     );
-
-  // Show help if no subcommand
-  if (args.length === 0) {
-    program.outputHelp();
-    return;
-  }
 
   try {
     await program.parseAsync(['node', 'mcpc-x402', ...args]);

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -28,6 +28,15 @@ import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
 const USDC_DECIMALS = 6;
 
 /**
+ * Pad the fractional part of a decimal string so it always shows at least
+ * `minDecimals` places (e.g. "1" → "1.000000"), keeping any extra precision.
+ */
+function padDecimals(value: string, minDecimals: number): string {
+  const [intPart, fracPart = ''] = value.split('.');
+  return `${intPart}.${fracPart.padEnd(minDecimals, '0')}`;
+}
+
+/**
  * Generate a QR code string for the given text using small (half-block) mode.
  */
 function generateQrCode(text: string): Promise<string> {
@@ -208,10 +217,10 @@ async function walletInfo(options: {
   console.log(`  ${chalk.bold('Address')}        ${theme.cyan(wallet.address)}`);
   console.log(`  ${chalk.bold('Created')}        ${wallet.createdAt}`);
   if (!balanceError) {
-    console.log(`  ${chalk.bold('ETH Balance')}    ${ethBalance}`);
-    console.log(`  ${chalk.bold('USDC Balance')}   ${usdcBalance}`);
+    console.log(`  ${chalk.bold('ETH balance')}    ${padDecimals(ethBalance, 6)}`);
+    console.log(`  ${chalk.bold('USDC balance')}   ${padDecimals(usdcBalance, 6)}`);
   } else {
-    console.log(`  ${chalk.bold('Balances')}       ${theme.red('Failed to fetch')}`);
+    console.log(`  ${chalk.bold('balances')}       ${theme.red('Failed to fetch')}`);
   }
   await printAddressQrCode(wallet.address);
   if (options.showUsageHint) {

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -56,10 +56,12 @@ async function printAddressQrCode(address: string): Promise<void> {
   console.log('');
   console.log(chalk.bold('  Scan to fund this wallet:'));
   console.log(
-    qr
-      .split('\n')
-      .map((line) => `  ${line}`)
-      .join('\n')
+    chalk.whiteBright(
+      qr
+        .split('\n')
+        .map((line) => `  ${line}`)
+        .join('\n')
+    )
   );
 }
 

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -223,7 +223,7 @@ async function walletInfo(options: {
     console.log(`  ${chalk.bold('ETH balance')}    ${padDecimals(ethBalance, 6)}`);
     console.log(`  ${chalk.bold('USDC balance')}   ${padDecimals(usdcBalance, 6)}`);
   } else {
-    console.log(`  ${chalk.bold('balances')}       ${theme.red('Failed to fetch')}`);
+    console.log(`  ${theme.red('Failed to fetch balances')}`);
   }
   await printAddressQrCode(wallet.address);
   if (options.showUsageHint) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import { Command, CommanderError, Help } from 'commander';
 import { setVerbose, setJsonMode, closeFileLogger } from '../lib/index.js';
 import { isMcpError, formatHumanError, ClientError } from '../lib/index.js';
 import chalk from 'chalk';
-import { formatJson, formatJsonError, rainbow, theme } from './output.js';
+import { formatJson, formatJsonError, jsonHelp, rainbow, theme } from './output.js';
 import * as tools from './commands/tools.js';
 import * as resources from './commands/resources.js';
 import * as skills from './commands/skills.js';
@@ -150,16 +150,6 @@ function getOptionsFromCommand(command: Command): HandlerOptions {
   }
 
   return options;
-}
-
-/**
- * Format a JSON output help line with backtick-style Markdown formatting.
- * Optional schemaUrl adds a "Schema:" link for AI agents.
- */
-function jsonHelp(description: string, shape?: string, schemaUrl?: string): string {
-  const line = shape ? `  ${description}:\n  ${shape}` : `  ${description}`;
-  const link = schemaUrl ? `\n  Schema: ${schemaUrl}` : '';
-  return `\n${chalk.bold('JSON output (--json):')}\n${line}${link}\n`;
 }
 
 const SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2025-11-25/schema';

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1776,3 +1776,13 @@ export function formatServerDetails(
 
   return lines.join('\n');
 }
+
+/**
+ * Format a JSON output help line with backtick-style Markdown formatting.
+ * Optional schemaUrl adds a "Schema:" link for AI agents.
+ */
+export function jsonHelp(description: string, shape?: string, schemaUrl?: string): string {
+  const line = shape ? `  ${description}:\n  ${shape}` : `  ${description}`;
+  const link = schemaUrl ? `\n  Schema: ${schemaUrl}` : '';
+  return `\n${chalk.bold('JSON output (--json):')}\n${line}${link}\n`;
+}


### PR DESCRIPTION
`mcpc x402` with no subcommand now shows the wallet info (address, balances, funding QR code) instead of the command help, matching how other commands behave. The `mcpc x402 info` subcommand is deprecated — hidden from help, prints a warning — and will be removed in a future release.

- Balance labels are lowercase and always show at least 6 decimal places; a fetch failure prints a single "Failed to fetch balances" line
- The funding QR code renders in bright white for easier scanning
- Every x402 subcommand's help now documents its `--json` output shape, and `x402 sign` explains that it prints the PAYMENT-SIGNATURE header to stdout
- Shared `jsonHelp()` helper moved from `index.ts` to `output.ts` for reuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hPgskXe8VWjXW4aFJixaM