### PR TITLE
Include the install-size report in the GitHub release body

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,15 @@ jobs:
         if: inputs.type == 'release'
         run: pnpm run build:readme
 
+      - name: Report install size
+        id: install-size
+        # Measures the tarball/unpacked/full-install size of what will be
+        # published and compares it with the latest version on npm: prints a
+        # table to the logs and run summary, warns if this release is much
+        # bigger, and exposes the report as an output that the GitHub release
+        # steps embed in the release body.
+        run: node scripts/report-install-size.mjs
+
       # ── Pre-release ────────────────────────────────────────────────
       - name: Bump pre-release version
         if: inputs.type == 'pre-release'
@@ -190,10 +199,6 @@ jobs:
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
           } | tee -a "$GITHUB_STEP_SUMMARY"
-          # Report the production install size (tarball, unpacked, full install)
-          # and compare with the latest published version, warning if this
-          # release is much bigger. Appends to the run summary by itself.
-          node scripts/report-install-size.mjs
 
       - name: Publish pre-release to npm
         if: inputs.type == 'pre-release'
@@ -220,6 +225,8 @@ jobs:
             # or
             bun install -g ${{ steps.prerelease.outputs.package-name }}@${{ steps.prerelease.outputs.version }}
             ```
+
+            ${{ steps.install-size.outputs.report }}
           target_commitish: ${{ github.sha }}
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
@@ -251,10 +258,6 @@ jobs:
             echo "bun install -g ${PKG_NAME}@${NEW_VERSION}"
             echo "\`\`\`"
           } | tee -a "$GITHUB_STEP_SUMMARY"
-          # Report the production install size (tarball, unpacked, full install)
-          # and compare with the latest published version, warning if this
-          # release is much bigger. Appends to the run summary by itself.
-          node scripts/report-install-size.mjs
 
       - name: Update CHANGELOG.md
         if: inputs.type == 'release'
@@ -307,5 +310,7 @@ jobs:
             # or
             bun install -g ${{ steps.release.outputs.package-name }}@${{ steps.release.outputs.version }}
             ```
+
+            ${{ steps.install-size.outputs.report }}
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}

--- a/scripts/report-install-size.mjs
+++ b/scripts/report-install-size.mjs
@@ -9,8 +9,9 @@
  *   - unpacked package size (the package itself inside node_modules)
  *   - full install size (node_modules including all transitive dependencies)
  *
- * Prints a markdown report to stdout and appends it to $GITHUB_STEP_SUMMARY
- * when running in GitHub Actions. Emits a ::warning:: annotation if the full
+ * Prints a markdown report to stdout, appends it to $GITHUB_STEP_SUMMARY, and
+ * writes it as a `report` step output to $GITHUB_OUTPUT when running in GitHub
+ * Actions (used to embed it in the release body). Emits a ::warning:: annotation if the full
  * install grew by more than GROWTH_WARN_PCT% (and at least 1 MB) — it does not
  * fail the release; the person releasing decides whether the growth is expected.
  *
@@ -117,6 +118,11 @@ try {
   console.log(report);
   if (process.env.GITHUB_STEP_SUMMARY) {
     appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${report}\n`);
+  }
+  // Expose the report as a step output so the workflow can embed it in the
+  // GitHub release body (the run summary is not part of the release page).
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `report<<MCPC_REPORT_EOF\n${report}\nMCPC_REPORT_EOF\n`);
   }
 
   if (previous) {


### PR DESCRIPTION
The install-size report added in #299 only went to the workflow run summary, so the release page itself (e.g. v0.4.1-beta.0) showed no size info. The script now also exposes the report as a step output, and both the pre-release and release steps embed it in the release body right under the install instructions.

- `report-install-size.mjs` writes the markdown report to `$GITHUB_OUTPUT` (multiline `report` output) in addition to stdout and the run summary
- The two inline invocations in the version-bump steps are replaced by one dedicated `Report install size` step shared by both release types
- Both `action-gh-release` bodies append `${{ steps.install-size.outputs.report }}`

Refs #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ho8d2XkXtPXPgUnyGSntJb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ho8d2XkXtPXPgUnyGSntJb)_