### PR TITLE
Shrink install ~70 MB (bundle viem, trim package) and speed up startup ~5x (lazy-load heavy deps)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,6 +190,10 @@ jobs:
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
           } | tee -a "$GITHUB_STEP_SUMMARY"
+          # Report the production install size (tarball, unpacked, full install)
+          # and compare with the latest published version, warning if this
+          # release is much bigger. Appends to the run summary by itself.
+          node scripts/report-install-size.mjs
 
       - name: Publish pre-release to npm
         if: inputs.type == 'pre-release'
@@ -247,6 +251,10 @@ jobs:
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
           } | tee -a "$GITHUB_STEP_SUMMARY"
+          # Report the production install size (tarball, unpacked, full install)
+          # and compare with the latest published version, warning if this
+          # release is much bigger. Appends to the run summary by itself.
+          node scripts/report-install-size.mjs
 
       - name: Update CHANGELOG.md
         if: inputs.type == 'release'

--- a/.npmignore
+++ b/.npmignore
@@ -8,9 +8,22 @@ examples/
 .vscode/
 .github/
 tsconfig.json
+tsconfig.test.json
 jest.config.js
+vitest.config.ts
+eslint.config.js
 .eslintrc.js
 .prettierrc
+pnpm-workspace.yaml
+renovate.json
+
+# GitHub Pages assets (served from apify.github.io/mcpc, not read from the installed package)
+_config.yml
+client-metadata.json
+client-logo.svg
+
+# Repo documentation assets (README images/GIFs — several MB, never read at runtime)
+docs/
 
 # Build artifacts
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Installing mcpc is now much smaller and faster: the viem library used by the experimental x402 payment feature is bundled into a single ~650 KB tree-shaken file at build time instead of installing its ~70 MB dependency tree, and the npm package no longer ships README media (download shrinks from ~7 MB to ~0.4 MB). x402 code is also loaded only when actually used, roughly halving the startup time of every other command.
+- Installing mcpc is now much smaller and faster: the viem library used by the experimental x402 payment feature is bundled into a single ~650 KB tree-shaken file at build time instead of installing its ~70 MB dependency tree, and the npm package no longer ships README media (download shrinks from ~7 MB to ~0.4 MB).
+- Commands start much faster (typically ~150 ms instead of ~700 ms): x402/viem, the OAuth login stack, spinners, and the proxy layer are now loaded only when actually used.
 - `mcpc x402` (with no subcommand) now shows your wallet info and funding QR code instead of the command help. Run `mcpc help x402` for the full command reference. The `mcpc x402 info` subcommand is deprecated in favor of bare `mcpc x402` and will be removed in a future release.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Installing mcpc is now much smaller and faster: the viem library used by the experimental x402 payment feature is bundled into a single ~650 KB tree-shaken file at build time instead of installing its ~70 MB dependency tree, and the npm package no longer ships README media (download shrinks from ~7 MB to ~0.4 MB). x402 code is also loaded only when actually used, roughly halving the startup time of every other command.
 - `mcpc x402` (with no subcommand) now shows your wallet info and funding QR code instead of the command help. Run `mcpc help x402` for the full command reference. The `mcpc x402 info` subcommand is deprecated in favor of bare `mcpc x402` and will be removed in a future release.
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -628,6 +628,7 @@ When implementing features:
     - `server` (not `target`) for server URLs/addresses
     - No `success` wrapper - indicate errors via exit codes
     - No debug prefixes like `[Using target: ...]` in JSON mode
+14. **Lazy-load large or special-purpose dependencies** - Command startup time matters: `mcpc` is invoked once per shell command, so everything statically imported by `src/cli/index.ts` or `src/bridge/index.ts` is paid on _every_ invocation. Any dependency that is large, or only needed by a specific command or feature, must be loaded lazily with a dynamic `await import(...)` at the point of use (type-only imports are free and stay static). Never re-export such a module from a barrel file (`index.ts`) — that silently makes it eager again. Example: the x402 feature's viem crypto code is loaded only when x402 is actually used, and viem itself is tree-shaken into a self-contained bundle at build time (`scripts/bundle-viem.mjs`, boundary module `src/lib/x402/viem.ts`) so it stays a devDependency instead of adding ~35 MB to every user's install. Before adding a heavy dependency, prefer this bundle-behind-a-boundary pattern over adding it to `dependencies`.
 
 ## Debugging
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,23 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-non-null-assertion': 'warn',
       'no-console': 'off',
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['viem', 'viem/*'],
+              message:
+                'Import viem only via src/lib/x402/viem.ts — it is bundled at build time so viem stays a devDependency.',
+            },
+          ],
+        },
+      ],
     },
+  },
+  {
+    // The boundary module is the single place allowed to import viem.
+    files: ['src/lib/x402/viem.ts'],
+    rules: { 'no-restricted-imports': 'off' },
   }
 );

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node": ">=22.12.0"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && node scripts/bundle-viem.mjs",
     "build:watch": "tsc --watch",
     "build:readme": "./scripts/update-readme.sh",
     "test": "pnpm run build && pnpm run test:unit && ./test/e2e/run.sh --no-build --parallel 8 && ./test/e2e/run.sh --no-build --parallel 8 --runtime bun",
@@ -62,11 +62,11 @@
     "ora": "^9.4.0",
     "proper-lockfile": "^4.1.2",
     "qrcode-terminal": "^0.12.0",
-    "undici": "^7.28.0",
-    "viem": "^2.52.2"
+    "undici": "^7.28.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "esbuild": "^0.28.1",
     "@types/node": "^25.9.3",
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",
@@ -82,6 +82,7 @@
     "tsx": "^4.22.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.1",
+    "viem": "^2.52.2",
     "vitest": "4.1.9"
   },
   "packageManager": "pnpm@10.33.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       undici:
         specifier: ^7.28.0
         version: 7.28.0
-      viem:
-        specifier: ^2.52.2
-        version: 2.52.2(typescript@6.0.3)(zod@4.4.3)
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -57,6 +54,9 @@ importers:
       doctoc:
         specifier: ^2.5.0
         version: 2.5.0
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint:
         specifier: ^10.5.0
         version: 10.5.0
@@ -84,9 +84,12 @@ importers:
       typescript-eslint:
         specifier: ^8.61.1
         version: 8.61.1(eslint@10.5.0)(typescript@6.0.3)
+      viem:
+        specifier: ^2.52.2
+        version: 2.52.2(typescript@6.0.3)(zod@4.4.3)
       vitest:
         specifier: 4.1.9
-        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4))
+        version: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4))
 
 packages:
 
@@ -173,158 +176,158 @@ packages:
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
-  '@esbuild/aix-ppc64@0.28.0':
-    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.28.0':
-    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.28.0':
-    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.28.0':
-    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.28.0':
-    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.28.0':
-    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.28.0':
-    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.28.0':
-    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.28.0':
-    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.28.0':
-    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.28.0':
-    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.28.0':
-    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.28.0':
-    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.28.0':
-    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.28.0':
-    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.28.0':
-    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.28.0':
-    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.28.0':
-    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.28.0':
-    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.28.0':
-    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.28.0':
-    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.28.0':
-    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.28.0':
-    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.28.0':
-    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.28.0':
-    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1186,8 +1189,8 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
-  esbuild@0.28.0:
-    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2740,82 +2743,82 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.28.0':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.28.0':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.28.0':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.28.0':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.28.0':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.28.0':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.28.0':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.28.0':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.28.0':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.28.0':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.28.0':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.28.0':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.28.0':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.28.0':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.28.0':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.28.0':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.28.0':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.28.0':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.28.0':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.28.0':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.28.0':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.28.0':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.28.0':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.28.0':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.28.0':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.28.0':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0)':
@@ -3234,7 +3237,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4))
+      vitest: 4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -3245,13 +3248,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.9(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.9(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)
+      vite: 8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -3645,34 +3648,34 @@ snapshots:
 
   es6-error@4.1.1: {}
 
-  esbuild@0.28.0:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.28.0
-      '@esbuild/android-arm': 0.28.0
-      '@esbuild/android-arm64': 0.28.0
-      '@esbuild/android-x64': 0.28.0
-      '@esbuild/darwin-arm64': 0.28.0
-      '@esbuild/darwin-x64': 0.28.0
-      '@esbuild/freebsd-arm64': 0.28.0
-      '@esbuild/freebsd-x64': 0.28.0
-      '@esbuild/linux-arm': 0.28.0
-      '@esbuild/linux-arm64': 0.28.0
-      '@esbuild/linux-ia32': 0.28.0
-      '@esbuild/linux-loong64': 0.28.0
-      '@esbuild/linux-mips64el': 0.28.0
-      '@esbuild/linux-ppc64': 0.28.0
-      '@esbuild/linux-riscv64': 0.28.0
-      '@esbuild/linux-s390x': 0.28.0
-      '@esbuild/linux-x64': 0.28.0
-      '@esbuild/netbsd-arm64': 0.28.0
-      '@esbuild/netbsd-x64': 0.28.0
-      '@esbuild/openbsd-arm64': 0.28.0
-      '@esbuild/openbsd-x64': 0.28.0
-      '@esbuild/openharmony-arm64': 0.28.0
-      '@esbuild/sunos-x64': 0.28.0
-      '@esbuild/win32-arm64': 0.28.0
-      '@esbuild/win32-ia32': 0.28.0
-      '@esbuild/win32-x64': 0.28.0
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -4957,7 +4960,7 @@ snapshots:
 
   tsx@4.22.4:
     dependencies:
-      esbuild: 0.28.0
+      esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -5068,7 +5071,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4):
+  vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5077,14 +5080,14 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.9.3
-      esbuild: 0.28.0
+      esbuild: 0.28.1
       fsevents: 2.3.3
       tsx: 4.22.4
 
-  vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)):
+  vitest@4.1.9(@types/node@25.9.3)(@vitest/coverage-v8@4.1.9)(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.9
-      '@vitest/mocker': 4.1.9(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.9(vite@8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.9
       '@vitest/runner': 4.1.9
       '@vitest/snapshot': 4.1.9
@@ -5101,7 +5104,7 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.12(@types/node@25.9.3)(esbuild@0.28.0)(tsx@4.22.4)
+      vite: 8.0.12(@types/node@25.9.3)(esbuild@0.28.1)(tsx@4.22.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3

--- a/scripts/bundle-viem.mjs
+++ b/scripts/bundle-viem.mjs
@@ -1,0 +1,68 @@
+/**
+ * Bundles the viem boundary module (src/lib/x402/viem.ts) into a single
+ * self-contained ESM file, overwriting the tsc-compiled re-export stub at
+ * dist/lib/x402/viem.js. This lets viem live in devDependencies: users
+ * installing @apify/mcpc download a ~1 MB tree-shaken bundle instead of
+ * viem's ~35 MB dependency tree.
+ *
+ * Runs as part of `pnpm run build` (after tsc). The tsc-generated viem.d.ts
+ * is kept, so TypeScript consumers within the repo see unchanged types.
+ */
+import { build } from 'esbuild';
+import { rm, stat } from 'fs/promises';
+
+const OUTFILE = 'dist/lib/x402/viem.js';
+
+const result = await build({
+  entryPoints: ['src/lib/x402/viem.ts'],
+  outfile: OUTFILE,
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+  target: 'node22',
+  // Unminified for debuggable stack traces; the size delta (~0.5 MB) is noise
+  // next to the ~35 MB of dependencies this replaces.
+  minify: false,
+  // Don't ship a multi-MB sourcemap of vendored code.
+  sourcemap: false,
+  // Keep viem/@noble MIT license headers in the artifact.
+  legalComments: 'eof',
+  metafile: true,
+  logLevel: 'silent',
+});
+
+// tsc emitted a sourcemap for the re-export stub we just overwrote — remove it.
+await rm(`${OUTFILE}.map`, { force: true });
+
+// Guards: fail the build if tree-shaking regresses. Do NOT "fix" a failure by
+// marking packages external — that only defers the error to runtime for users.
+// Note: metafile.inputs is the full parse graph (everything esbuild *visited*);
+// what actually ships is outputs[].inputs with bytesInOutput > 0.
+const output = result.metafile.outputs[OUTFILE];
+const bundled = Object.entries(output.inputs)
+  .filter(([, info]) => info.bytesInOutput > 0)
+  .map(([path]) => path);
+
+// ws/isows are only reachable via viem's websocket transports; mcpc uses only
+// the http() transport, so they must tree-shake away entirely.
+const websocketDeps = bundled.filter((p) => /node_modules\/(ws|isows)\//.test(p));
+if (websocketDeps.length > 0) {
+  throw new Error(
+    `viem bundle contains websocket deps (should tree-shake away):\n${websocketDeps.join('\n')}`
+  );
+}
+
+// Only base + baseSepolia are imported; more means the viem/chains barrel
+// (~700 chain definitions) stopped tree-shaking.
+const chainDefs = bundled.filter((p) => p.includes('chains/definitions/'));
+if (chainDefs.length > 4) {
+  throw new Error(
+    `viem bundle contains ${chainDefs.length} chain definitions (expected 2: base, baseSepolia)`
+  );
+}
+
+const { size } = await stat(OUTFILE);
+if (size > 4 * 1024 * 1024) {
+  throw new Error(`viem bundle unexpectedly large (${size} bytes) — check tree-shaking`);
+}
+console.log(`viem bundle: ${(size / 1024).toFixed(0)} KiB, ${bundled.length} modules`);

--- a/scripts/report-install-size.mjs
+++ b/scripts/report-install-size.mjs
@@ -1,0 +1,137 @@
+/**
+ * Computes the production install size of the package and compares it with the
+ * latest version published to npm, so an unexpectedly large release is caught
+ * during the release workflow rather than by users.
+ *
+ * Measures three things for the current working tree (requires a completed
+ * `pnpm run build`) and for the latest published release:
+ *   - tarball size (what users download)
+ *   - unpacked package size (the package itself inside node_modules)
+ *   - full install size (node_modules including all transitive dependencies)
+ *
+ * Prints a markdown report to stdout and appends it to $GITHUB_STEP_SUMMARY
+ * when running in GitHub Actions. Emits a ::warning:: annotation if the full
+ * install grew by more than GROWTH_WARN_PCT% (and at least 1 MB) — it does not
+ * fail the release; the person releasing decides whether the growth is expected.
+ *
+ * The comparison with npm degrades gracefully (e.g. first release, registry
+ * hiccup), but a failure to pack or install the *new* tarball fails the script,
+ * since that means the package itself is broken.
+ *
+ * Usage: node scripts/report-install-size.mjs (locally or in CI)
+ */
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, readdirSync, lstatSync, readFileSync, appendFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const GROWTH_WARN_PCT = 20;
+const GROWTH_WARN_MIN_BYTES = 1024 * 1024;
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], ...opts });
+}
+
+/** Recursive byte size of a directory (symlinks counted as the link itself). */
+function dirSize(path) {
+  let total = 0;
+  for (const entry of readdirSync(path, { withFileTypes: true })) {
+    const fullPath = join(path, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) total += dirSize(fullPath);
+    else total += lstatSync(fullPath).size;
+  }
+  return total;
+}
+
+function mb(bytes) {
+  return bytes == null ? 'n/a' : `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function delta(previous, current) {
+  if (previous == null || current == null || previous === 0) return 'n/a';
+  const pct = ((current - previous) / previous) * 100;
+  const sign = pct >= 0 ? '+' : '';
+  return `${sign}${pct.toFixed(1)}%`;
+}
+
+/** Install a tarball or package spec into a fresh temp project and measure it. */
+function measureInstall(workDir, label, spec, packageName) {
+  const projectDir = join(workDir, label);
+  mkdirSync(projectDir);
+  run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error', spec], { cwd: projectDir });
+  const nodeModules = join(projectDir, 'node_modules');
+  return {
+    installBytes: dirSize(nodeModules),
+    unpackedBytes: dirSize(join(nodeModules, ...packageName.split('/'))),
+  };
+}
+
+const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const workDir = mkdtempSync(join(tmpdir(), 'mcpc-install-size-'));
+
+try {
+  // Current working tree: pack, then install the tarball into a fresh project.
+  const tarball = join(workDir, 'package.tgz');
+  run('pnpm', ['pack', '--out', tarball]);
+  const current = {
+    tarballBytes: lstatSync(tarball).size,
+    ...measureInstall(workDir, 'current', tarball, pkg.name),
+  };
+
+  // Latest published release (skipped gracefully on first release / registry errors).
+  let previous = null;
+  try {
+    const latestVersion = JSON.parse(run('npm', ['view', pkg.name, 'version', '--json']));
+    const dist = JSON.parse(run('npm', ['view', `${pkg.name}@${latestVersion}`, 'dist', '--json']));
+    let tarballBytes = null;
+    try {
+      // Download and count bytes: HEAD content-length is not reliably present
+      // (proxies and CDNs may strip it), and the tarball is only a few MB.
+      const response = await fetch(dist.tarball);
+      if (response.ok) tarballBytes = (await response.arrayBuffer()).byteLength;
+    } catch {
+      // Tarball size unavailable; the other metrics still get compared.
+    }
+    previous = {
+      version: latestVersion,
+      tarballBytes,
+      ...measureInstall(workDir, 'previous', `${pkg.name}@${latestVersion}`, pkg.name),
+    };
+  } catch {
+    // First release or npm unreachable — report current sizes without comparison.
+  }
+
+  const previousLabel = previous ? `latest (${previous.version})` : 'latest (none found)';
+  const report = [
+    '#### Install size',
+    '',
+    `| Metric | This release | ${previousLabel} | Change |`,
+    '| --- | --- | --- | --- |',
+    `| Tarball download | ${mb(current.tarballBytes)} | ${mb(previous?.tarballBytes)} | ${delta(previous?.tarballBytes, current.tarballBytes)} |`,
+    `| Unpacked package | ${mb(current.unpackedBytes)} | ${mb(previous?.unpackedBytes)} | ${delta(previous?.unpackedBytes, current.unpackedBytes)} |`,
+    `| Full install (with dependencies) | ${mb(current.installBytes)} | ${mb(previous?.installBytes)} | ${delta(previous?.installBytes, current.installBytes)} |`,
+    '',
+  ].join('\n');
+
+  console.log(report);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`);
+  }
+
+  if (previous) {
+    for (const [label, previousBytes, currentBytes] of [
+      ['tarball download', previous.tarballBytes, current.tarballBytes],
+      ['full install', previous.installBytes, current.installBytes],
+    ]) {
+      if (previousBytes == null) continue;
+      const growth = currentBytes - previousBytes;
+      if (growth >= GROWTH_WARN_MIN_BYTES && growth / previousBytes >= GROWTH_WARN_PCT / 100) {
+        const message = `${pkg.name} ${label} grew from ${mb(previousBytes)} to ${mb(currentBytes)} (${delta(previousBytes, currentBytes)}) vs ${previous.version} — make sure this is expected before releasing.`;
+        console.log(process.env.GITHUB_ACTIONS ? `::warning::${message}` : `WARNING: ${message}`);
+      }
+    }
+  }
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
+}

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -53,13 +53,10 @@ const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.j
 };
 import { ProxyServer } from './proxy-server.js';
 import type { ProxyConfig } from '../lib/types.js';
-import {
-  createX402FetchMiddleware,
-  extractPaymentRequiredFromResult,
-  extractAcceptFromPaymentRequired,
-  type X402PaymentCache,
-} from '../lib/x402/fetch-middleware.js';
-import { signPayment, type SignerWallet } from '../lib/x402/signer.js';
+// x402 modules pull in the bundled viem (~1 MB of crypto code) — import types
+// only here and load the implementations lazily at the x402-gated call sites.
+import type { X402PaymentCache } from '../lib/x402/fetch-middleware.js';
+import type { SignerWallet } from '../lib/x402/signer.js';
 import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 
 // HTTP proxy and TLS settings are configured in main() after parsing --insecure flag
@@ -614,6 +611,7 @@ class BridgeProcess {
         // McpClient caches tools in-memory after the first listAllTools call
         return this.client?.getCachedTools()?.find((t: Tool) => t.name === name);
       };
+      const { createX402FetchMiddleware } = await import('../lib/x402/fetch-middleware.js');
       customFetch = createX402FetchMiddleware(proxyFetch, {
         wallet,
         getToolByName,
@@ -1161,6 +1159,8 @@ class BridgeProcess {
   ): Promise<{ handled: true; result: unknown } | { handled: false }> {
     if (!this.x402Wallet) return { handled: false };
 
+    const { extractPaymentRequiredFromResult, extractAcceptFromPaymentRequired } =
+      await import('../lib/x402/fetch-middleware.js');
     const paymentRequired = extractPaymentRequiredFromResult(toolResult);
     if (!paymentRequired) return { handled: false };
 
@@ -1175,6 +1175,7 @@ class BridgeProcess {
     // Invalidate cache and sign fresh
     this.x402PaymentCache.signature = null;
     try {
+      const { signPayment } = await import('../lib/x402/signer.js');
       const signed = await signPayment({
         wallet: this.x402Wallet,
         accept: parsed.accept,

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1760,7 +1760,7 @@ async function main(): Promise<void> {
 
   // Set up HTTP proxy from environment variables (HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and lowercase variants)
   // Also handle --insecure flag to disable TLS certificate verification
-  initProxy({ insecure });
+  await initProxy({ insecure });
 
   try {
     const bridgeOptions: BridgeOptions = {

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -12,17 +12,13 @@ import {
 } from '../output.js';
 import type { CommandOptions, OutputMode } from '../../lib/types.js';
 import { deleteAuthProfiles } from '../../lib/auth/profiles.js';
-import { performOAuthFlow } from '../../lib/auth/oauth-flow.js';
 import { getServerHost, normalizeServerUrl, validateProfileName } from '../../lib/utils.js';
 import { closeProxy } from '../../lib/proxy.js';
 import { DEFAULT_AUTH_PROFILE, DEFAULT_CLIENT_METADATA_URL } from '../../lib/auth/oauth-utils.js';
 import type { OAuthClientCredentialsInfo } from '../../lib/auth/keychain.js';
-import {
-  loginClientCredentials,
-  validateKeyAlgorithm,
-  resolvePrivateKeyPem,
-  DEFAULT_KEY_ALGORITHM,
-} from '../../lib/auth/client-credentials.js';
+// The OAuth flow modules (oauth-flow.js, client-credentials.js) statically pull
+// in the MCP SDK's auth stack, which is expensive to import — they are loaded
+// lazily inside the login paths so other commands don't pay the cost at startup.
 
 /**
  * Authenticate with a server and create/update auth profile
@@ -134,6 +130,7 @@ export async function login(
     if (resolvedClientMetadataUrl) {
       clientCredentials.clientMetadataUrl = resolvedClientMetadataUrl;
     }
+    const { performOAuthFlow } = await import('../../lib/auth/oauth-flow.js');
     const result = await performOAuthFlow(
       normalizedUrl,
       profileName,
@@ -224,6 +221,13 @@ async function loginWithClientCredentials(
       '--callback-port/--callback-host cannot be used with --grant client-credentials'
     );
   }
+
+  const {
+    loginClientCredentials,
+    validateKeyAlgorithm,
+    resolvePrivateKeyPem,
+    DEFAULT_KEY_ALGORITHM,
+  } = await import('../../lib/auth/client-credentials.js');
 
   const info: OAuthClientCredentialsInfo = { clientId: options.clientId };
   if (options.scope) {

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -49,7 +49,8 @@ import {
 } from '../../lib/auth/keychain.js';
 import { getWallet } from '../../lib/wallets.js';
 import chalk from 'chalk';
-import ora from 'ora';
+// ora is loaded lazily at the spinner call site — it is only needed for
+// human-mode bulk connects and costs ~50 ms at import.
 import { createLogger } from '../../lib/logger.js';
 import { parseProxyArg } from '../parser.js';
 import {
@@ -742,6 +743,7 @@ async function bulkConnectEntries(
   if (options.outputMode === 'human' && results.some((r) => r.status === 'created')) {
     const total = results.length;
     let done = 0;
+    const { default: ora } = await import('ora');
     const spinner = ora(`Connecting to ${total} server${total === 1 ? '' : 's'}...`).start();
     results = await waitForBulkConnectReady(results, options, () => {
       done += 1;

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -10,4 +10,5 @@ export * from './sessions.js';
 export * from './logging.js';
 export * from './utilities.js';
 export * from './auth.js';
-export * from './x402.js';
+// x402 is deliberately NOT re-exported here: it pulls in the bundled viem
+// crypto code and must only ever be loaded lazily via dynamic import.

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -2,7 +2,9 @@
  * Tools command handlers
  */
 
-import ora from 'ora';
+// ora is loaded lazily at the spinner call site — it is only needed for
+// long-running human-mode calls and costs ~50 ms at import.
+import type { Ora } from 'ora';
 import chalk from 'chalk';
 import {
   formatOutput,
@@ -324,7 +326,7 @@ export async function callTool(
     } else if (useTask) {
       // Task-augmented execution with progress display
       const startTime = Date.now();
-      let spinner: ReturnType<typeof ora> | null = null;
+      let spinner: Ora | null = null;
       let timerInterval: ReturnType<typeof setInterval> | null = null;
       let lastStatusMessage: string | undefined;
       let lastProgressMessage: string | undefined;
@@ -364,6 +366,7 @@ export async function callTool(
       };
 
       if (options.outputMode === 'human') {
+        const { default: ora } = await import('ora');
         spinner = ora({
           text: `Running tool ${chalk.bold(name)}... (0:00)${escHintText}`,
           color: 'cyan',

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -5,9 +5,17 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
 import qrcode from 'qrcode-terminal';
-import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-import { createPublicClient, http, formatEther, formatUnits, erc20Abi, type Hex } from 'viem';
-import { base } from 'viem/chains';
+import {
+  base,
+  createPublicClient,
+  erc20Abi,
+  formatEther,
+  formatUnits,
+  generatePrivateKey,
+  http,
+  privateKeyToAccount,
+  type Hex,
+} from '../../lib/x402/viem.js';
 import {
   formatSuccess,
   formatError,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -51,7 +51,7 @@ const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.j
 // Also handle --insecure flag to disable TLS certificate verification (for self-signed certs)
 {
   const insecure = process.argv.includes('--insecure');
-  initProxy({ insecure });
+  await initProxy({ insecure });
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,7 +24,6 @@ import * as logs from './commands/logs.js';
 import * as auth from './commands/auth.js';
 import * as tasks from './commands/tasks.js';
 import * as grepCmd from './commands/grep.js';
-import { handleX402Command } from './commands/x402.js';
 import { clean } from './commands/clean.js';
 import { MCPC_OAUTH_CALLBACK_HOSTS, MCPC_OAUTH_CALLBACK_PORTS } from '../lib/auth/oauth-utils.js';
 import type { OutputMode, X402SchemePreference } from '../lib/index.js';
@@ -53,6 +52,16 @@ const { version: mcpcVersion } = createRequire(import.meta.url)('../../package.j
 {
   const insecure = process.argv.includes('--insecure');
   initProxy({ insecure });
+}
+
+/**
+ * The x402 command module pulls in the bundled viem (~1 MB of crypto code),
+ * so load it only when an x402 command actually runs — every other command
+ * would otherwise pay the import cost at startup.
+ */
+async function handleX402Command(args: string[]): Promise<void> {
+  const { handleX402Command: run } = await import('./commands/x402.js');
+  await run(args);
 }
 
 /**

--- a/src/lib/proxy.ts
+++ b/src/lib/proxy.ts
@@ -13,23 +13,53 @@
  *    EnvHttpProxyAgent dispatcher, for use in code that bypasses the global dispatcher.
  */
 
-import { EnvHttpProxyAgent, setGlobalDispatcher, type Dispatcher } from 'undici';
+import type { Dispatcher } from 'undici';
 
 let proxyAgent: Dispatcher | undefined;
+let insecureRequested = false;
+
+/**
+ * Whether any proxy environment variable that EnvHttpProxyAgent acts on is set.
+ * NO_PROXY alone does nothing without a proxy URL, so it is not checked.
+ */
+function proxyEnvConfigured(): boolean {
+  return Boolean(
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy
+  );
+}
+
+/**
+ * Create the EnvHttpProxyAgent dispatcher, loading undici on demand.
+ * undici costs ~100 ms to import, so it is only loaded when a proxy is
+ * actually configured (or TLS verification is disabled) — with neither,
+ * the native global fetch behaves identically without it.
+ */
+async function createProxyAgent(): Promise<Dispatcher> {
+  const { EnvHttpProxyAgent } = await import('undici');
+  return new EnvHttpProxyAgent(insecureRequested ? { connect: { rejectUnauthorized: false } } : {});
+}
 
 /**
  * Initialize HTTP proxy support from environment variables
  * (HTTPS_PROXY, HTTP_PROXY, NO_PROXY, and lowercase variants).
  *
  * Sets the global undici dispatcher AND initializes the proxy-aware fetch agent.
- * Must be called once at process startup (in CLI and bridge entry points).
+ * Must be called (and awaited) once at process startup, in the CLI and bridge
+ * entry points. When no proxy is configured and TLS verification is not
+ * disabled, this is a no-op and undici is never loaded.
  *
  * @param options.insecure - Disable TLS certificate verification (for self-signed certs)
  */
-export function initProxy(options?: { insecure?: boolean }): void {
-  proxyAgent = new EnvHttpProxyAgent(
-    options?.insecure ? { connect: { rejectUnauthorized: false } } : {}
-  );
+export async function initProxy(options?: { insecure?: boolean }): Promise<void> {
+  insecureRequested = Boolean(options?.insecure);
+  if (!insecureRequested && !proxyEnvConfigured()) {
+    return;
+  }
+  const { setGlobalDispatcher } = await import('undici');
+  proxyAgent = await createProxyAgent();
   setGlobalDispatcher(proxyAgent);
 }
 
@@ -49,9 +79,17 @@ export function initProxy(options?: { insecure?: boolean }): void {
  * stream unconsumed (which crashes the process on exit on Windows). Returning a global
  * `Response` keeps those checks working and the body properly drained.
  */
-export function proxyFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+export async function proxyFetch(
+  input: string | URL | Request,
+  init?: RequestInit
+): Promise<Response> {
   if (!proxyAgent) {
-    proxyAgent = new EnvHttpProxyAgent();
+    if (!insecureRequested && !proxyEnvConfigured()) {
+      // No proxy configured — the native global fetch behaves identically,
+      // and undici stays unloaded.
+      return fetch(input, init);
+    }
+    proxyAgent = await createProxyAgent();
   }
   // The cast bridges the type-only version skew between the runtime `undici` package's
   // Dispatcher and the `undici-types` Dispatcher baked into @types/node's global fetch;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,9 +70,6 @@ export type {
   CancelTaskResult,
 };
 
-// Re-export protocol version constants
-export { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
-
 /** Keepalive ping interval in milliseconds (30 seconds) */
 export const KEEPALIVE_INTERVAL_MS = 30_000;
 

--- a/src/lib/x402/signer.ts
+++ b/src/lib/x402/signer.ts
@@ -5,16 +5,17 @@
  * Used by both the CLI `x402 sign` command and the fetch middleware.
  */
 
-import { privateKeyToAccount } from 'viem/accounts';
 import {
+  base,
+  baseSepolia,
   createPublicClient,
   createWalletClient,
   encodeFunctionData,
   getAddress,
   http,
+  privateKeyToAccount,
   type Hex,
-} from 'viem';
-import { base, baseSepolia } from 'viem/chains';
+} from './viem.js';
 import { ClientError } from '../errors.js';
 import { createLogger } from '../logger.js';
 import type { X402SchemePreference } from '../types.js';

--- a/src/lib/x402/viem.ts
+++ b/src/lib/x402/viem.ts
@@ -1,0 +1,31 @@
+/**
+ * viem boundary module — the ONLY file in src/ allowed to import from viem.
+ *
+ * At build time, `scripts/bundle-viem.mjs` overwrites the tsc-compiled
+ * dist/lib/x402/viem.js with a self-contained, tree-shaken esbuild bundle, so
+ * viem can stay a devDependency and the published package is ~35 MB smaller.
+ * During development (plain tsc / tsc --watch / vitest), the compiled
+ * re-exports resolve against the installed devDependency as usual.
+ *
+ * Rules for this file:
+ * - No relative imports. The bundler would inline them, creating a second copy
+ *   (separate module identity) of anything they define (e.g. a duplicate
+ *   ClientError class that breaks instanceof checks).
+ * - Export only what the x402 feature actually uses — every extra symbol grows
+ *   the bundle. `scripts/bundle-viem.mjs` enforces tree-shaking invariants.
+ */
+export {
+  createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
+  getAddress,
+  http,
+  formatEther,
+  formatUnits,
+  erc20Abi,
+} from 'viem';
+export { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+export { base, baseSepolia } from 'viem/chains';
+
+/** Self-contained Hex type (identical to viem's) so published .d.ts files never reference viem. */
+export type Hex = `0x${string}`;

--- a/test/unit/lib/x402/signer.test.ts
+++ b/test/unit/lib/x402/signer.test.ts
@@ -30,25 +30,29 @@ const { mockReadContract, mockSendTransaction, mockWaitForTransactionReceipt, mo
     mockSignTypedData: vi.fn(),
   }));
 
-vi.mock('viem', () => ({
-  createPublicClient: vi.fn().mockReturnValue({
-    readContract: (...args: unknown[]) => mockReadContract(...args),
-    waitForTransactionReceipt: (...args: unknown[]) => mockWaitForTransactionReceipt(...args),
-  }),
-  createWalletClient: vi.fn().mockReturnValue({
-    signTypedData: (...args: unknown[]) => mockSignTypedData(...args),
-    sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
-  }),
-  encodeFunctionData: vi.fn().mockReturnValue('0xencodedapprovedata'),
-  getAddress: vi.fn((addr: string) => addr.toLowerCase()),
-  http: vi.fn().mockReturnValue('http-transport'),
-}));
-
-vi.mock('viem/accounts', () => ({
-  privateKeyToAccount: vi.fn().mockReturnValue({
-    address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
-  }),
-}));
+// Mock the viem boundary module (the only file importing viem). The spread of
+// the original keeps real values for everything not stubbed — notably the
+// `base`/`baseSepolia` chain objects, of which only `.id` is used.
+vi.mock('../../../../src/lib/x402/viem.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../../src/lib/x402/viem.js')>();
+  return {
+    ...original,
+    createPublicClient: vi.fn().mockReturnValue({
+      readContract: (...args: unknown[]) => mockReadContract(...args),
+      waitForTransactionReceipt: (...args: unknown[]) => mockWaitForTransactionReceipt(...args),
+    }),
+    createWalletClient: vi.fn().mockReturnValue({
+      signTypedData: (...args: unknown[]) => mockSignTypedData(...args),
+      sendTransaction: (...args: unknown[]) => mockSendTransaction(...args),
+    }),
+    encodeFunctionData: vi.fn().mockReturnValue('0xencodedapprovedata'),
+    getAddress: vi.fn((addr: string) => addr.toLowerCase()),
+    http: vi.fn().mockReturnValue('http-transport'),
+    privateKeyToAccount: vi.fn().mockReturnValue({
+      address: '0xAb5801a7D398351b8bE11C439e05C5B3259aeC9B',
+    }),
+  };
+});
 
 // Default mock behaviour — allowance is sufficient, no approve needed, signing succeeds.
 beforeEach(() => {

--- a/test/unit/packaging.test.ts
+++ b/test/unit/packaging.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -39,5 +40,15 @@ describe('published package contents', () => {
     expect(paths).toContain('skills/mcpc/SKILL.md');
     expect(paths).toContain('bin/mcpc');
     expect(paths).toContain('dist/cli/commands/help.js');
+    // The bundled viem boundary must ship — x402 resolves viem from it at runtime.
+    expect(paths).toContain('dist/lib/x402/viem.js');
   }, 60_000);
+
+  it('does not ship viem as a runtime dependency (it is bundled at build time)', () => {
+    const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+    const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')) as {
+      dependencies: Record<string, string>;
+    };
+    expect(pkg.dependencies['viem']).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Installing mcpc previously downloaded viem's ~70 MB dependency tree, and every command paid ~680 ms of startup importing dependencies used only by specific features. viem is now tree-shaken into a single ~650 KB bundle at build time and moved to devDependencies; heavy modules load lazily; the npm tarball stops shipping README media. Install shrinks from ~110 MB to ~36 MB (tarball ~6.9 MB → ~0.4 MB) and typical startup drops to ~150 ms.

- All viem imports go through a boundary module (`src/lib/x402/viem.ts`) that esbuild bundles after tsc, with build-time guards against tree-shaking regressions; an eslint rule enforces the boundary
- Lazy-loaded: x402/viem, the OAuth login stack (SDK auth), undici (skipped entirely without proxy env vars or `--insecure`), and ora spinners; removed an unused SDK value re-export that pulled zod schemas into every command
- The release workflow now reports tarball/unpacked/full-install size next to the install instructions, compares with the latest npm version, and warns if the install grew >20%
- `.npmignore` now excludes `docs/` and dev config files

Verified by signing an x402 payment through the bundled code and checking the EIP-712 signature against an independent viem install; unit + e2e suites pass on node and bun.

https://claude.ai/code/session_01Ho8d2XkXtPXPgUnyGSntJb