### PR TITLE
Fix tool-call double execution, proxy DNS-rebinding exposure, and exit-code contract violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - `mcpc login` now explains OAuth client-registration failures with actionable guidance (use `--client-id` or `--client-metadata-url`) instead of surfacing a raw SDK JSON parse error. This affects servers that reject Dynamic Client Registration, such as Figma's remote MCP server, which only accepts an allow-list of approved clients.
+- Tool calls are no longer silently re-executed after a bridge crash or IPC timeout — a slow non-idempotent tool (payment, deploy) could previously run twice. The session is still reconnected automatically, and the error now says whether the call may have executed.
+- `tools-call` and `tasks-result` now exit with code 2 when the tool result reports an error (`isError`), matching the documented exit codes so shell scripts chaining on `&&` stop on failure.
+- `mcpc <@session> tools-call <tool> --help` now prints the tool's parameter schema as intended, instead of the generic command help.
+- Fixed the `--proxy` MCP server: it now validates `Host`/`Origin` headers to block DNS-rebinding attacks from web pages, supports multiple client sessions, and actually terminates sessions on HTTP DELETE (previously the second client to connect was locked out until restart).
+- Recovering the result of an async task after a bridge crash now returns the tool's real output instead of a placeholder status message.
+- A corrupted `sessions.json` is now backed up and reported instead of being silently reset, which permanently deleted all session records on the next save.
+- Very large integer arguments (e.g. snowflake IDs like `id:=12345678901234567890`) are now passed as strings instead of silently losing precision.
+- Closing a session with a local stdio server now waits for the full shutdown sequence (close stdin → SIGTERM → SIGKILL) instead of abandoning it after 1 second, which could leave orphaned server processes.
+- `mcpc login` flag-validation mistakes now exit with code 1 (client error) instead of 4, and JSON-mode errors consistently include the exit `code` field.
+- Fixed list pagination to detect repeated cursors from misbehaving servers instead of looping forever.
+- A one-off `--timeout` no longer leaks into subsequent requests on the same session.
+- Errors from `close` and `restart` are no longer printed twice.
+
+### Security
+
+- mcpc no longer advertises the `sampling` and `roots` MCP capabilities it does not implement, so servers won't send requests that can only fail.
+- The fallback bridge socket directory under the system temp dir is now verified to be a real directory owned by the current user before use.
 
 ## [0.4.0] - 2026-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,12 +110,10 @@ mcpc/
 
 **1. Core Module (`src/core/`)**
 
-- Runtime-agnostic MCP protocol implementation (works with Node.js ≥22.12 and Bun ≥1)
-- Transport abstraction: Streamable HTTP and stdio
-- Protocol state machine: initialization handshake, version negotiation, session management
-- Request/response correlation using JSON-RPC style with request IDs
-- Multiplexing: supports up to 10 concurrent requests, queues up to 100
-- Streamable HTTP connection management with reconnection (exponential backoff: 1s → 30s max)
+- Thin, runtime-agnostic wrapper around the official `@modelcontextprotocol/sdk` client (works with Node.js ≥22.12 and Bun ≥1)
+- Transport abstraction: Streamable HTTP and stdio (both created via the SDK's transports)
+- Captures negotiated protocol version and MCP session ID after connect
+- Streamable HTTP connection management with reconnection delegated to the SDK (exponential backoff: 1s → 30s max, up to 10 retries)
 - Event emitter for async notifications (tools/resources/prompts list changes, progress, logging)
 - Uses native `fetch` API (no external HTTP libraries needed)
 - **Note**: Only supports Streamable HTTP transport (current standard). The deprecated HTTP with SSE transport is not supported.
@@ -126,11 +124,11 @@ mcpc/
 - Session persistence via `~/.mcpc/sessions.json` with file locking (`proper-lockfile` package)
 - Process lifecycle management for local package servers (stdio transport)
 - Unix domain socket server for CLI-to-bridge IPC (named pipes on Windows)
-- Socket location: `~/.mcpc/bridges/<session-name>.sock`
-- Heartbeat mechanism for health monitoring
-- Orphaned process cleanup on startup
+- Socket location: `~/.mcpc/bridges/<session-name>.<pid>.sock` (falls back to a short hashed path under the system temp dir when the path would exceed the OS socket limit)
+- Keepalive ping every 30 seconds, `lastSeenAt` recorded in `sessions.json`
+- Orphaned log and socket file cleanup (note: orphaned *processes* are not reaped automatically)
 - Atomic writes for session file (write to temp, then rename)
-- Lock timeout: 5 seconds
+- File lock acquisition: up to 10 retries with randomized backoff (5s max per retry)
 
 **3. CLI Executable (`src/cli/`)**
 
@@ -147,11 +145,21 @@ mcpc/
 - `mcpc` - List all sessions and authentication profiles
 - `mcpc @<session>` - Show session info, server capabilities, and authentication details
 - `mcpc @<session> <command>` - Execute MCP command (e.g., `mcpc @apify tools-list`)
-- `mcpc connect <server> @<name>` - Create a named persistent session
-- `mcpc login <server> [--profile <name>]` - Login via OAuth and save auth profile
+  - Tools: `tools-list`, `tools-get`, `tools-call` (with `--task`/`--detach` for async tasks, `--schema`/`--schema-mode` for schema validation)
+  - Resources: `resources-list`, `resources-read`, `resources-subscribe`, `resources-unsubscribe`, `resources-templates-list`
+  - Prompts: `prompts-list`, `prompts-get`
+  - Tasks: `tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`
+  - Skills: `skills-list`, `skills-get`
+  - Other: `grep`, `logs`, `ping`, `logging-set-level`, `restart`, `close`, `help`
+- `mcpc connect <server> @<name>` - Create a named persistent session (also bulk: `mcpc connect <file>` for all config entries, `mcpc connect` for auto-discovered configs; `--proxy` exposes the session as a local MCP HTTP server)
+- `mcpc login <server> [--profile <name>]` - Login via OAuth and save auth profile (`--grant client-credentials` for non-interactive M2M auth)
 - `mcpc logout <server> [--profile <name>]` - Delete an authentication profile
+- `mcpc grep <pattern>` - Search tools/instructions (and optionally resources/prompts) across all sessions
+- `mcpc x402 <subcommand>` - Configure an x402 payment wallet (experimental)
 - `mcpc clean [sessions|profiles|logs|all ...]` - Clean up mcpc data
-- `mcpc help [command]` - Show help for a specific command
+- `mcpc help [command]` - Show help for a specific command (`--skill` prints the agent guide)
+
+Run `mcpc --help` and `mcpc help <command>` for the authoritative, always-current inventory — the usage block in README.md is generated from it.
 
 **Server formats for `connect`, `login`, `logout`:**
 
@@ -170,7 +178,7 @@ mcpc/
 
 1. User creates session: `mcpc connect mcp.apify.com @apify`
 2. CLI creates entry in `sessions.json`, spawns bridge process
-3. Bridge creates Unix socket at `~/.mcpc/bridges/apify.sock`
+3. Bridge creates Unix socket at `~/.mcpc/bridges/@apify.<pid>.sock`
 4. Bridge performs MCP initialization:
    - Sends `initialize` request with protocol version and capabilities
    - Receives server info, version, and capabilities
@@ -184,10 +192,10 @@ mcpc/
 
 **Session States:**
 
-- 🟢 **live** - Bridge process running and server responding (lastSeenAt within 2 minutes)
+- 🟢 **live** - Bridge process running and server responding (lastSeenAt within ~65 seconds — two missed 30s keepalive pings plus a 5s buffer)
 - 🟡 **connecting** - Initial bridge connection in progress (first `connect`)
 - 🟡 **reconnecting** - Bridge crashed and is being automatically reconnected
-- 🟡 **disconnected** - Bridge process running but server unreachable (lastSeenAt stale >2min); auto-recovers when server responds
+- 🟡 **disconnected** - Bridge process running but server unreachable (lastSeenAt stale >~65s); auto-recovers when server responds
 - 🟡 **crashed** - Bridge process crashed or killed; auto-reconnects in the background
 - 🔴 **unauthorized** - Server rejected authentication (401/403) or token refresh failed; requires `login` then `restart`
 - 🔴 **expired** - Server rejected session ID (404); requires `restart`
@@ -198,8 +206,8 @@ mcpc/
 
 - Persistent HTTP connection with bidirectional streaming (protocol version 2025-11-25)
 - Server and client can send messages in both directions over the same connection
-- Automatic reconnection with exponential backoff (1s → 30s max)
-- Queues requests during disconnection (fails after 3 minutes)
+- Automatic reconnection with exponential backoff (1s → 30s max, up to 10 retries, handled by the SDK)
+- CLI-to-bridge IPC requests time out after 3 minutes (or `--timeout` + a 10s margin); an IPC timeout is never retried, since the request may still be executing on the server
 - **Important**: Only the Streamable HTTP transport is supported (current MCP standard). The deprecated HTTP with SSE transport (2024-11-05) is not implemented.
 
 **Required HTTP Headers:**
@@ -248,14 +256,15 @@ mcpc/
 - CLI detects socket connection failure
 - Reads `sessions.json` for last known config
 - Spawns new bridge, re-initializes MCP connection
-- Continues request
+- Retries the request once — but only for idempotent operations. Tool calls are
+  NOT re-executed (the server may already have run them); the session is
+  reconnected and the error tells the user to verify the outcome.
 
 **Network failures:**
 
-- Bridge detects connection error, begins exponential backoff
-- Queues incoming requests (max 100, timeout 3 minutes)
-- On reconnect: drains queue
-- On timeout: fails with network error
+- The SDK's Streamable HTTP transport reconnects with exponential backoff (1s → 30s max)
+- CLI-to-bridge IPC requests fail with a network error after the IPC timeout
+  (3 minutes by default); IPC timeouts are never retried
 
 ### Security Considerations
 
@@ -416,7 +425,7 @@ Environment variable substitution supported: `${VAR_NAME}`
 **Test utilities:**
 
 - `test/e2e/server/` - Test MCP server
-- `test/mock-keychain.ts` - Mock OS keychain
+- `test/e2e/lib/framework.sh` - Shell test framework for E2E suites
 
 ## Runtime Requirements
 
@@ -444,8 +453,8 @@ Environment variable substitution supported: `${VAR_NAME}`
 **Bearer Token Handling:**
 
 - Bearer tokens passed via `--header "Authorization: Bearer ${TOKEN}"` are NOT stored as profiles
-- They are stored in OS keychain per-session (key: `mcpc:session:<name>:bearer-token`)
-- Bridge loads them automatically when making requests
+- All session headers are stored in the OS keychain as one JSON blob per session (keychain account: `session:<name>:headers`)
+- Bridge loads them automatically when making requests (delivered over IPC after spawn, never via argv)
 
 **CLI Commands:**
 
@@ -492,7 +501,7 @@ On failure, the error message includes instructions on how to login. This ensure
 
 1. User runs `mcpc login <server> --profile personal`
 2. CLI discovers OAuth metadata via `WWW-Authenticate` header or well-known URIs
-3. CLI creates local HTTP callback server on `http://localhost:<random-port>/callback`
+3. CLI creates local HTTP callback server on `http://127.0.0.1:<port>/callback` (ports tried in order: 13316, 31613, 16133; host configurable via `--callback-host`)
 4. CLI opens browser to authorization URL with PKCE challenge
 5. User authenticates, browser redirects to callback with authorization code
 6. CLI exchanges code for tokens using PKCE verifier
@@ -501,32 +510,39 @@ On failure, the error message includes instructions on how to login. This ensure
 
 **Implementation Modules:**
 
-- `src/lib/auth/auth-profiles.ts` - Manage profiles.json (CRUD operations)
+- `src/lib/auth/profiles.ts` - Manage profiles.json (CRUD operations)
 - `src/lib/auth/keychain.ts` - OS keychain wrapper (save/load/delete tokens)
 - `src/lib/auth/oauth-provider.ts` - Implements `OAuthClientProvider` from MCP SDK
 - `src/lib/auth/oauth-flow.ts` - Orchestrates interactive OAuth flow
+- `src/lib/auth/oauth-utils.ts` - OAuth metadata discovery, callback ports, CIMD URL validation
 - `src/lib/auth/oauth-token-manager.ts` - Token validation and refresh
 - `src/lib/auth/token-refresh.ts` - Token refresh logic with keychain persistence
+- `src/lib/auth/client-credentials.ts` - Non-interactive client-credentials grant (`login --grant client-credentials`)
+- `src/lib/auth/auth-page.ts` - HTML for the OAuth callback result page (escaped)
 
 **Session-to-Profile Relationship:**
 
 ```jsonc
 // sessions.json
 {
-  "apify-personal": {
-    "name": "apify-personal",
-    "target": "https://mcp.apify.com",
-    "transport": "http",
-    "profileName": "personal",  // References profile
-    "pid": 12345,
-    "socketPath": "~/.mcpc/bridges/apify-personal.sock"
+  "sessions": {
+    "@apify-personal": {
+      "name": "@apify-personal",
+      "server": { "url": "https://mcp.apify.com" },
+      "profileName": "personal", // References profile
+      "pid": 12345,
+      "protocolVersion": "2025-11-25",
+      "status": "active",
+      "createdAt": "2025-12-14T10:00:00Z",
+      "lastSeenAt": "2025-12-14T10:05:00Z"
+    }
   }
 }
 
-// profiles.json
+// profiles.json (profiles are keyed by normalized server HOST, not full URL)
 {
   "profiles": {
-    "https://mcp.apify.com": {
+    "mcp.apify.com": {
       "personal": {
         "name": "personal",
         "serverUrl": "https://mcp.apify.com",
@@ -540,9 +556,11 @@ On failure, the error message includes instructions on how to login. This ensure
   }
 }
 
-// OS Keychain
-// Key: mcpc:auth:https://mcp.apify.com:personal:tokens
+// OS Keychain (service "mcpc")
+// Account: auth-profile:mcp.apify.com:personal:tokens
 // Value: {"access_token": "...", "refresh_token": "...", "expires_at": ...}
+// Other accounts: auth-profile:<host>:<profile>:client (registered OAuth client),
+// session:<name>:headers (per-session headers), session:<name>:proxy-bearer-token
 ```
 
 ## State and Data Storage
@@ -552,7 +570,7 @@ All state files are stored in `~/.mcpc/` directory (unless overridden by `MCPC_H
 - `~/.mcpc/sessions.json` - Active sessions with references to auth profiles, active async tasks, and resource subscriptions (file-locked for concurrent access)
 - `~/.mcpc/profiles.json` - Authentication profiles (OAuth metadata, scopes, expiry)
 - `~/.mcpc/bridges/` - Unix domain socket files for bridge processes
-- `~/.mcpc/logs/bridge-<session>.log` - Bridge process logs (max 10MB, 5 files)
+- `~/.mcpc/logs/bridge-<session>.log` - Bridge process logs (rotated at 10MB, up to 5 rotated files kept)
 - OS keychain - Sensitive credentials (OAuth tokens, bearer tokens, client secrets)
 
 ## Key Dependencies
@@ -624,9 +642,10 @@ When implementing features:
 11. **Hyphenated commands** - All MCP commands use hyphens: `tools-list`, `resources-read`, `prompts-list`
 12. **Command-first syntax** - Top-level commands come first (`connect`, `login`, `clean`); MCP operations always go through a named session (`mcpc @session <command>`)
 13. **JSON field naming** - Use consistent field names in JSON output:
-    - `sessionName` (not `name`) for session identifiers
+    - `sessionName` for session identifiers in command results (e.g. `connect`, `close`); the `mcpc --json` session list spreads the stored `SessionData`, whose field is `name`
     - `server` (not `target`) for server URLs/addresses
     - No `success` wrapper - indicate errors via exit codes
+    - Errors printed in JSON mode use the shape `{ error: <message>, code: <exit code> }` on stderr
     - No debug prefixes like `[Using target: ...]` in JSON mode
 14. **Lazy-load large or special-purpose dependencies** - Command startup time matters: `mcpc` is invoked once per shell command, so everything statically imported by `src/cli/index.ts` or `src/bridge/index.ts` is paid on _every_ invocation. Any dependency that is large, or only needed by a specific command or feature, must be loaded lazily with a dynamic `await import(...)` at the point of use (type-only imports are free and stay static). Never re-export such a module from a barrel file (`index.ts`) — that silently makes it eager again. Example: the x402 feature's viem crypto code is loaded only when x402 is actually used, and viem itself is tree-shaken into a self-contained bundle at build time (`scripts/bundle-viem.mjs`, boundary module `src/lib/x402/viem.ts`) so it stays a devDependency instead of adding ~35 MB to every user's install. Before adding a heavy dependency, prefer this bundle-behind-a-boundary pattern over adding it to `dependencies`.
 
@@ -647,6 +666,7 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 - `MCPC_HOME_DIR` - Directory for session and auth profiles data (default: `~/.mcpc`)
 - `MCPC_VERBOSE` - Enable verbose logging (set to `1`, `true`, or `yes`, case-insensitive)
 - `MCPC_JSON` - Enable JSON output (set to `1`, `true`, or `yes`, case-insensitive)
+- `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` (and lowercase variants) - Route outbound HTTP(S) requests through a proxy
 
 ## Current Implementation Status
 
@@ -661,19 +681,24 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 - **Logging**: Structured logging with verbose mode support, per-session bridge logs with rotation
 - **Environment Variables**: MCPC_HOME_DIR, MCPC_VERBOSE, MCPC_JSON support
 - **Command Handlers**: All MCP commands fully functional
-  - `tools-list`, `tools-get`, `tools-call`
+  - `tools-list`, `tools-get`, `tools-call` (incl. `--task`/`--detach` async execution and `--schema` validation)
   - `resources-list`, `resources-read`, `resources-subscribe`, `resources-unsubscribe`, `resources-templates-list`
   - `prompts-list`, `prompts-get`
+  - `tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`
+  - `skills-list`, `skills-get`
+  - `grep` (per-session and global), `logs` (with `--follow`)
   - `logging-set-level`
   - `ping` (with roundtrip timing)
-  - `connect`, `close`, `help` (session management)
-  - `login`, `logout` (authentication management)
+  - `connect` (single, config-file bulk, auto-discovery), `restart`, `close`, `help` (session management)
+  - `login` (authorization-code and client-credentials grants), `logout` (authentication management)
+  - `x402` wallet management and automatic x402 payments on tool calls (experimental)
+- **MCP proxy**: `connect --proxy [host:]port` exposes a session as a local Streamable HTTP MCP server (Host/Origin-validated, optional `--proxy-bearer-token`)
 - **Bridge Process**: Persistent MCP connections with Unix domain socket IPC
 - **Session Management**: Complete `sessions.json` persistence with file locking
 - **IPC Layer**: Unix socket communication between CLI and bridge (BridgeClient, SessionClient)
 - **Target Resolution**: URL/session/config resolution logic (sessions and HTTP servers working)
 - **CLI-to-MCP Integration**: Full integration via direct connection and session bridge
-- **Caching**: In-memory cache with TTL (5min default), automatic invalidation via server notifications
+- **Caching**: In-memory tools cache in the bridge, invalidated by `tools/list_changed` notifications (no TTL on stateful connections; 60s TTL fallback for stateless connections that can't push notifications)
 - **Notification Handling**: Full notification support in the bridge process
   - `tools/list_changed`, `resources/list_changed`, `prompts/list_changed` notifications
   - Automatic cache invalidation on list changes, timestamps tracked in `sessions.json`
@@ -685,8 +710,8 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 - **Error Recovery**: Automatic recovery from failures
   - Bridge crash detection and automatic restart
   - Socket reconnection with preserved session state
-  - Automatic retry on network errors (with bridge restart)
-  - Clean handling of orphaned processes
+  - Automatic retry of idempotent operations on socket failures (with bridge restart); tool calls are never silently re-executed
+  - Orphaned socket and log file cleanup
 - **Config File Loading**: Complete stdio transport support for local packages
 - **OAuth Implementation**: Full OAuth 2.1 flow with PKCE
   - Interactive OAuth flow (browser-based)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributions are welcome!
 - Delightful for humans and AI agents alike (interactive + scripting)
 - Avoid unnecessary interaction loops, provide sufficient context, yet be concise (save tokens)
 - One clear way to do things (orthogonal commands, no surprises)
-- Do not ask for user input (except `shell` and `login`, no unexpected OAuth flows)
+- Do not ask for user input (except `login`, no unexpected OAuth flows)
 - Be forgiving, always help users make progress (great errors + guidance)
 - Be consistent with the [MCP specification](https://modelcontextprotocol.io/specification/latest), with `--json` strictly
 - Minimal and portable (few deps, cross-platform)
@@ -108,7 +108,7 @@ The codebase is a single TypeScript package with three internal modules:
 
 ```
 src/
-├── core/       # Runtime-agnostic MCP protocol implementation (Node ≥18, Bun ≥1)
+├── core/       # Runtime-agnostic MCP protocol implementation (Node ≥22.12, Bun ≥1)
 ├── bridge/     # Persistent bridge process — one per session, owns the MCP connection
 ├── cli/        # `mcpc` command — argument parsing, output formatting, IPC to the bridge
 └── lib/        # Shared utilities (auth, keychain, file locking, …)

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ bun install -g @apify/mcpc
 
 **Linux:** credentials use the OS keychain via the [Secret Service API](https://specifications.freedesktop.org/secret-service/).
 GNOME/KDE desktops work out of the box. On headless/CI systems, `mcpc` falls back to a
-file-based store (`~/.mcpc/credentials`, mode `0600`).
+file-based store (`~/.mcpc/credentials.json`, mode `0600`).
 
 To force the keychain on headless systems, install `libsecret` + `gnome-keyring`
 (via `apt-get`, `dnf`, or `pacman`) and run:
@@ -221,10 +221,10 @@ mcpc connect ~/.vscode/mcp.json   # connect every server in one file
 
 Bulk connects auto-generate session names (so they don't take an `@session`) and **skip local
 stdio servers by default** — pass `--stdio` to include them. Each discovered config file is listed
-with its servers and their status (`● live`, `● connecting`); files that can't be used are shown as
-`(0 servers)` or `(invalid)` with the reason, rather than silently ignored. Without `--json` the
-command returns right away without waiting for every connection to finish (still-connecting sessions
-show `● connecting`); `--json` waits and reports each server's details.
+with its servers and their status (`● live`, `✗ failed`); files that can't be used are shown as
+`(0 servers)` or `(invalid)` with the reason, rather than silently ignored. The command waits for
+every handshake to finish (with a progress spinner in human mode); `--json` reports each server's
+details. If every server fails to connect, the command exits with a non-zero code.
 
 ### MCP commands
 
@@ -301,9 +301,10 @@ mcpc grep "e" -m 5
 mcpc grep "actor" --json
 ```
 
-By default, `grep` searches only tools. Use `--resources` or `--prompts` to search those types
-(combine with `--tools` to include tools too). Sessions that are crashed or unavailable are shown
-with their status rather than silently skipped.
+By default, `grep` searches tools and server instructions. Use `--resources` or `--prompts` to
+search those types instead (combine with `--tools` or `--instructions` to mix and match). Sessions
+that are crashed or unavailable are shown with their status rather than silently skipped. Like
+`grep(1)`, the command exits with code 0 when there are matches and 1 when there are none.
 
 The `grep` command is useful for **dynamic tool discovery**,
 also called [Tool search tool](https://www.anthropic.com/engineering/advanced-tool-use) by Anthropic
@@ -322,7 +323,8 @@ With `--json` option, `mcpc` always emits only a single JSON object (or array), 
 [MCP specification](https://modelcontextprotocol.io/specification/latest).**
 On success, the JSON object is printed to stdout, on error to stderr.
 
-Note that `--json` is not available for `login` and `mcpc --help` commands.
+Note that `--json` is not available for `mcpc --help`. For `login`, `--json` prints a single
+`{ profile, serverUrl, scopes }` object on stdout (interactive prompts go to stderr).
 
 ## Sessions
 
@@ -847,12 +849,11 @@ refreshed automatically; pin a non-discoverable token endpoint with `--token-end
 
 #### Server instructions
 
-MCP servers can provide instructions describing their capabilities and usage. These are displayed when you connect to a server or run the `help` command:
+MCP servers can provide instructions describing their capabilities and usage. These are displayed when you connect to a server or show its session overview:
 
 ```bash
-# Show server info, capabilities, and instructions (both commands behave the same)
+# Show server info, capabilities, and instructions
 mcpc @apify
-mcpc @apify help
 
 # JSON mode
 mcpc @apify --json
@@ -1240,11 +1241,11 @@ MCP enables arbitrary tool execution and data access - treat servers like you tr
 
 | What                   | How                                             |
 | ---------------------- | ----------------------------------------------- |
-| **OAuth tokens**       | Stored in OS keychain, never on disk            |
+| **OAuth tokens**       | Stored in OS keychain (headless fallback: `credentials.json`, `0600`) |
 | **HTTP headers**       | Stored in OS keychain per-session               |
 | **Bridge credentials** | Passed via Unix socket IPC, kept in memory only |
 | **Process arguments**  | No secrets visible in `ps aux`                  |
-| **x402 private key**   | Stored in `wallets.json` (`0600` permissions)   |
+| **x402 private key**   | Stored in OS keychain (fallback: `wallets.json`, `0600`) |
 | **Config files**       | Contain only metadata, never tokens             |
 | **File permissions**   | `0600` (user-only) for all config files         |
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -17,7 +17,9 @@ import { createLogger, setVerbose, initFileLogger, closeFileLogger } from '../li
 import {
   fileExists,
   getSocketPath,
+  getShortSocketDir,
   ensureDir,
+  ensureSecureTempDir,
   cleanupOrphanedLogFiles,
   isSessionExpiredError,
   StderrTail,
@@ -842,6 +844,7 @@ class BridgeProcess {
       port,
       client: this.client,
       sessionName: this.options.sessionName,
+      version: mcpcVersion,
     };
     if (bearerToken) {
       proxyOptions.bearerToken = bearerToken;
@@ -1009,7 +1012,14 @@ class BridgeProcess {
     // relocate over-long paths to a short dir under the temp dir — create whichever
     // one applies.
     if (process.platform !== 'win32') {
-      await ensureDir(dirname(this.socketPath));
+      const socketDir = dirname(this.socketPath);
+      if (socketDir === getShortSocketDir()) {
+        // The temp-dir fallback lives in a world-writable location with a
+        // predictable name — verify ownership/permissions before trusting it.
+        await ensureSecureTempDir(socketDir);
+      } else {
+        await ensureDir(socketDir);
+      }
 
       // Remove existing socket file if it exists (Unix only).
       // Fail on error
@@ -1222,7 +1232,10 @@ class BridgeProcess {
     }
 
     try {
-      // Apply per-request timeout if provided (from CLI --timeout flag, in seconds → milliseconds)
+      // Apply per-request timeout if provided (from CLI --timeout flag, in seconds →
+      // milliseconds). The client reads the value synchronously when the routed method
+      // is entered, and the finally below restores the baseline, so a one-off --timeout
+      // never leaks into concurrent or later requests.
       if (message.timeout !== undefined) {
         this.client.setRequestTimeout(message.timeout * 1000);
       }
@@ -1500,6 +1513,10 @@ class BridgeProcess {
       await this.handlePossibleExpiration(error as Error);
 
       this.sendError(socket, error as Error, message.id);
+    } finally {
+      if (message.timeout !== undefined) {
+        this.client?.resetRequestTimeout();
+      }
     }
   }
 

--- a/src/bridge/proxy-server.ts
+++ b/src/bridge/proxy-server.ts
@@ -32,11 +32,16 @@ import { createLogger } from '../lib/logger.js';
 
 const logger = createLogger('proxy-server');
 
+/** Host names that always resolve to the local machine. */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
 export interface ProxyServerOptions {
   host: string;
   port: number;
   client: McpClient;
   sessionName: string;
+  /** mcpc version reported to proxy clients in the server implementation info */
+  version: string;
   bearerToken?: string;
   instructions?: string; // Instructions from upstream server to pass to proxy clients
 }
@@ -47,9 +52,9 @@ export interface ProxyServerOptions {
  */
 export class ProxyServer {
   private httpServer: HttpServer | null = null;
-  private mcpServer: MCPServer | null = null;
-  private transport: StreamableHTTPServerTransport | null = null;
   private options: ProxyServerOptions;
+  /** Active proxy sessions keyed by MCP session ID (one transport per client session) */
+  private transports = new Map<string, StreamableHTTPServerTransport>();
 
   constructor(options: ProxyServerOptions) {
     this.options = options;
@@ -59,36 +64,9 @@ export class ProxyServer {
    * Start the proxy server
    */
   async start(): Promise<void> {
-    const { host, port, client, sessionName, bearerToken, instructions } = this.options;
+    const { host, port, sessionName, bearerToken } = this.options;
 
     logger.info(`Starting proxy server on ${host}:${port} for session ${sessionName}`);
-
-    // Create MCP server that forwards to upstream client
-    this.mcpServer = new MCPServer(
-      {
-        name: `mcpc-proxy${sessionName}`,
-        version: 'yolo',
-      },
-      {
-        capabilities: {
-          tools: {},
-          resources: {},
-          prompts: {},
-          logging: {},
-        },
-        // Pass upstream server's instructions to proxy clients (if available)
-        ...(instructions && { instructions }),
-      }
-    );
-
-    // Register handlers that forward to upstream client
-    this.registerHandlers(client);
-
-    // Create transport with session management and connect MCP server once
-    this.transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
-    await this.mcpServer.connect(this.transport as unknown as Transport);
 
     // Create HTTP server
     this.httpServer = createServer((req, res) => {
@@ -116,6 +94,57 @@ export class ProxyServer {
   }
 
   /**
+   * Validate Host and Origin headers to prevent DNS-rebinding attacks.
+   *
+   * A malicious web page can point a hostname it controls at 127.0.0.1 and issue
+   * requests to the proxy from the user's browser — riding on the bridge's
+   * authenticated upstream session. Such requests arrive with the attacker's
+   * hostname in `Host` and/or a non-local `Origin`, so both are rejected here.
+   *
+   * When the proxy is deliberately bound to a non-loopback address, the operator
+   * has opted into network exposure and legitimate Host values are unknowable —
+   * only the Origin check applies there (browsers always send Origin on
+   * cross-origin requests; non-browser MCP clients typically send none).
+   */
+  private validateHostAndOrigin(req: IncomingMessage, res: ServerResponse): boolean {
+    const bindHost = this.options.host;
+    const isLoopbackBind = LOOPBACK_HOSTS.has(bindHost);
+
+    if (isLoopbackBind) {
+      // Strip port and brackets from the Host header (e.g. "127.0.0.1:3000", "[::1]:3000")
+      const rawHost = req.headers.host ?? '';
+      const hostName = rawHost
+        .replace(/:\d+$/, '')
+        .replace(/^\[|\]$/g, '')
+        .toLowerCase();
+      if (!LOOPBACK_HOSTS.has(hostName) && hostName !== bindHost.toLowerCase()) {
+        logger.warn(`Rejected proxy request with unexpected Host header: ${rawHost}`);
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Forbidden: invalid Host header' }));
+        return false;
+      }
+    }
+
+    const origin = req.headers.origin;
+    if (origin) {
+      let originHost: string;
+      try {
+        originHost = new URL(origin).hostname.toLowerCase();
+      } catch {
+        originHost = '';
+      }
+      if (!LOOPBACK_HOSTS.has(originHost)) {
+        logger.warn(`Rejected proxy request with non-local Origin: ${origin}`);
+        res.writeHead(403, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Forbidden: invalid Origin header' }));
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
    * Handle incoming HTTP requests
    */
   private async handleRequest(
@@ -126,6 +155,10 @@ export class ProxyServer {
     const { method, url } = req;
 
     logger.debug(`Proxy request: ${method} ${url}`);
+
+    if (!this.validateHostAndOrigin(req, res)) {
+      return;
+    }
 
     // Health check endpoint
     if (url === '/health' && method === 'GET') {
@@ -153,16 +186,11 @@ export class ProxyServer {
       }
     }
 
-    // Handle MCP requests (POST and GET delegate to the transport)
-    if (method === 'POST' || method === 'GET') {
-      await this.transport!.handleRequest(req, res);
-      return;
-    }
-
-    // Handle DELETE for session termination
-    if (method === 'DELETE') {
-      res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ status: 'session terminated' }));
+    // POST/GET/DELETE all delegate to the per-session transport. DELETE is
+    // handled by the transport itself (real session termination), so multiple
+    // clients can initialize, terminate, and re-initialize sessions freely.
+    if (method === 'POST' || method === 'GET' || method === 'DELETE') {
+      await this.handleMcpRequest(req, res);
       return;
     }
 
@@ -172,48 +200,128 @@ export class ProxyServer {
   }
 
   /**
+   * Route an MCP request to its session transport, creating a new session
+   * (transport + MCP server instance) for an initialize request.
+   */
+  private async handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    if (sessionId) {
+      const transport = this.transports.get(sessionId);
+      if (!transport) {
+        // Unknown/expired session — per spec the client must re-initialize
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Session not found' }));
+        return;
+      }
+      await transport.handleRequest(req, res);
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Missing MCP-Session-Id header' }));
+      return;
+    }
+
+    // No session ID on a POST: treat as a new initialize request
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sid) => {
+        logger.debug(`Proxy session initialized: ${sid}`);
+        this.transports.set(sid, transport);
+      },
+    });
+    transport.onclose = () => {
+      if (transport.sessionId) {
+        logger.debug(`Proxy session closed: ${transport.sessionId}`);
+        this.transports.delete(transport.sessionId);
+      }
+    };
+
+    const mcpServer = this.createMcpServer();
+    await mcpServer.connect(transport as unknown as Transport);
+    await transport.handleRequest(req, res);
+
+    // Non-initialize POST without a session ID: the transport rejects it and
+    // never assigns a session — release the orphaned instances.
+    if (!transport.sessionId) {
+      await transport.close().catch(() => {});
+      await mcpServer.close().catch(() => {});
+    }
+  }
+
+  /**
+   * Create an MCP server instance (one per proxy session) whose handlers
+   * forward to the upstream client.
+   */
+  private createMcpServer(): MCPServer {
+    const { client, sessionName, version, instructions } = this.options;
+
+    const mcpServer = new MCPServer(
+      {
+        name: `mcpc-proxy${sessionName}`,
+        version,
+      },
+      {
+        capabilities: {
+          tools: {},
+          resources: {},
+          prompts: {},
+          logging: {},
+        },
+        // Pass upstream server's instructions to proxy clients (if available)
+        ...(instructions && { instructions }),
+      }
+    );
+
+    this.registerHandlers(mcpServer, client);
+    return mcpServer;
+  }
+
+  /**
    * Register MCP request handlers that forward to upstream client
    */
-  private registerHandlers(client: McpClient): void {
+  private registerHandlers(mcpServer: MCPServer, client: McpClient): void {
     // Ping
-    this.mcpServer!.setRequestHandler(PingRequestSchema, async () => {
+    mcpServer.setRequestHandler(PingRequestSchema, async () => {
       await client.ping();
       return {};
     });
 
     // Tools
-    this.mcpServer!.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(ListToolsRequestSchema, async (request) => {
       return await client.listTools(request.params?.cursor);
     });
 
-    this.mcpServer!.setRequestHandler(CallToolRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
       return await client.callTool(request.params.name, request.params.arguments);
     });
 
     // Resources
-    this.mcpServer!.setRequestHandler(ListResourcesRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(ListResourcesRequestSchema, async (request) => {
       return await client.listResources(request.params?.cursor);
     });
 
-    this.mcpServer!.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
       return await client.listResourceTemplates(request.params?.cursor);
     });
 
-    this.mcpServer!.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       return await client.readResource(request.params.uri);
     });
 
     // Prompts
-    this.mcpServer!.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(ListPromptsRequestSchema, async (request) => {
       return await client.listPrompts(request.params?.cursor);
     });
 
-    this.mcpServer!.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(GetPromptRequestSchema, async (request) => {
       return await client.getPrompt(request.params.name, request.params.arguments);
     });
 
     // Logging
-    this.mcpServer!.setRequestHandler(SetLevelRequestSchema, async (request) => {
+    mcpServer.setRequestHandler(SetLevelRequestSchema, async (request) => {
       await client.setLoggingLevel(request.params.level);
       return {};
     });
@@ -225,25 +333,15 @@ export class ProxyServer {
   async stop(): Promise<void> {
     logger.info('Stopping proxy server...');
 
-    // Close transport
-    if (this.transport) {
+    // Close all session transports (closing a transport also closes its MCP server)
+    for (const [sid, transport] of this.transports) {
       try {
-        await this.transport.close();
+        await transport.close();
       } catch (error) {
-        logger.warn('Error closing transport:', error);
+        logger.warn(`Error closing proxy session ${sid}:`, error);
       }
-      this.transport = null;
     }
-
-    // Close MCP server
-    if (this.mcpServer) {
-      try {
-        await this.mcpServer.close();
-      } catch (error) {
-        logger.warn('Error closing MCP server:', error);
-      }
-      this.mcpServer = null;
-    }
+    this.transports.clear();
 
     // Close HTTP server
     if (this.httpServer) {

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -11,6 +11,7 @@ import {
   theme,
 } from '../output.js';
 import type { CommandOptions, OutputMode } from '../../lib/types.js';
+import { ClientError, isMcpError } from '../../lib/errors.js';
 import { deleteAuthProfiles } from '../../lib/auth/profiles.js';
 import { getServerHost, normalizeServerUrl, validateProfileName } from '../../lib/utils.js';
 import { closeProxy } from '../../lib/proxy.js';
@@ -49,7 +50,7 @@ export async function login(
     // Accept both hyphen and underscore spellings (e.g. "client_credentials").
     const grant = (options.grant ?? 'authorization-code').toLowerCase().replace(/_/g, '-');
     if (grant !== 'authorization-code' && grant !== 'client-credentials') {
-      throw new Error(
+      throw new ClientError(
         `Invalid --grant "${grant}". Supported values: authorization-code (default), client-credentials.`
       );
     }
@@ -63,18 +64,18 @@ export async function login(
 
     // --client-key / --client-key-alg / --token-endpoint only apply to client-credentials.
     if (options.clientKey || options.clientKeyAlg) {
-      throw new Error('--client-key/--client-key-alg require --grant client-credentials');
+      throw new ClientError('--client-key/--client-key-alg require --grant client-credentials');
     }
     if (options.tokenEndpoint) {
-      throw new Error('--token-endpoint is only supported with --grant client-credentials');
+      throw new ClientError('--token-endpoint is only supported with --grant client-credentials');
     }
 
     if (options.clientSecret && !options.clientId) {
-      throw new Error('--client-secret requires --client-id');
+      throw new ClientError('--client-secret requires --client-id');
     }
 
     if (options.clientMetadataUrl && options.clientId) {
-      throw new Error(
+      throw new ClientError(
         '--client-metadata-url cannot be combined with --client-id (they are mutually exclusive ' +
           'client registration approaches)'
       );
@@ -102,7 +103,7 @@ export async function login(
       options.callbackHost === 'localhost' &&
       resolvedClientMetadataUrl === DEFAULT_CLIENT_METADATA_URL
     ) {
-      throw new Error(
+      throw new ClientError(
         '--callback-host localhost cannot be used with the default hosted CIMD, which only ' +
           'registers 127.0.0.1 redirect URIs. Use --client-id (pre-registered client), ' +
           '--client-metadata-url (custom CIMD listing localhost redirect URIs), or ' +
@@ -161,10 +162,13 @@ export async function login(
     }
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
+    // Flag-validation mistakes are client errors (exit 1); actual auth failures
+    // keep exit 4. Typed errors carry their own code.
+    const exitCode = isMcpError(error) ? error.code : 4;
     if (options.outputMode === 'human') {
       console.error(formatError(errorMessage));
     } else {
-      console.error(formatOutput({ error: errorMessage }, 'json'));
+      console.error(formatOutput({ error: errorMessage, code: exitCode }, 'json'));
     }
     // `login` runs OAuth/token requests in this process. A forced process.exit()
     // here races libuv's handle teardown on Windows and aborts with an async-handle
@@ -172,7 +176,7 @@ export async function login(
     // (closes idle keep-alive sockets for a prompt exit) and let the event loop exit
     // on its own via process.exitCode — the same clean teardown the success path uses.
     await closeProxy();
-    process.exitCode = 4; // Authentication error
+    process.exitCode = exitCode;
     return;
   }
 }
@@ -181,7 +185,7 @@ export async function login(
  * Non-interactive login using the OAuth client-credentials grant.
  * Validates the supplied credentials against the server, stores them, and writes
  * the profile. No browser and no user interaction. Throws on invalid flag
- * combinations; the caller's try/catch maps errors to exit code 4.
+ * combinations (ClientError, exit 1); the caller maps errors to their exit codes.
  */
 async function loginWithClientCredentials(
   normalizedUrl: string,
@@ -200,13 +204,13 @@ async function loginWithClientCredentials(
   }
 ): Promise<void> {
   if (!options.clientId) {
-    throw new Error('--grant client-credentials requires --client-id');
+    throw new ClientError('--grant client-credentials requires --client-id');
   }
 
   const clientSecret = options.clientSecret;
   const clientKey = options.clientKey;
   if (!!clientSecret === !!clientKey) {
-    throw new Error(
+    throw new ClientError(
       'With --grant client-credentials, provide exactly one of --client-secret ' +
         '(client_secret_basic) or --client-key (private_key_jwt)'
     );
@@ -214,10 +218,10 @@ async function loginWithClientCredentials(
 
   // Browser-flow-only options have no meaning for the client-credentials grant.
   if (typeof options.clientMetadataUrl === 'string') {
-    throw new Error('--client-metadata-url cannot be used with --grant client-credentials');
+    throw new ClientError('--client-metadata-url cannot be used with --grant client-credentials');
   }
   if (options.callbackPort !== undefined || options.callbackHost !== undefined) {
-    throw new Error(
+    throw new ClientError(
       '--callback-port/--callback-host cannot be used with --grant client-credentials'
     );
   }
@@ -237,7 +241,9 @@ async function loginWithClientCredentials(
     try {
       void new URL(options.tokenEndpoint);
     } catch {
-      throw new Error(`Invalid --token-endpoint: "${options.tokenEndpoint}" is not a valid URL`);
+      throw new ClientError(
+        `Invalid --token-endpoint: "${options.tokenEndpoint}" is not a valid URL`
+      );
     }
     info.tokenEndpoint = options.tokenEndpoint;
   }
@@ -299,7 +305,7 @@ export async function logout(
           formatError(`Profile ${theme.magenta(profileName)} for ${normalizedUrl} not found`)
         );
       } else {
-        console.error(formatOutput({ error: 'Profile not found' }, 'json'));
+        console.error(formatOutput({ error: 'Profile not found', code: 1 }, 'json'));
       }
       process.exit(1); // Client error
       return;
@@ -345,7 +351,7 @@ export async function logout(
     if (options.outputMode === 'human') {
       console.error(formatError(errorMessage));
     } else {
-      console.error(formatOutput({ error: errorMessage }, 'json'));
+      console.error(formatOutput({ error: errorMessage, code: 1 }, 'json'));
     }
     process.exit(1); // Client error
   }

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -928,6 +928,11 @@ export async function connectAllFromConfig(
   if (options.outputMode === 'json') {
     const resultEntries = await buildBulkConnectEntries(results, options);
     console.log(formatOutput([...resultEntries, ...stdioSkipped.map(toSkippedStdioEntry)], 'json'));
+    // Same all-failed rule as human mode, signaled via exit code (rule: JSON
+    // output stays clean; errors are indicated via exit codes)
+    if (results.length > 0 && results.every((r) => r.status === 'failed')) {
+      process.exitCode = 1;
+    }
     return;
   }
 
@@ -1074,6 +1079,10 @@ export async function connectAllFromStandardConfigs(options: BulkConnectOptions)
     }
     const resultEntries = await buildBulkConnectEntries(results, options);
     console.log(formatOutput([...resultEntries, ...skippedJsonEntries], 'json'));
+    // Same all-failed rule as human mode, signaled via exit code
+    if (results.length > 0 && results.every((r) => r.status === 'failed')) {
+      process.exitCode = 1;
+    }
     return;
   }
 

--- a/src/cli/commands/grep.ts
+++ b/src/cli/commands/grep.ts
@@ -5,7 +5,7 @@
 import chalk from 'chalk';
 import type { Tool, Resource, Prompt, CommandOptions, SessionData } from '../../lib/types.js';
 import { ClientError } from '../../lib/errors.js';
-import { isProcessAlive } from '../../lib/utils.js';
+import { isProcessAlive, fetchAllPages } from '../../lib/utils.js';
 import { consolidateSessions } from '../../lib/sessions.js';
 import { reconnectCrashedSessions } from '../../lib/bridge-manager.js';
 import { withSessionClient } from '../../lib/session-client.js';
@@ -324,28 +324,20 @@ async function searchClient(
  * Fetch all resources with pagination
  */
 async function fetchAllResources(client: IMcpClient): Promise<Resource[]> {
-  const all: Resource[] = [];
-  let cursor: string | undefined;
-  do {
-    const result = await client.listResources(cursor);
-    all.push(...result.resources);
-    cursor = result.nextCursor;
-  } while (cursor);
-  return all;
+  return fetchAllPages(
+    (cursor) => client.listResources(cursor),
+    (page) => page.resources
+  );
 }
 
 /**
  * Fetch all prompts with pagination
  */
 async function fetchAllPrompts(client: IMcpClient): Promise<Prompt[]> {
-  const all: Prompt[] = [];
-  let cursor: string | undefined;
-  do {
-    const result = await client.listPrompts(cursor);
-    all.push(...result.prompts);
-    cursor = result.nextCursor;
-  } while (cursor);
-  return all;
+  return fetchAllPages(
+    (cursor) => client.listPrompts(cursor),
+    (page) => page.prompts
+  );
 }
 
 // ─── Output formatting ──────────────────────────────────────────────

--- a/src/cli/commands/prompts.ts
+++ b/src/cli/commands/prompts.ts
@@ -6,6 +6,7 @@ import type { CommandOptions } from '../../lib/types.js';
 import { formatOutput } from '../output.js';
 import { withMcpClient } from '../helpers.js';
 import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
+import { fetchAllPages } from '../../lib/utils.js';
 
 /**
  * List available prompts
@@ -14,14 +15,10 @@ import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
 export async function listPrompts(target: string, options: CommandOptions): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     // Fetch all prompts across all pages
-    const allPrompts = [];
-    let cursor: string | undefined = undefined;
-
-    do {
-      const result = await client.listPrompts(cursor);
-      allPrompts.push(...result.prompts);
-      cursor = result.nextCursor;
-    } while (cursor);
+    const allPrompts = await fetchAllPages(
+      (cursor) => client.listPrompts(cursor),
+      (page) => page.prompts
+    );
 
     console.log(
       formatOutput(allPrompts, options.outputMode, {

--- a/src/cli/commands/resources.ts
+++ b/src/cli/commands/resources.ts
@@ -5,7 +5,7 @@
 import chalk from 'chalk';
 import { formatOutput, formatSuccess, formatWarning, formatResourceContents } from '../output.js';
 import { withMcpClient } from '../helpers.js';
-import { resolvePath } from '../../lib/utils.js';
+import { resolvePath, fetchAllPages } from '../../lib/utils.js';
 import { selectResourceContent, writeResourceFile } from '../../lib/resource-content.js';
 import { ClientError } from '../../lib/errors.js';
 import type { CommandOptions } from '../../lib/types.js';
@@ -17,14 +17,10 @@ import type { CommandOptions } from '../../lib/types.js';
 export async function listResources(target: string, options: CommandOptions): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     // Fetch all resources across all pages
-    const allResources = [];
-    let cursor: string | undefined = undefined;
-
-    do {
-      const result = await client.listResources(cursor);
-      allResources.push(...result.resources);
-      cursor = result.nextCursor;
-    } while (cursor);
+    const allResources = await fetchAllPages(
+      (cursor) => client.listResources(cursor),
+      (page) => page.resources
+    );
 
     console.log(
       formatOutput(allResources, options.outputMode, {
@@ -44,14 +40,10 @@ export async function listResourceTemplates(
 ): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     // Fetch all resource templates across all pages
-    const allTemplates = [];
-    let cursor: string | undefined = undefined;
-
-    do {
-      const result = await client.listResourceTemplates(cursor);
-      allTemplates.push(...result.resourceTemplates);
-      cursor = result.nextCursor;
-    } while (cursor);
+    const allTemplates = await fetchAllPages(
+      (cursor) => client.listResourceTemplates(cursor),
+      (page) => page.resourceTemplates
+    );
 
     console.log(
       formatOutput(allTemplates, options.outputMode, {

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -18,7 +18,6 @@ import type { ServerConfig, ConnectionMode } from '../../lib/types.js';
 import {
   formatOutput,
   formatSuccess,
-  formatError,
   formatSessionLine,
   formatServerDetails,
   formatTimeAgo,
@@ -235,49 +234,34 @@ export async function closeSession(
   name: string,
   options: { outputMode: OutputMode }
 ): Promise<void> {
-  try {
-    // Check if session exists
-    if (!(await sessionExists(name))) {
-      throw new ClientError(`Session not found: ${name}`);
-    }
+  // Errors propagate to the central handler in cli/index.ts, which owns error
+  // rendering — printing here too would show every failure twice.
 
-    // Stop the bridge process (graceful: send IPC shutdown on Windows so
-    // the bridge can send HTTP DELETE to the server before exiting)
-    await stopBridge(name, { graceful: true });
+  // Check if session exists
+  if (!(await sessionExists(name))) {
+    throw new ClientError(`Session not found: ${name}`);
+  }
 
-    // Delete session record from storage
-    await deleteSession(name);
+  // Stop the bridge process (graceful: send IPC shutdown on Windows so
+  // the bridge can send HTTP DELETE to the server before exiting)
+  await stopBridge(name, { graceful: true });
 
-    // Success!
-    if (options.outputMode === 'human') {
-      console.log(formatSuccess(`Session ${name} closed successfully\n`));
-    } else {
-      console.log(
-        formatOutput(
-          {
-            sessionName: name,
-            closed: true,
-          },
-          'json'
-        )
-      );
-    }
-  } catch (error) {
-    if (options.outputMode === 'human') {
-      console.error(formatError((error as Error).message));
-    } else {
-      console.error(
-        formatOutput(
-          {
-            sessionName: name,
-            closed: false,
-            error: (error as Error).message,
-          },
-          'json'
-        )
-      );
-    }
-    throw error;
+  // Delete session record from storage
+  await deleteSession(name);
+
+  // Success!
+  if (options.outputMode === 'human') {
+    console.log(formatSuccess(`Session ${name} closed successfully\n`));
+  } else {
+    console.log(
+      formatOutput(
+        {
+          sessionName: name,
+          closed: true,
+        },
+        'json'
+      )
+    );
   }
 }
 
@@ -363,106 +347,88 @@ export async function restartSession(
   name: string,
   options: { outputMode: OutputMode; verbose?: boolean }
 ): Promise<void> {
-  try {
-    // Get existing session
-    const session = await getSession(name);
+  // Get existing session
+  const session = await getSession(name);
 
-    if (!session) {
-      throw new ClientError(`Session not found: ${name}`);
-    }
-
-    if (options.outputMode === 'human') {
-      console.log(theme.yellow(`Restarting session ${name}...`));
-    }
-
-    // Stop the bridge (even if it's alive). Graceful so the old bridge sends an HTTP DELETE
-    // to terminate its MCP session before exiting: an explicit restart starts a *fresh*
-    // session (see the note below), so the previous server-side session must be released
-    // rather than orphaned. On Windows SIGTERM is an immediate kill, so graceful mode sends
-    // an IPC shutdown first; on Unix SIGTERM already triggers graceful shutdown.
-    try {
-      await stopBridge(name, { graceful: true });
-    } catch {
-      // Bridge may already be stopped
-    }
-
-    // Get server config from session
-    const serverConfig = session.server;
-    if (!serverConfig) {
-      throw new ClientError(`Session ${name} has no server configuration`);
-    }
-
-    // Load headers from keychain if present
-    const { readKeychainSessionHeaders } = await import('../../lib/auth/keychain.js');
-    const headers = await readKeychainSessionHeaders(name);
-
-    // Resolve auth profile: use stored profile, or auto-detect a "default" profile.
-    // This handles the case where user creates a session without auth, then later runs
-    // `mcpc login <server>` to create a default profile, and restarts the session.
-    const hasExplicitAuthHeader = headers?.Authorization !== undefined;
-    let profileName = session.profileName;
-    if (!profileName && serverConfig.url && !hasExplicitAuthHeader && !session.x402) {
-      profileName = await resolveAuthProfile(serverConfig.url, serverConfig.url, undefined, {
-        sessionName: name,
-      });
-      if (profileName) {
-        logger.debug(`Discovered auth profile "${profileName}" for session ${name}`);
-        await updateSession(name, { profileName });
-      }
-    }
-
-    // Start bridge process.
-    // NOTE: Do NOT pass mcpSessionId on explicit restart — a restart starts a fresh session
-    // rather than resuming the old one. Session resumption is only attempted on automatic
-    // bridge restart (when the bridge crashes and the CLI detects it); if the server rejects
-    // the session ID, the session is marked as expired.
-    const bridgeOptions: StartBridgeOptions = {
-      sessionName: name,
-      serverConfig: { ...serverConfig, ...(headers && { headers }) },
-      verbose: options.verbose || false,
-      ...(headers && { headers }),
-      ...(profileName && { profileName }),
-      ...(session.proxy && { proxyConfig: session.proxy }),
-      ...(session.x402 && { x402: session.x402 }),
-      ...(session.insecure && { insecure: session.insecure }),
-    };
-
-    const { pid } = await startBridge(bridgeOptions);
-
-    // Update session with new bridge PID and clear any expired/crashed status
-    await updateSession(name, { pid, status: 'active' });
-    logger.debug(`Session ${name} restarted with bridge PID: ${pid}`);
-
-    // Success message
-    if (options.outputMode === 'human') {
-      console.log(formatSuccess(`Session ${name} restarted`));
-      console.log(
-        chalk.dim(
-          'Note: previous session state was lost (e.g. added tools, async tasks); resource subscriptions are re-established automatically'
-        )
-      );
-    }
-
-    // Show server details (like when creating a session)
-    await showServerDetails(name, {
-      ...options,
-      hideTarget: false,
-    });
-  } catch (error) {
-    if (options.outputMode === 'human') {
-      console.error(formatError((error as Error).message));
-    } else {
-      console.error(
-        formatOutput(
-          {
-            sessionName: name,
-            restarted: false,
-            error: (error as Error).message,
-          },
-          'json'
-        )
-      );
-    }
-    throw error;
+  if (!session) {
+    throw new ClientError(`Session not found: ${name}`);
   }
+
+  if (options.outputMode === 'human') {
+    console.log(theme.yellow(`Restarting session ${name}...`));
+  }
+
+  // Stop the bridge (even if it's alive). Graceful so the old bridge sends an HTTP DELETE
+  // to terminate its MCP session before exiting: an explicit restart starts a *fresh*
+  // session (see the note below), so the previous server-side session must be released
+  // rather than orphaned. On Windows SIGTERM is an immediate kill, so graceful mode sends
+  // an IPC shutdown first; on Unix SIGTERM already triggers graceful shutdown.
+  try {
+    await stopBridge(name, { graceful: true });
+  } catch {
+    // Bridge may already be stopped
+  }
+
+  // Get server config from session
+  const serverConfig = session.server;
+  if (!serverConfig) {
+    throw new ClientError(`Session ${name} has no server configuration`);
+  }
+
+  // Load headers from keychain if present
+  const { readKeychainSessionHeaders } = await import('../../lib/auth/keychain.js');
+  const headers = await readKeychainSessionHeaders(name);
+
+  // Resolve auth profile: use stored profile, or auto-detect a "default" profile.
+  // This handles the case where user creates a session without auth, then later runs
+  // `mcpc login <server>` to create a default profile, and restarts the session.
+  const hasExplicitAuthHeader = headers?.Authorization !== undefined;
+  let profileName = session.profileName;
+  if (!profileName && serverConfig.url && !hasExplicitAuthHeader && !session.x402) {
+    profileName = await resolveAuthProfile(serverConfig.url, serverConfig.url, undefined, {
+      sessionName: name,
+    });
+    if (profileName) {
+      logger.debug(`Discovered auth profile "${profileName}" for session ${name}`);
+      await updateSession(name, { profileName });
+    }
+  }
+
+  // Start bridge process.
+  // NOTE: Do NOT pass mcpSessionId on explicit restart — a restart starts a fresh session
+  // rather than resuming the old one. Session resumption is only attempted on automatic
+  // bridge restart (when the bridge crashes and the CLI detects it); if the server rejects
+  // the session ID, the session is marked as expired.
+  const bridgeOptions: StartBridgeOptions = {
+    sessionName: name,
+    serverConfig: { ...serverConfig, ...(headers && { headers }) },
+    verbose: options.verbose || false,
+    ...(headers && { headers }),
+    ...(profileName && { profileName }),
+    ...(session.proxy && { proxyConfig: session.proxy }),
+    ...(session.x402 && { x402: session.x402 }),
+    ...(session.insecure && { insecure: session.insecure }),
+  };
+
+  const { pid } = await startBridge(bridgeOptions);
+
+  // Update session with new bridge PID and clear any expired/crashed status
+  await updateSession(name, { pid, status: 'active' });
+  logger.debug(`Session ${name} restarted with bridge PID: ${pid}`);
+
+  // Success message
+  if (options.outputMode === 'human') {
+    console.log(formatSuccess(`Session ${name} restarted`));
+    console.log(
+      chalk.dim(
+        'Note: previous session state was lost (e.g. added tools, async tasks); resource subscriptions are re-established automatically'
+      )
+    );
+  }
+
+  // Show server details (like when creating a session)
+  await showServerDetails(name, {
+    ...options,
+    hideTarget: false,
+  });
 }

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -21,6 +21,7 @@
 import type { CommandOptions, IMcpClient } from '../../lib/types.js';
 import type { ReadResourceResult, Resource } from '@modelcontextprotocol/sdk/types.js';
 import { ServerError, ClientError } from '../../lib/errors.js';
+import { fetchAllPages } from '../../lib/utils.js';
 import { withMcpClient } from '../helpers.js';
 import { formatOutput, formatSkills, formatSkillDetail } from '../output.js';
 
@@ -222,13 +223,10 @@ export async function discoverSkills(client: IMcpClient): Promise<Skill[]> {
   }
 
   // Fallback: scan all resources, matching `skill://<id>/SKILL.md`.
-  const all: Resource[] = [];
-  let cursor: string | undefined;
-  do {
-    const page = await client.listResources(cursor);
-    all.push(...page.resources);
-    cursor = page.nextCursor;
-  } while (cursor);
+  const all: Resource[] = await fetchAllPages(
+    (cursor) => client.listResources(cursor),
+    (page) => page.resources
+  );
 
   return skillsFromResources(all);
 }

--- a/src/cli/commands/tasks.ts
+++ b/src/cli/commands/tasks.ts
@@ -9,6 +9,7 @@ import type { CommandOptions } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 import { formatTask, formatTasks } from '../output.js';
 import { renderCallToolResult } from './tools.js';
+import { fetchAllPages } from '../../lib/utils.js';
 
 /**
  * Get the final result of a task (wraps MCP `tasks/result`).
@@ -35,14 +36,10 @@ export async function getTaskResult(
 export async function listTasks(target: string, options: CommandOptions): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     // Fetch all tasks across all pages
-    const allTasks = [];
-    let cursor: string | undefined = undefined;
-
-    do {
-      const result = await client.listTasks(cursor);
-      allTasks.push(...result.tasks);
-      cursor = result.nextCursor;
-    } while (cursor);
+    const allTasks = await fetchAllPages(
+      (cursor) => client.listTasks(cursor),
+      (page) => page.tasks
+    );
 
     if (options.outputMode === 'human') {
       if (allTasks.length === 0) {
@@ -90,6 +87,12 @@ export async function cancelTask(
 ): Promise<void> {
   await withMcpClient(target, options, async (client, _context) => {
     const result = await client.cancelTask(taskId);
+
+    // Exit-code contract: a cancel that did not result in cancellation is a
+    // server-side failure (exit 2), in both output modes.
+    if (result.status !== 'cancelled') {
+      process.exitCode = 2;
+    }
 
     if (options.outputMode === 'human') {
       if (result.status === 'cancelled') {

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -51,6 +51,13 @@ export function renderCallToolResult(
     errorHint?: string;
   }
 ): void {
+  // Honor the documented exit-code contract: a tool that reports failure via
+  // isError exits with code 2 (server error), so scripts chaining on `&&` stop.
+  // The result is still rendered normally in both output modes.
+  if (result.isError) {
+    process.exitCode = 2;
+  }
+
   if (options.outputMode === 'human') {
     if (banners) {
       if (result.isError && banners.error) {

--- a/src/cli/commands/x402.ts
+++ b/src/cli/commands/x402.ts
@@ -26,7 +26,8 @@ import {
   theme,
 } from '../output.js';
 import { getWallet, saveWallet, removeWallet } from '../../lib/wallets.js';
-import { ClientError } from '../../lib/errors.js';
+import { ClientError, isMcpError } from '../../lib/errors.js';
+import { getJsonFromEnv } from '../parser.js';
 import type { OutputMode } from '../../lib/types.js';
 import { signPayment, parsePaymentRequired } from '../../lib/x402/signer.js';
 
@@ -294,7 +295,13 @@ async function signPaymentCommand(options: SignOptions): Promise<void> {
     amountOverride = BigInt(Math.round(amountUsd * 10 ** USDC_DECIMALS));
   }
 
-  const expiryOverride = options.expiry ? parseInt(options.expiry, 10) : undefined;
+  let expiryOverride: number | undefined;
+  if (options.expiry) {
+    expiryOverride = parseInt(options.expiry, 10);
+    if (isNaN(expiryOverride) || expiryOverride <= 0) {
+      throw new ClientError('--expiry must be a positive number of seconds.');
+    }
+  }
 
   // Sign using shared signer
   const result = await signPayment({
@@ -493,9 +500,16 @@ ${jsonHelp('`{ paymentSignature, from, to, amount, amountAtomicUnits, network, e
   try {
     await program.parseAsync(['node', 'mcpc-x402', ...args]);
   } catch (error) {
-    if (error instanceof ClientError) {
-      console.error(formatError(error.message));
-      process.exit(1);
+    if (isMcpError(error)) {
+      // Respect --json/MCPC_JSON for machine-readable errors, and preserve the
+      // error's own exit code instead of flattening everything to 1.
+      const jsonMode = args.includes('--json') || getJsonFromEnv();
+      if (jsonMode) {
+        console.error(formatJson({ error: error.message, code: error.code }));
+      } else {
+        console.error(formatError(error.message));
+      }
+      process.exit(error.code);
     }
     throw error;
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -297,9 +297,10 @@ async function main(): Promise<void> {
       await closeFileLogger();
     }
 
-    // Flush stdout before exiting
+    // Flush stdout before exiting. Honor any exit code set by the command
+    // handler (e.g. tools-call sets 2 when the tool result has isError).
     await flushStdout();
-    process.exit(0);
+    process.exit(process.exitCode ?? 0);
   }
 
   // Top-level commands: login, logout, connect, clean, help, x402
@@ -830,6 +831,9 @@ ${chalk.bold('Examples:')}
   mcpc @apify grep "actor"                  Search within a single session
   mcpc grep "file" --json                   JSON output for scripting
   mcpc grep "actor" -m 5                    Show at most 5 results
+
+${chalk.bold('Exit codes:')}
+  0 = matches found, 1 = no matches (grep convention)
 ${jsonHelp('`[{ sessionName, tools?: Tool[], resources?: Resource[], prompts?: Prompt[], instructions?: string[] }]`')}`
     )
     .action(async (pattern, opts, command) => {
@@ -919,6 +923,14 @@ function tuneCommandHelp(cmd: Command): void {
   if (!cmd.options.some((o) => o.long === '--json')) {
     cmd.option('--json', 'Output in JSON format');
   }
+  // A command that disabled its help option did so deliberately (e.g. tools-call
+  // intercepts --help in its action to show the tool's schema) — re-registering
+  // it here would make Commander swallow --help before the action ever runs.
+  // Commander marks a disabled help option with `_helpOption === null`.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((cmd as any)._helpOption === null) {
+    return;
+  }
   cmd.helpOption('-h, --help', 'Display help');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const helpOpt = (cmd as any)._getHelpOption?.();
@@ -997,6 +1009,9 @@ ${chalk.bold('Examples:')}
   mcpc ${session} grep "search"                  Search tools and instructions
   mcpc ${session} grep "search" --resources      Search resources only
   mcpc ${session} grep "search|find" -E          Regex search
+
+${chalk.bold('Exit codes:')}
+  0 = matches found, 1 = no matches (grep convention)
 ${jsonHelp('`{ tools?: Tool[], resources?: Resource[], prompts?: Prompt[], instructions?: string[] }`')}`
     )
     .action(async (pattern, opts, command) => {
@@ -1074,7 +1089,6 @@ ${chalk.bold('JSON output (--json):')}
   program
     .command('tools-call <name> [args...]')
     .description('Call an MCP tool with arguments.')
-    .helpOption(false) // Disable built-in --help so we can intercept it for tool schema
     .option(
       '--task',
       'Use async task execution; Ctrl+C prints the task ID and exits (experimental)'
@@ -1092,6 +1106,7 @@ ${chalk.bold('Arguments:')}
 
   Values are auto-parsed: strings, numbers, booleans, JSON objects/arrays.
   To force a string, wrap in quotes: id:='"123"'
+  Tip: mcpc ${session} tools-call <tool> --help prints the tool's parameter schema.
 
 ${chalk.bold('Async tasks (--task, --detach):')}
   --task shows a progress spinner while the task runs on the server.
@@ -1105,17 +1120,8 @@ ${chalk.bold('Schema validation:')}
 ${toolsCallCombinedJsonHelp}`
     )
     .action(async (name, args, options, command) => {
-      // Intercept --help: with helpOption(false) Commander won't catch it.
-      // "tools-call --help" (no tool name) → name is '--help', show command help.
-      // "tools-call search --help" → show tool parameter schema (shortcut for tools-get).
-      if (name === '--help' || name === '-h') {
-        command.help();
-        return;
-      }
-      if (args.includes('--help') || args.includes('-h')) {
-        await tools.getTool(session, name, getOptionsFromCommand(command));
-        return;
-      }
+      // Note: "tools-call <tool> --help" (tool schema shortcut) is intercepted
+      // before Commander parses — see extractToolsCallHelpTarget().
       await tools.callTool(session, name, {
         args,
         task: options.task,
@@ -1458,6 +1464,26 @@ function createSessionProgram(): Command {
 }
 
 /**
+ * Detect the "tools-call <tool> --help" shortcut. Returns the tool name when the
+ * invocation is a tools-call carrying both a tool name and a help flag; undefined
+ * otherwise (a plain "tools-call --help" falls through to Commander's command help).
+ */
+function extractToolsCallHelpTarget(args: string[]): string | undefined {
+  if (!args.includes('--help') && !args.includes('-h')) return undefined;
+  const positionals: string[] = [];
+  for (let i = 2; i < args.length && positionals.length < 2; i++) {
+    const arg = args[i];
+    if (!arg || arg === '--help' || arg === '-h') continue;
+    if (arg.startsWith('-')) {
+      if (optionTakesValue(arg) && !arg.includes('=')) i++; // skip option value
+      continue;
+    }
+    positionals.push(arg);
+  }
+  return positionals[0] === 'tools-call' ? positionals[1] : undefined;
+}
+
+/**
  * Handle commands for a session target (@name)
  */
 async function handleSessionCommands(session: string, args: string[]): Promise<void> {
@@ -1469,6 +1495,22 @@ async function handleSessionCommands(session: string, args: string[]): Promise<v
     if (options.json) setJsonMode(true);
 
     await sessions.showServerDetails(session, {
+      outputMode: options.json ? 'json' : 'human',
+      ...(options.verbose && { verbose: true }),
+      ...(options.timeout !== undefined && { timeout: options.timeout }),
+    });
+    return;
+  }
+
+  // "tools-call <tool> --help" shortcut: print the tool's parameter schema
+  // (same as tools-get <tool>). Must be intercepted before Commander parses —
+  // Commander consumes --help itself and would show the generic command help.
+  const toolHelpName = extractToolsCallHelpTarget(args);
+  if (toolHelpName) {
+    const options = extractOptions(args);
+    if (options.verbose) setVerbose(true);
+    if (options.json) setJsonMode(true);
+    await tools.getTool(session, toolHelpName, {
       outputMode: options.json ? 'json' : 'human',
       ...(options.verbose && { verbose: true }),
       ...(options.timeout !== undefined && { timeout: options.timeout }),

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -466,6 +466,15 @@ export function parseServerArg(
  * This allows natural CLI usage like: count:=10, enabled:=true, name:=hello
  */
 function autoParseValue(value: string): unknown {
+  // Integers beyond Number.MAX_SAFE_INTEGER (e.g. snowflake IDs) would silently
+  // lose precision as JS numbers — pass them through as strings instead.
+  if (/^-?\d+$/.test(value)) {
+    const abs = value.startsWith('-') ? value.slice(1) : value;
+    if (abs.length >= 16 && !Number.isSafeInteger(Number(value))) {
+      return value;
+    }
+  }
+
   // Try to parse as JSON (handles numbers, booleans, null, arrays, objects)
   try {
     return JSON.parse(value);

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -23,13 +23,14 @@ export interface BuildClientCapabilitiesOptions {
 /**
  * Build the MCP client capabilities mcpc advertises to servers.
  *
+ * Only capabilities mcpc actually implements are declared. In particular,
+ * `sampling` and `roots` are NOT declared: mcpc has no LLM to answer
+ * `sampling/createMessage` and registers no `roots/list` handler, so declaring
+ * them would invite server requests that can only fail with "Method not found".
+ *
  * Kept as a single source of truth so it can evolve per protocol generation:
- * - `roots` and `sampling` (and server-side `logging`) are deprecated as of `2026-07-28`
- *   (SEP-2577) but remain functional through at least 2027-07-28 and are still required by
- *   legacy servers, so we keep declaring them. Servers ignore capabilities they don't
- *   understand, so over-declaring against a newer server is harmless.
- * - `tasks` will move into the negotiated `extensions` map (a reverse-DNS id) once the SDK
- *   exposes the `2026-07-28` Tasks extension — this is the single place to make that switch.
+ * `tasks` will move into the negotiated `extensions` map (a reverse-DNS id) once the SDK
+ * exposes the `2026-07-28` Tasks extension — this is the single place to make that switch.
  *
  * Capabilities are declared before the protocol version is negotiated, so this cannot
  * branch on the server's version.
@@ -38,14 +39,9 @@ export function buildClientCapabilities(
   options: BuildClientCapabilitiesOptions = {}
 ): ClientCapabilities {
   return {
-    roots: { listChanged: true },
-    sampling: {},
     tasks: {
       list: {},
       cancel: {},
-      requests: {
-        sampling: { createMessage: {} },
-      },
     },
     ...(options.clientCredentials
       ? { extensions: { [CLIENT_CREDENTIALS_EXTENSION_KEY]: {} } }

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -23,6 +23,7 @@ import type {
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { createNoOpLogger, type Logger } from '../lib/logger.js';
 import { ServerError, NetworkError, isShutdownError } from '../lib/errors.js';
+import { fetchAllPages } from '../lib/utils.js';
 
 /**
  * Traverse the .cause chain to find the deepest (most specific) error message
@@ -115,6 +116,8 @@ export class McpClient implements IMcpClient {
   private transport?: TransportWithTermination;
   private hasConnected = false;
   private requestTimeout: number = DEFAULT_REQUEST_TIMEOUT_MS;
+  /** Baseline timeout from the constructor — what resetRequestTimeout() restores. */
+  private readonly configuredRequestTimeout: number;
   private cachedTools: Tool[] | null = null;
   private cachedToolsExpiresAt: number | null = null;
 
@@ -123,6 +126,7 @@ export class McpClient implements IMcpClient {
     if (options.requestTimeout !== undefined) {
       this.requestTimeout = options.requestTimeout;
     }
+    this.configuredRequestTimeout = this.requestTimeout;
 
     this.client = new SDKClient(clientInfo, {
       capabilities: options.capabilities || {},
@@ -147,6 +151,15 @@ export class McpClient implements IMcpClient {
    */
   setRequestTimeout(timeoutMs: number): void {
     this.requestTimeout = timeoutMs;
+  }
+
+  /**
+   * Restore the request timeout to the constructor-configured baseline.
+   * The bridge calls this after each request that carried an explicit
+   * `--timeout`, so a one-off override never leaks into later requests.
+   */
+  resetRequestTimeout(): void {
+    this.requestTimeout = this.configuredRequestTimeout;
   }
 
   /**
@@ -244,10 +257,15 @@ export class McpClient implements IMcpClient {
         }
       }
 
-      // Now close the client
+      // Now close the client. Stdio transports need a longer budget: the SDK's
+      // close() escalates close-stdin → wait → SIGTERM → wait → SIGKILL (~4.5s
+      // worst case), and abandoning it early would orphan the child server
+      // process. HTTP transports have nothing to kill, so they get a short one.
+      const isHttp = typeof this.transport?.terminateSession === 'function';
+      const closeBudgetMs = isHttp ? 1000 : 6000;
       await Promise.race([
         this.client.close(),
-        new Promise<void>((resolve) => setTimeout(resolve, 1000)),
+        new Promise<void>((resolve) => setTimeout(resolve, closeBudgetMs)),
       ]);
       this.logger.debug('Connection closed');
     } catch (error) {
@@ -339,14 +357,10 @@ export class McpClient implements IMcpClient {
       return { tools: this.cachedTools };
     }
 
-    const allTools: Tool[] = [];
-    let cursor: string | undefined = undefined;
-
-    do {
-      const result = await this.listTools(cursor);
-      allTools.push(...result.tools);
-      cursor = result.nextCursor;
-    } while (cursor);
+    const allTools: Tool[] = await fetchAllPages(
+      (cursor) => this.listTools(cursor),
+      (page) => page.tools
+    );
 
     this.cachedTools = allTools;
     // Stateless connections get a time-based expiry as a fallback for absent list_changed
@@ -757,13 +771,10 @@ export class McpClient implements IMcpClient {
           task.status === 'failed' ||
           task.status === 'cancelled'
         ) {
-          // For completed tasks, the result is in the task itself
           if (task.status === 'completed') {
-            // Re-fetch task to get final result if needed
-            // The GetTaskResult includes the task with its artifacts
-            return {
-              content: [{ type: 'text', text: task.statusMessage || 'Task completed' }],
-            };
+            // Fetch the actual tool result — the task status only carries a
+            // human-readable message, not the tool output.
+            return await this.getTaskResult(taskId);
           }
           throw new ServerError(
             `Task ${taskId} ${task.status}: ${task.statusMessage || 'no details'}`

--- a/src/lib/auth/oauth-utils.ts
+++ b/src/lib/auth/oauth-utils.ts
@@ -181,7 +181,9 @@ export async function refreshAccessToken(
   });
 
   if (!response.ok) {
-    const errorText = await response.text();
+    // Log only a bounded snippet — a non-conforming auth server could echo
+    // sensitive or attacker-influenced content into the persisted bridge log.
+    const errorText = (await response.text()).slice(0, 400);
     logger.error(`Token refresh failed: ${response.status} ${errorText}`);
 
     if (response.status === 400 || response.status === 401) {

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -19,13 +19,22 @@ import { connect, type Socket } from 'net';
 import { EventEmitter } from 'events';
 import type { IpcMessage, TaskUpdate, X402WalletCredentials } from './types.js';
 import { createLogger } from './logger.js';
-import { NetworkError, ClientError, ServerError, AuthError } from './errors.js';
+import { NetworkError, ClientError, ServerError, AuthError, IpcTimeoutError } from './errors.js';
 import { generateRequestId, sleep } from './utils.js';
 
 const logger = createLogger('bridge-client');
 
-// Timeout for MCP requests (3 minutes as per CLAUDE.md)
+// Default timeout for IPC requests to the bridge (3 minutes)
 const REQUEST_TIMEOUT = 3 * 60 * 1000;
+
+/**
+ * Extra margin added to the CLI-side IPC timer on top of an explicit `--timeout`.
+ * The bridge arms its own MCP request timer with the same `--timeout` value; the
+ * margin guarantees the bridge's typed timeout error (a ServerError with context)
+ * always wins the race against the CLI's blunt IPC timeout, instead of the CLI
+ * misdiagnosing a healthy bridge as unresponsive.
+ */
+const IPC_TIMEOUT_MARGIN_MS = 10_000;
 
 // Timeout for initial socket connection (5 seconds)
 const CONNECT_TIMEOUT = 5 * 1000;
@@ -276,14 +285,17 @@ export class BridgeClient extends EventEmitter {
 
     logger.debug('Sending request:', { id, method });
 
-    // Use custom timeout (in seconds, convert to ms) or default
-    const timeoutMs = timeout !== undefined ? timeout * 1000 : REQUEST_TIMEOUT;
+    // Use custom timeout (in seconds, convert to ms) or default. An explicit
+    // timeout gets a margin on top so the bridge's own MCP timer (armed with the
+    // same value) always fires first — see IPC_TIMEOUT_MARGIN_MS.
+    const timeoutMs =
+      timeout !== undefined ? timeout * 1000 + IPC_TIMEOUT_MARGIN_MS : REQUEST_TIMEOUT;
 
     // Create promise for response
     const promise = new Promise<unknown>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         this.pendingRequests.delete(id);
-        reject(new NetworkError(`Request timeout: ${method}`));
+        reject(new IpcTimeoutError(`Request timeout: ${method}`));
       }, timeoutMs);
 
       this.pendingRequests.set(id, { resolve, reject, timeoutId });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -83,6 +83,18 @@ export class AuthError extends McpError {
 }
 
 /**
+ * IPC request timeout (exit code 3)
+ *
+ * Raised when the CLI gives up waiting for the bridge to answer over the IPC
+ * socket. Unlike a socket failure, a timeout does NOT mean the bridge crashed —
+ * the bridge (and the MCP server behind it) may still be processing the request.
+ * Callers must therefore never treat this as "safe to restart and retry":
+ * restarting the bridge would tear down an in-flight request, and re-sending it
+ * could execute a non-idempotent tool call twice.
+ */
+export class IpcTimeoutError extends NetworkError {}
+
+/**
  * Check if an error message indicates an authentication error from the server.
  * Uses word boundaries for numeric codes (401, 403) to avoid false positives
  * from error codes or other numbers that happen to contain these digits.

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -33,7 +33,7 @@ import type { ListResourceTemplatesResult } from '@modelcontextprotocol/sdk/type
 import { BridgeClient } from './bridge-client.js';
 import { ensureBridgeReady, restartBridge } from './bridge-manager.js';
 import { updateSession } from './sessions.js';
-import { NetworkError } from './errors.js';
+import { NetworkError, IpcTimeoutError } from './errors.js';
 import { getSocketPath, generateRequestId } from './utils.js';
 import { createLogger } from './logger.js';
 
@@ -66,12 +66,24 @@ export class SessionClient implements IMcpClient {
    * If the bridge socket connection fails (bridge crashed/killed), we:
    * 1. Restart the bridge once
    * 2. Reconnect
-   * 3. Retry the operation once
+   * 3. Retry the operation once — but only for idempotent operations
    *
-   * This handles the common case of a crashed bridge without complex retry logic.
+   * Two cases are deliberately NOT retried:
+   * - IPC timeouts: the bridge is likely healthy and still processing the request;
+   *   restarting would kill the in-flight request and retrying could execute it twice.
+   * - Non-idempotent operations (tool calls) after a socket failure: the bridge died
+   *   with the request in flight, so the server may already have executed it. We
+   *   restart the bridge to recover the session, but surface the uncertainty to the
+   *   caller instead of silently re-executing.
+   *
    * MCP-level errors (server errors, auth errors) are NOT retried - they're returned to caller.
    */
-  private async withRetry<T>(operation: () => Promise<T>, operationName: string): Promise<T> {
+  private async withRetry<T>(
+    operation: () => Promise<T>,
+    operationName: string,
+    options?: { idempotent?: boolean }
+  ): Promise<T> {
+    const idempotent = options?.idempotent ?? true;
     try {
       return await operation();
     } catch (error) {
@@ -80,6 +92,15 @@ export class SessionClient implements IMcpClient {
         // Add log hint for MCP/server errors
         const err = error as Error;
         err.message = `${err.message}. For details, run: mcpc ${this.sessionName} logs`;
+        throw error;
+      }
+
+      // IPC timeout: the bridge did not answer in time, but it did not crash —
+      // the request may still be running. Never restart or retry here.
+      if (error instanceof IpcTimeoutError) {
+        error.message =
+          `${error.message}. The bridge did not respond in time; the request may still be ` +
+          `running on the server. For details, run: mcpc ${this.sessionName} logs`;
         throw error;
       }
 
@@ -97,6 +118,16 @@ export class SessionClient implements IMcpClient {
       this.bridgeClient = new BridgeClient(socketPath);
       await this.bridgeClient.connect();
       await updateSession(this.sessionName, { status: 'active' });
+
+      if (!idempotent) {
+        // The request was in flight when the bridge died — the server may or may
+        // not have executed it. The session is reconnected; let the user decide.
+        error.message =
+          `${error.message}. The bridge connection was lost while the request was in flight — ` +
+          `it may or may not have executed on the server. The session has been reconnected; ` +
+          `verify the outcome before retrying. For details, run: mcpc ${this.sessionName} logs`;
+        throw error;
+      }
 
       logger.debug(`Reconnected to bridge for ${this.sessionName}, retrying ${operationName}`);
 
@@ -170,7 +201,8 @@ export class SessionClient implements IMcpClient {
           params,
           this.requestTimeout
         ) as Promise<CallToolResult>,
-      'callTool'
+      'callTool',
+      { idempotent: false }
     );
   }
 
@@ -337,6 +369,20 @@ export class SessionClient implements IMcpClient {
         throw error;
       }
 
+      // IPC timeout: the bridge is likely still processing the call — never
+      // restart or re-invoke (the tool could execute twice). If we know the task
+      // ID, keep following it; otherwise surface the timeout.
+      if (error instanceof IpcTimeoutError) {
+        if (capturedTaskId) {
+          logger.debug(`IPC timeout, polling existing task ${capturedTaskId} instead`);
+          return await this.pollTask(capturedTaskId, onUpdate);
+        }
+        error.message =
+          `${error.message}. The bridge did not respond in time; the tool call may still be ` +
+          `running on the server. For details, run: mcpc ${this.sessionName} logs`;
+        throw error;
+      }
+
       logger.debug(`Socket error during callToolWithTask, will restart bridge...`);
       await this.bridgeClient.close();
       const { pid: newPid } = await restartBridge(this.sessionName);
@@ -351,9 +397,14 @@ export class SessionClient implements IMcpClient {
         return await this.pollTask(capturedTaskId, onUpdate);
       }
 
-      // Task wasn't created yet — retry the full tool call
-      logger.debug(`Reconnected, retrying callToolWithTask`);
-      return await executeToolCall();
+      // No task was observed, but the tools/call request was already in flight
+      // when the bridge died — the server may have received it. Re-invoking could
+      // execute the tool twice, so surface the uncertainty instead.
+      error.message =
+        `${error.message}. The bridge connection was lost while the tool call was in flight — ` +
+        `it may or may not have executed on the server. The session has been reconnected; ` +
+        `check mcpc ${this.sessionName} tasks-list and verify the outcome before retrying.`;
+      throw error;
     }
   }
 
@@ -372,7 +423,8 @@ export class SessionClient implements IMcpClient {
           { name, arguments: args, useTask: true, detach: true, ...(meta && { _meta: meta }) },
           this.requestTimeout
         ) as Promise<TaskUpdate>,
-      'callToolDetached'
+      'callToolDetached',
+      { idempotent: false }
     );
   }
 

--- a/src/lib/sessions.ts
+++ b/src/lib/sessions.ts
@@ -40,14 +40,41 @@ async function loadSessionsInternal(): Promise<SessionsStorage> {
     const storage = JSON.parse(content) as SessionsStorage;
 
     if (!storage.sessions || typeof storage.sessions !== 'object') {
-      logger.warn('Invalid sessions file format, returning empty sessions');
+      await quarantineCorruptSessionsFile(filePath, 'invalid format (missing "sessions" object)');
       return { sessions: {} };
     }
 
     return storage;
   } catch (error) {
-    logger.warn(`Failed to load sessions: ${(error as Error).message}`);
+    await quarantineCorruptSessionsFile(filePath, (error as Error).message);
     return { sessions: {} };
+  }
+}
+
+/**
+ * Move an unreadable sessions.json aside instead of silently discarding it.
+ *
+ * Without this, a corrupted file would be treated as "no sessions" and the very
+ * next save would overwrite it with an empty map — permanently losing every
+ * session record while their bridges keep running as orphans. The backup keeps
+ * the data recoverable and the stderr warning makes the corruption visible.
+ */
+async function quarantineCorruptSessionsFile(filePath: string, reason: string): Promise<void> {
+  const backupPath = `${filePath}.corrupt-${Date.now()}`;
+  try {
+    await atomicRename(filePath, backupPath);
+    logger.warn(`Sessions file is corrupted (${reason}); backed up to ${backupPath}`);
+    console.error(
+      `Warning: ~/.mcpc sessions file was corrupted (${reason}). ` +
+        `It has been backed up to ${backupPath} and reset. ` +
+        `Run 'mcpc' to see current sessions and 'mcpc clean sessions' to clean up stale bridges.`
+    );
+  } catch (renameError) {
+    // Rename failed (e.g. permissions) — warn, but do not throw: commands like
+    // `mcpc connect` must still be usable.
+    logger.warn(
+      `Sessions file is corrupted (${reason}) and could not be backed up: ${(renameError as Error).message}`
+    );
   }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,8 +7,56 @@ import { createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { homedir, tmpdir } from 'os';
 import { join, resolve, isAbsolute } from 'path';
-import { mkdir, access, constants, rename } from 'fs/promises';
-import { ClientError } from './errors.js';
+import { mkdir, access, constants, rename, lstat, chmod } from 'fs/promises';
+import { ClientError, ServerError } from './errors.js';
+
+/**
+ * Safety cap on pages fetched by fetchAllPages(). Generous — real servers
+ * paginate in the tens of pages; the cap only exists to bound a misbehaving
+ * server that keeps handing out fresh cursors forever.
+ */
+const MAX_PAGINATION_PAGES = 1000;
+
+/**
+ * Fetch every page of a paginated MCP list operation and collect the items.
+ *
+ * Guards against misbehaving servers: a cursor that repeats (a pagination
+ * cycle) or an excessive page count aborts with a ServerError instead of
+ * looping forever with unbounded memory growth. This matters especially in
+ * the bridge, where list refreshes run unattended on server notifications.
+ */
+export async function fetchAllPages<TPage extends { nextCursor?: string | undefined }, TItem>(
+  fetchPage: (cursor?: string) => Promise<TPage>,
+  getItems: (page: TPage) => TItem[]
+): Promise<TItem[]> {
+  const items: TItem[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  let pages = 0;
+
+  do {
+    const page = await fetchPage(cursor);
+    items.push(...getItems(page));
+    pages++;
+
+    cursor = page.nextCursor;
+    if (cursor !== undefined) {
+      if (seenCursors.has(cursor)) {
+        throw new ServerError(
+          'Server returned a pagination cursor it already used — aborting to avoid an infinite loop'
+        );
+      }
+      seenCursors.add(cursor);
+      if (pages >= MAX_PAGINATION_PAGES) {
+        throw new ServerError(
+          `Server pagination exceeded ${MAX_PAGINATION_PAGES} pages — aborting`
+        );
+      }
+    }
+  } while (cursor);
+
+  return items;
+}
 
 /**
  * Expand tilde (~) to home directory in paths
@@ -148,6 +196,36 @@ export async function ensureDir(dirPath: string, mode: number = 0o700): Promise<
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
       throw error;
     }
+  }
+}
+
+/**
+ * Create (or validate) a private directory in a world-writable location such as
+ * the system temp dir.
+ *
+ * `mkdir` does not fix the ownership or permissions of a pre-existing directory,
+ * and the short socket dir name is predictable (derived from the mcpc home path) —
+ * on a shared machine another local user could pre-create it, or plant a symlink,
+ * to reach the bridge IPC socket and drive the authenticated session. So verify
+ * the path is a real directory owned by the current user, and tighten its
+ * permissions to 0700 if needed.
+ */
+export async function ensureSecureTempDir(dirPath: string): Promise<void> {
+  await ensureDir(dirPath, 0o700);
+
+  const stats = await lstat(dirPath);
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new ClientError(
+      `Refusing to use socket directory ${dirPath}: not a real directory (possible tampering)`
+    );
+  }
+  if (typeof process.getuid === 'function' && stats.uid !== process.getuid()) {
+    throw new ClientError(
+      `Refusing to use socket directory ${dirPath}: owned by another user (uid ${stats.uid})`
+    );
+  }
+  if ((stats.mode & 0o077) !== 0) {
+    await chmod(dirPath, 0o700);
   }
 }
 

--- a/test/unit/bridge/proxy-server.test.ts
+++ b/test/unit/bridge/proxy-server.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Unit tests for the proxy MCP server's DNS-rebinding protections.
+ *
+ * A malicious web page can point an attacker-controlled hostname at 127.0.0.1
+ * and drive the proxy (and the authenticated upstream session) from the user's
+ * browser. Requests forged that way arrive with a non-local Host and/or Origin
+ * header, so the proxy must reject them with 403.
+ */
+
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { ProxyServer } from '../../../src/bridge/proxy-server.js';
+import type { McpClient } from '../../../src/core/mcp-client.js';
+
+const onWindows = process.platform === 'win32';
+
+/** Minimal upstream client stub — handlers are never invoked in these tests. */
+const stubClient = {} as unknown as McpClient;
+
+function request(options: {
+  port: number;
+  method?: string;
+  path?: string;
+  headers?: Record<string, string>;
+}): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port: options.port,
+        method: options.method ?? 'GET',
+        path: options.path ?? '/health',
+        headers: options.headers ?? {},
+      },
+      (res) => {
+        let body = '';
+        res.on('data', (chunk) => (body += chunk));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Find a free TCP port by binding to 0 and releasing it. */
+async function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = http.createServer();
+    srv.listen(0, '127.0.0.1', () => {
+      const port = (srv.address() as AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+    srv.on('error', reject);
+  });
+}
+
+describe.skipIf(onWindows)('ProxyServer Host/Origin validation', () => {
+  let proxy: ProxyServer;
+  let port: number;
+
+  beforeAll(async () => {
+    port = await freePort();
+    proxy = new ProxyServer({
+      host: '127.0.0.1',
+      port,
+      client: stubClient,
+      sessionName: '@test',
+      version: '0.0.0-test',
+    });
+    await proxy.start();
+  });
+
+  afterAll(async () => {
+    await proxy.stop();
+  });
+
+  it('accepts requests with a loopback Host header', async () => {
+    const res = await request({ port });
+    expect(res.status).toBe(200);
+    expect(res.body).toContain('ok');
+  });
+
+  it('rejects requests with a non-local Host header (DNS rebinding)', async () => {
+    const res = await request({ port, headers: { Host: 'attacker.example.com' } });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain('Host');
+  });
+
+  it('rejects non-local Host with port suffix', async () => {
+    const res = await request({ port, headers: { Host: `rebind.evil:${port}` } });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects requests with a non-local Origin header', async () => {
+    const res = await request({
+      port,
+      headers: { Host: `127.0.0.1:${port}`, Origin: 'https://evil.example.com' },
+    });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain('Origin');
+  });
+
+  it('accepts requests with a loopback Origin header', async () => {
+    const res = await request({
+      port,
+      headers: { Host: `127.0.0.1:${port}`, Origin: 'http://localhost:5173' },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('requires MCP-Session-Id for non-POST MCP requests', async () => {
+    const res = await request({ port, path: '/' });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown session ID', async () => {
+    const res = await request({
+      port,
+      path: '/',
+      headers: { 'mcp-session-id': 'nonexistent-session' },
+    });
+    expect(res.status).toBe(404);
+  });
+});

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -89,6 +89,23 @@ describe('parseCommandArgs', () => {
       expect(result).toEqual({ limit: 10 });
     });
 
+    it('should keep integers beyond MAX_SAFE_INTEGER as strings (no precision loss)', () => {
+      // e.g. snowflake IDs — JSON.parse would silently round these
+      const result = parseCommandArgs(['id:=12345678901234567890']);
+      expect(result).toEqual({ id: '12345678901234567890' });
+    });
+
+    it('should keep large negative integers as strings', () => {
+      const result = parseCommandArgs(['id:=-12345678901234567890']);
+      expect(result).toEqual({ id: '-12345678901234567890' });
+    });
+
+    it('should still parse safe 16+ digit-looking numbers within range', () => {
+      // 16 digits but within MAX_SAFE_INTEGER (9007199254740991)
+      const result = parseCommandArgs(['n:=9007199254740991']);
+      expect(result).toEqual({ n: 9007199254740991 });
+    });
+
     it('should parse boolean true', () => {
       const result = parseCommandArgs(['enabled:=true']);
       expect(result).toEqual({ enabled: true });

--- a/test/unit/core/capabilities.test.ts
+++ b/test/unit/core/capabilities.test.ts
@@ -8,11 +8,13 @@ import {
 } from '../../../src/core/capabilities.js';
 
 describe('buildClientCapabilities', () => {
-  it('always declares roots, sampling, and tasks', () => {
+  it('declares tasks but not unimplemented capabilities (sampling, roots)', () => {
     const caps = buildClientCapabilities();
-    expect(caps.roots).toEqual({ listChanged: true });
-    expect(caps.sampling).toEqual({});
     expect(caps.tasks).toBeDefined();
+    // mcpc has no LLM and registers no roots handler — declaring these would
+    // invite server requests that can only fail with "Method not found".
+    expect(caps.sampling).toBeUndefined();
+    expect(caps.roots).toBeUndefined();
   });
 
   it('omits the client-credentials extension by default', () => {

--- a/test/unit/lib/session-client.test.ts
+++ b/test/unit/lib/session-client.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for SessionClient retry semantics (withRetry).
+ *
+ * The critical invariants under test:
+ * - An IPC timeout is NEVER retried and never restarts the bridge — the bridge
+ *   is likely healthy and still processing the request; restarting would kill
+ *   it and retrying could execute a non-idempotent tool call twice.
+ * - A socket failure restarts the bridge, but non-idempotent operations
+ *   (tool calls) are NOT re-executed — the server may already have run them.
+ * - Idempotent operations (listTools etc.) are retried once after restart.
+ */
+
+import { vi } from 'vitest';
+import { NetworkError, IpcTimeoutError, ServerError } from '../../../src/lib/errors.js';
+
+const restartBridge = vi.fn(async () => ({ pid: 4242 }));
+const updateSession = vi.fn(async () => {});
+const connect = vi.fn(async () => {});
+const replacementRequest = vi.fn(async () => ({ tools: [] }));
+
+vi.mock('../../../src/lib/bridge-manager.js', () => ({
+  restartBridge: (...args: unknown[]) => restartBridge(...(args as [])),
+  ensureBridgeReady: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/sessions.js', () => ({
+  updateSession: (...args: unknown[]) => updateSession(...(args as [])),
+}));
+
+// The BridgeClient created after a restart must not touch a real socket.
+vi.mock('../../../src/lib/bridge-client.js', () => ({
+  BridgeClient: class {
+    connect = connect;
+    close = vi.fn(async () => {});
+    request = replacementRequest;
+    on = vi.fn();
+    removeListener = vi.fn();
+  },
+}));
+
+import { SessionClient } from '../../../src/lib/session-client.js';
+import type { BridgeClient } from '../../../src/lib/bridge-client.js';
+
+/** Build a fake initial BridgeClient whose request() behaves as instructed. */
+function fakeBridgeClient(request: (...args: unknown[]) => Promise<unknown>): BridgeClient {
+  return {
+    request: vi.fn(request),
+    close: vi.fn(async () => {}),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as BridgeClient;
+}
+
+beforeEach(() => {
+  restartBridge.mockClear();
+  updateSession.mockClear();
+  connect.mockClear();
+  replacementRequest.mockClear();
+});
+
+describe('SessionClient.withRetry', () => {
+  it('does not restart or retry on an IPC timeout (tool call)', async () => {
+    const bridge = fakeBridgeClient(async () => {
+      throw new IpcTimeoutError('Request timeout: callTool');
+    });
+    const client = new SessionClient('@test', bridge);
+
+    await expect(client.callTool('deploy', {})).rejects.toThrow(/may still be running/);
+    expect(bridge.request).toHaveBeenCalledTimes(1);
+    expect(restartBridge).not.toHaveBeenCalled();
+  });
+
+  it('does not restart or retry on an IPC timeout (idempotent op)', async () => {
+    const bridge = fakeBridgeClient(async () => {
+      throw new IpcTimeoutError('Request timeout: listTools');
+    });
+    const client = new SessionClient('@test', bridge);
+
+    await expect(client.listTools()).rejects.toThrow(IpcTimeoutError);
+    expect(restartBridge).not.toHaveBeenCalled();
+  });
+
+  it('restarts the bridge but does NOT re-execute a tool call on socket failure', async () => {
+    const bridge = fakeBridgeClient(async () => {
+      throw new NetworkError('Socket closed');
+    });
+    const client = new SessionClient('@test', bridge);
+
+    await expect(client.callTool('deploy', {})).rejects.toThrow(/may or may not have executed/);
+    // Original request attempted once; the replacement client never re-sends it
+    expect(bridge.request).toHaveBeenCalledTimes(1);
+    expect(replacementRequest).not.toHaveBeenCalled();
+    // ...but the bridge WAS restarted so the session recovers
+    expect(restartBridge).toHaveBeenCalledTimes(1);
+  });
+
+  it('restarts the bridge and retries an idempotent operation once on socket failure', async () => {
+    const bridge = fakeBridgeClient(async () => {
+      throw new NetworkError('Socket closed');
+    });
+    const client = new SessionClient('@test', bridge);
+
+    const result = await client.listTools();
+    expect(result).toEqual({ tools: [] });
+    expect(restartBridge).toHaveBeenCalledTimes(1);
+    expect(replacementRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry MCP-level errors', async () => {
+    const bridge = fakeBridgeClient(async () => {
+      throw new ServerError('Tool execution failed');
+    });
+    const client = new SessionClient('@test', bridge);
+
+    await expect(client.listTools()).rejects.toThrow(/Tool execution failed/);
+    expect(restartBridge).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/lib/utils.test.ts
+++ b/test/unit/lib/utils.test.ts
@@ -27,7 +27,9 @@ import {
   truncate,
   isProcessAlive,
   generateRequestId,
+  fetchAllPages,
 } from '../../../src/lib/utils.js';
+import { ServerError } from '../../../src/lib/errors.js';
 import { DEFAULT_AUTH_PROFILE } from '../../../src/lib/auth/oauth-utils.js';
 
 describe('expandHome', () => {
@@ -592,5 +594,53 @@ describe('generateRequestId', () => {
     expect(id1).not.toBe(id2);
     expect(id1).toMatch(/^req_\d+_\d+$/);
     expect(id2).toMatch(/^req_\d+_\d+$/);
+  });
+});
+
+describe('fetchAllPages', () => {
+  it('collects items across all pages', async () => {
+    const pages: Record<string, { items: number[]; nextCursor?: string }> = {
+      start: { items: [1, 2], nextCursor: 'p2' },
+      p2: { items: [3], nextCursor: 'p3' },
+      p3: { items: [4, 5] },
+    };
+    const result = await fetchAllPages(
+      async (cursor) => pages[cursor ?? 'start'],
+      (page) => page.items
+    );
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('returns a single page when there is no nextCursor', async () => {
+    const result = await fetchAllPages(
+      async () => ({ items: ['only'] }),
+      (page) => page.items
+    );
+    expect(result).toEqual(['only']);
+  });
+
+  it('aborts with ServerError when the server repeats a cursor', async () => {
+    // A misbehaving server that always hands back the same cursor would
+    // otherwise loop forever with unbounded memory growth.
+    await expect(
+      fetchAllPages(
+        async () => ({ items: [1], nextCursor: 'same' }),
+        (page) => page.items
+      )
+    ).rejects.toThrow(ServerError);
+  });
+
+  it('aborts with ServerError on a cursor cycle', async () => {
+    const pages: Record<string, { items: number[]; nextCursor?: string }> = {
+      start: { items: [1], nextCursor: 'a' },
+      a: { items: [2], nextCursor: 'b' },
+      b: { items: [3], nextCursor: 'a' }, // cycle back to a
+    };
+    await expect(
+      fetchAllPages(
+        async (cursor) => pages[cursor ?? 'start'],
+        (page) => page.items
+      )
+    ).rejects.toThrow(/pagination cursor/);
   });
 });


### PR DESCRIPTION
Fixes the highest-priority findings from a deep code/security review of the codebase: a retry design that could silently execute a non-idempotent tool call twice, a `--proxy` server open to DNS rebinding (and locked to a single client), and several places where the documented exit-code contract leaked. Also realigns CLAUDE.md with the actual implementation — several of its architecture claims (request multiplexing/queueing, 5-min cache TTL, orphan reaping) described code that doesn't exist.

- IPC timeouts are never retried; tool calls are never re-executed after a bridge crash (the error now says the outcome is unknown)
- Proxy: Host/Origin validation (403), per-session transports, real DELETE termination
- Exit codes: `isError` tool results exit 2, `login` flag mistakes exit 1, all-failed bulk connect exits non-zero in `--json`; `tools-call <tool> --help` schema shortcut un-broken
- Pagination cursor-cycle guard via one shared `fetchAllPages()`; corrupted `sessions.json` backed up instead of wiped; big integers preserved as strings; stdio shutdown no longer orphans server processes
- 19 new unit tests (retry semantics, proxy validation over real HTTP, pagination guard); docs pass over CLAUDE.md/README/CONTRIBUTING

https://claude.ai/code/session_01Vw1kwgHUsX4AuFjjdf2dhT