### PR TITLE
Shorten overflowing command descriptions in session help

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1157,7 +1157,7 @@ ${toolsCallCombinedJsonHelp}`
 
   program
     .command('tasks-result <taskId>')
-    .description('Get MCP task final result (blocks until task reaches a terminal state).')
+    .description('Get MCP task final result (blocks until the task finishes).')
     .addHelpText('after', toolsCallJsonHelp)
     .action(async (taskId, _options, command) => {
       await tasks.getTaskResult(session, taskId, getOptionsFromCommand(command));
@@ -1226,7 +1226,7 @@ ${jsonHelp(
 
   program
     .command('resources-subscribe <uri> <file>')
-    .description('Subscribe to an MCP resource and keep a local file in sync with it.')
+    .description('Subscribe to an MCP resource and sync it to a local file.')
     .addHelpText(
       'after',
       `


### PR DESCRIPTION
The `tasks-result` and `resources-subscribe` descriptions wrapped to a second line in the `mcpc @session help` command table on a 100-column terminal. Shortened both to fit the description column (≤64 chars) while keeping their meaning.

https://claude.ai/code/session_01RMLrZWpNcGZHdXf6vyJb17