### PR TITLE
Deduplicate OS keychain unavailable warning across invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The "OS keychain unavailable" warning is now shown only once (on first occurrence) instead of repeating on every command. It reappears if the keychain recovers and later becomes unavailable again.
 - `mcpc login` now explains OAuth client-registration failures with actionable guidance (use `--client-id` or `--client-metadata-url`) instead of surfacing a raw SDK JSON parse error. This affects servers that reject Dynamic Client Registration, such as Figma's remote MCP server, which only accepts an allow-list of approved clients.
 - Tool calls are no longer silently re-executed after a bridge crash or IPC timeout — a slow non-idempotent tool (payment, deploy) could previously run twice. The session is still reconnected automatically, and the error now says whether the call may have executed.
 - `tools-call` and `tasks-result` now exit with code 2 when the tool result reports an error (`isError`), matching the documented exit codes so shell scripts chaining on `&&` stop on failure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The "OS keychain unavailable" warning is now shown only once (on first occurrence) instead of repeating on every command. It reappears if the keychain recovers and later becomes unavailable again.
+- The "OS keychain unavailable" warning no longer repeats on every command. It is now shown once, at the moment credentials are first stored in the fallback file (`~/.mcpc/credentials.json`).
 - `mcpc login` now explains OAuth client-registration failures with actionable guidance (use `--client-id` or `--client-metadata-url`) instead of surfacing a raw SDK JSON parse error. This affects servers that reject Dynamic Client Registration, such as Figma's remote MCP server, which only accepts an allow-list of approved clients.
 - Tool calls are no longer silently re-executed after a bridge crash or IPC timeout — a slow non-idempotent tool (payment, deploy) could previously run twice. The session is still reconnected automatically, and the error now says whether the call may have executed.
 - `tools-call` and `tasks-result` now exit with code 2 when the tool result reports an error (`isError`), matching the documented exit codes so shell scripts chaining on `&&` stop on failure.

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -20,6 +20,7 @@ import { loadSessions, deleteSession, consolidateSessions } from '../../lib/sess
 import { stopBridge } from '../../lib/bridge-manager.js';
 import { createLogger } from '../../lib/logger.js';
 import { deleteAuthProfiles } from '../../lib/auth/profiles.js';
+import { clearKeychainWarningMarker } from '../../lib/auth/keychain.js';
 
 const logger = createLogger('clean');
 
@@ -151,6 +152,9 @@ async function cleanAll(): Promise<CleanResult> {
 
   // Clean logs
   result.logs = await cleanLogs();
+
+  // Reset the one-time "OS keychain unavailable" warning marker
+  await clearKeychainWarningMarker();
 
   // Clean any remaining stale sockets and orphaned logs
   const staleResult = await cleanStale();

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -20,7 +20,6 @@ import { loadSessions, deleteSession, consolidateSessions } from '../../lib/sess
 import { stopBridge } from '../../lib/bridge-manager.js';
 import { createLogger } from '../../lib/logger.js';
 import { deleteAuthProfiles } from '../../lib/auth/profiles.js';
-import { clearKeychainWarningMarker } from '../../lib/auth/keychain.js';
 
 const logger = createLogger('clean');
 
@@ -152,9 +151,6 @@ async function cleanAll(): Promise<CleanResult> {
 
   // Clean logs
   result.logs = await cleanLogs();
-
-  // Reset the one-time "OS keychain unavailable" warning marker
-  await clearKeychainWarningMarker();
 
   // Clean any remaining stale sockets and orphaned logs
   const staleResult = await cleanStale();

--- a/src/lib/auth/keychain.ts
+++ b/src/lib/auth/keychain.ts
@@ -10,11 +10,11 @@
  * file-based fallback is used for the entire session.
  */
 
-import { readFile, writeFile, unlink, access } from 'fs/promises';
+import { readFile, writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import chalk from 'chalk';
 import { createLogger, getJsonMode } from '../logger.js';
-import { getServerHost, getMcpcHome, ensureDir } from '../utils.js';
+import { getServerHost, getMcpcHome, ensureDir, fileExists } from '../utils.js';
 import { withFileLock } from '../file-lock.js';
 
 const logger = createLogger('keychain');
@@ -96,50 +96,10 @@ async function probeKeychain(EntryClass: EntryConstructor): Promise<boolean> {
   }
 }
 
-// Marker file recording that the "OS keychain unavailable" warning was already
-// shown to the user. The in-process dedup (_probePromise) is not enough because
-// every mcpc invocation is a fresh process — without persistent state the
-// warning would repeat on every command.
+// Marker file recording that the "OS keychain unavailable" warning was shown.
+// The in-process dedup (_probePromise) is not enough: every mcpc invocation is
+// a fresh process, so without it the warning would repeat on every command.
 const warningMarkerPath = (): string => join(getMcpcHome(), '.keychain-warning-shown');
-
-async function warningAlreadyShown(): Promise<boolean> {
-  try {
-    await access(warningMarkerPath());
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Remove the marker so the warning shows once again on the next occurrence
- * (used when the keychain is found working, and by `mcpc clean all`).
- * Best-effort: never throws.
- */
-export async function clearKeychainWarningMarker(): Promise<void> {
-  await unlink(warningMarkerPath()).catch(() => {});
-}
-
-async function warnKeychainUnavailable(): Promise<void> {
-  const message =
-    `OS keychain unavailable, ` +
-    `falling back to file-based credential storage (${credentialsPath()}). ` +
-    `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`;
-
-  // Only warn once across invocations; keep a debug-level trace afterwards so
-  // --verbose and log files still record the fallback.
-  if (getJsonMode() || (await warningAlreadyShown())) {
-    logger.debug(message);
-    return;
-  }
-  logger.warn(chalk.red(message));
-  try {
-    await ensureDir(getMcpcHome());
-    await writeFile(warningMarkerPath(), `${new Date().toISOString()}\n`, { mode: 0o600 });
-  } catch {
-    // Best-effort: failing to persist the marker only means the warning may repeat.
-  }
-}
 
 // Serialise the one-time probe so concurrent callers don't race.
 let _probePromise: Promise<void> | null = null;
@@ -157,9 +117,24 @@ async function ensureProbed(): Promise<void> {
       }
       if (keychainAvailable) {
         // Keychain works — clear the marker so a future regression warns again.
-        await clearKeychainWarningMarker();
-      } else {
-        await warnKeychainUnavailable();
+        await unlink(warningMarkerPath()).catch(() => {});
+        return;
+      }
+      const message =
+        `OS keychain unavailable, ` +
+        `falling back to file-based credential storage (${credentialsPath()}). ` +
+        `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`;
+      if (getJsonMode() || (await fileExists(warningMarkerPath()))) {
+        // Warned before (or JSON mode) — keep a trace in verbose/log-file output only.
+        logger.debug(message);
+        return;
+      }
+      logger.warn(chalk.red(message));
+      try {
+        await ensureDir(getMcpcHome());
+        await writeFile(warningMarkerPath(), '', { mode: 0o600 });
+      } catch {
+        // Best-effort — a failed marker write only means the warning may repeat.
       }
     })();
   }

--- a/src/lib/auth/keychain.ts
+++ b/src/lib/auth/keychain.ts
@@ -6,15 +6,16 @@
  *
  * The @napi-rs/keyring native addon is loaded lazily on first use via a
  * cached import() promise.  If the addon or its shared-library dependency
- * (libsecret on Linux) is not present, a one-time warning is emitted and
- * file-based fallback is used for the entire session.
+ * (libsecret on Linux) is not present, file-based fallback is used for the
+ * entire session; a warning is shown once, when the fallback file is first
+ * created (i.e. when credentials actually get stored outside the keychain).
  */
 
-import { readFile, writeFile, unlink } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import chalk from 'chalk';
 import { createLogger, getJsonMode } from '../logger.js';
-import { getServerHost, getMcpcHome, ensureDir, fileExists } from '../utils.js';
+import { getServerHost, getMcpcHome, fileExists } from '../utils.js';
 import { withFileLock } from '../file-lock.js';
 
 const logger = createLogger('keychain');
@@ -36,6 +37,20 @@ async function fileGet(account: string): Promise<string | null> {
 }
 
 async function fileSet(account: string, value: string): Promise<void> {
+  // Warn exactly once, at the moment the fallback file gets created — i.e. when
+  // credentials first start being stored outside the OS keychain. Reads and
+  // subsequent writes stay silent (a debug-level trace is logged on every
+  // fallback occurrence in ensureProbed). The existence check must run before
+  // withFileLock, which pre-creates the file it locks.
+  if (!getJsonMode() && !(await fileExists(credentialsPath()))) {
+    logger.warn(
+      chalk.red(
+        `OS keychain unavailable, ` +
+          `falling back to file-based credential storage (${credentialsPath()}). ` +
+          `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`
+      )
+    );
+  }
   await withFileLock(credentialsPath(), async () => {
     const raw = await readFile(credentialsPath(), 'utf8').catch(() => '{}');
     const data = { ...(JSON.parse(raw) as Record<string, string>), [account]: value };
@@ -96,11 +111,6 @@ async function probeKeychain(EntryClass: EntryConstructor): Promise<boolean> {
   }
 }
 
-// Marker file recording that the "OS keychain unavailable" warning was shown.
-// The in-process dedup (_probePromise) is not enough: every mcpc invocation is
-// a fresh process, so without it the warning would repeat on every command.
-const warningMarkerPath = (): string => join(getMcpcHome(), '.keychain-warning-shown');
-
 // Serialise the one-time probe so concurrent callers don't race.
 let _probePromise: Promise<void> | null = null;
 
@@ -115,26 +125,11 @@ async function ensureProbed(): Promise<void> {
         // import() itself failed (missing native addon / libsecret)
         keychainAvailable = false;
       }
-      if (keychainAvailable) {
-        // Keychain works — clear the marker so a future regression warns again.
-        await unlink(warningMarkerPath()).catch(() => {});
-        return;
-      }
-      const message =
-        `OS keychain unavailable, ` +
-        `falling back to file-based credential storage (${credentialsPath()}). ` +
-        `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`;
-      if (getJsonMode() || (await fileExists(warningMarkerPath()))) {
-        // Warned before (or JSON mode) — keep a trace in verbose/log-file output only.
-        logger.debug(message);
-        return;
-      }
-      logger.warn(chalk.red(message));
-      try {
-        await ensureDir(getMcpcHome());
-        await writeFile(warningMarkerPath(), '', { mode: 0o600 });
-      } catch {
-        // Best-effort — a failed marker write only means the warning may repeat.
+      if (!keychainAvailable) {
+        // Debug-level only: the user-facing warning is emitted once, when the
+        // fallback file is first created (see fileSet). Warning on every probe
+        // would repeat on every mcpc invocation, since each one is a fresh process.
+        logger.debug(`OS keychain unavailable, using file-based credential storage`);
       }
     })();
   }

--- a/src/lib/auth/keychain.ts
+++ b/src/lib/auth/keychain.ts
@@ -10,11 +10,11 @@
  * file-based fallback is used for the entire session.
  */
 
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, unlink, access } from 'fs/promises';
 import { join } from 'path';
 import chalk from 'chalk';
 import { createLogger, getJsonMode } from '../logger.js';
-import { getServerHost, getMcpcHome } from '../utils.js';
+import { getServerHost, getMcpcHome, ensureDir } from '../utils.js';
 import { withFileLock } from '../file-lock.js';
 
 const logger = createLogger('keychain');
@@ -96,6 +96,51 @@ async function probeKeychain(EntryClass: EntryConstructor): Promise<boolean> {
   }
 }
 
+// Marker file recording that the "OS keychain unavailable" warning was already
+// shown to the user. The in-process dedup (_probePromise) is not enough because
+// every mcpc invocation is a fresh process — without persistent state the
+// warning would repeat on every command.
+const warningMarkerPath = (): string => join(getMcpcHome(), '.keychain-warning-shown');
+
+async function warningAlreadyShown(): Promise<boolean> {
+  try {
+    await access(warningMarkerPath());
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Remove the marker so the warning shows once again on the next occurrence
+ * (used when the keychain is found working, and by `mcpc clean all`).
+ * Best-effort: never throws.
+ */
+export async function clearKeychainWarningMarker(): Promise<void> {
+  await unlink(warningMarkerPath()).catch(() => {});
+}
+
+async function warnKeychainUnavailable(): Promise<void> {
+  const message =
+    `OS keychain unavailable, ` +
+    `falling back to file-based credential storage (${credentialsPath()}). ` +
+    `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`;
+
+  // Only warn once across invocations; keep a debug-level trace afterwards so
+  // --verbose and log files still record the fallback.
+  if (getJsonMode() || (await warningAlreadyShown())) {
+    logger.debug(message);
+    return;
+  }
+  logger.warn(chalk.red(message));
+  try {
+    await ensureDir(getMcpcHome());
+    await writeFile(warningMarkerPath(), `${new Date().toISOString()}\n`, { mode: 0o600 });
+  } catch {
+    // Best-effort: failing to persist the marker only means the warning may repeat.
+  }
+}
+
 // Serialise the one-time probe so concurrent callers don't race.
 let _probePromise: Promise<void> | null = null;
 
@@ -110,14 +155,11 @@ async function ensureProbed(): Promise<void> {
         // import() itself failed (missing native addon / libsecret)
         keychainAvailable = false;
       }
-      if (!keychainAvailable && !getJsonMode()) {
-        logger.warn(
-          chalk.red(
-            `OS keychain unavailable, ` +
-              `falling back to file-based credential storage (${credentialsPath()}). ` +
-              `Install a keyring daemon (e.g. gnome-keyring or kwallet) for better security.`
-          )
-        );
+      if (keychainAvailable) {
+        // Keychain works — clear the marker so a future regression warns again.
+        await clearKeychainWarningMarker();
+      } else {
+        await warnKeychainUnavailable();
       }
     })();
   }

--- a/test/unit/lib/auth/keychain.test.ts
+++ b/test/unit/lib/auth/keychain.test.ts
@@ -67,6 +67,7 @@ vi.mock('chalk', () => ({
 
 let testHome: string;
 const credFile = () => join(testHome, 'credentials.json');
+const warningMarkerFile = () => join(testHome, '.keychain-warning-shown');
 
 beforeAll(async () => {
   testHome = join(tmpdir(), `mcpc-keychain-test-${Date.now()}`);
@@ -83,6 +84,7 @@ beforeEach(async () => {
   keychainStore.clear();
   keychainThrows = false;
   await rm(credFile(), { force: true });
+  await rm(warningMarkerFile(), { force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -262,6 +264,56 @@ describe('file fallback when OS keychain unavailable', () => {
 
     expect(await readKeychainSessionHeaders('a')).toEqual({ token: 'aaa' });
     expect(await readKeychainSessionHeaders('b')).toEqual({ token: 'bbb' });
+  });
+
+  it('shows the unavailable warning only once across invocations', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const countWarnings = () =>
+      errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
+        .length;
+
+    try {
+      // First "process": warns and persists the marker file
+      const first = await loadKeychain();
+      await first.storeKeychainSessionHeaders('sess', { token: 'a' });
+      expect(countWarnings()).toBe(1);
+      await expect(stat(warningMarkerFile())).resolves.toBeDefined();
+
+      // Second "process" (fresh module instance): marker exists → no warning
+      const second = await loadKeychain();
+      await second.readKeychainSessionHeaders('sess');
+      expect(countWarnings()).toBe(1);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it('warns again after the keychain recovers and then breaks again', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const countWarnings = () =>
+      errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
+        .length;
+
+    try {
+      // Keychain broken: warning shown, marker written
+      const first = await loadKeychain();
+      await first.storeKeychainSessionHeaders('sess', { token: 'a' });
+      expect(countWarnings()).toBe(1);
+
+      // Keychain recovered: successful probe clears the marker
+      keychainThrows = false;
+      const second = await loadKeychain();
+      await second.storeKeychainSessionHeaders('sess', { token: 'b' });
+      await expect(stat(warningMarkerFile())).rejects.toThrow();
+
+      // Keychain broken again: warning shows once more
+      keychainThrows = true;
+      const third = await loadKeychain();
+      await third.readKeychainSessionHeaders('sess');
+      expect(countWarnings()).toBe(2);
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 
   it('does not retry OS keychain once fallback is active', async () => {

--- a/test/unit/lib/auth/keychain.test.ts
+++ b/test/unit/lib/auth/keychain.test.ts
@@ -288,6 +288,31 @@ describe('file fallback when OS keychain unavailable', () => {
     }
   });
 
+  it('still logs the fallback at debug level after the first warning', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const countWarnings = () =>
+      errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
+        .length;
+
+    try {
+      // First "process": full warning
+      const first = await loadKeychain();
+      await first.storeKeychainSessionHeaders('sess', { token: 'a' });
+      expect(countWarnings()).toBe(1);
+
+      // Second "process" with --verbose: the warning is suppressed by the
+      // marker, but a debug-level trace is still emitted on every occurrence.
+      const second = await loadKeychain();
+      const { setVerbose } = await import('../../../../src/lib/logger.js');
+      setVerbose(true);
+      await second.readKeychainSessionHeaders('sess');
+      expect(countWarnings()).toBe(2);
+      expect(String(errorSpy.mock.calls.at(-1)?.[0])).toContain('[DEBUG]');
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
   it('warns again after the keychain recovers and then breaks again', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const countWarnings = () =>

--- a/test/unit/lib/auth/keychain.test.ts
+++ b/test/unit/lib/auth/keychain.test.ts
@@ -67,7 +67,6 @@ vi.mock('chalk', () => ({
 
 let testHome: string;
 const credFile = () => join(testHome, 'credentials.json');
-const warningMarkerFile = () => join(testHome, '.keychain-warning-shown');
 
 beforeAll(async () => {
   testHome = join(tmpdir(), `mcpc-keychain-test-${Date.now()}`);
@@ -84,7 +83,6 @@ beforeEach(async () => {
   keychainStore.clear();
   keychainThrows = false;
   await rm(credFile(), { force: true });
-  await rm(warningMarkerFile(), { force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -266,75 +264,67 @@ describe('file fallback when OS keychain unavailable', () => {
     expect(await readKeychainSessionHeaders('b')).toEqual({ token: 'bbb' });
   });
 
-  it('shows the unavailable warning only once across invocations', async () => {
+  it('warns once when credentials.json is first created, not on reads', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const countWarnings = () =>
       errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
         .length;
 
     try {
-      // First "process": warns and persists the marker file
+      // Read-only fallback: nothing stored yet → no warning
       const first = await loadKeychain();
+      expect(await first.readKeychainSessionHeaders('sess')).toBeUndefined();
+      expect(countWarnings()).toBe(0);
+
+      // First write creates credentials.json → warning shown once
       await first.storeKeychainSessionHeaders('sess', { token: 'a' });
       expect(countWarnings()).toBe(1);
-      await expect(stat(warningMarkerFile())).resolves.toBeDefined();
+      await first.storeKeychainSessionHeaders('other', { token: 'b' });
+      expect(countWarnings()).toBe(1);
 
-      // Second "process" (fresh module instance): marker exists → no warning
+      // New "process" (fresh module instance): file exists → still no warning
       const second = await loadKeychain();
-      await second.readKeychainSessionHeaders('sess');
+      await second.storeKeychainSessionHeaders('sess', { token: 'c' });
       expect(countWarnings()).toBe(1);
     } finally {
       errorSpy.mockRestore();
     }
   });
 
-  it('still logs the fallback at debug level after the first warning', async () => {
+  it('logs a debug-level trace on every invocation in verbose mode', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const countWarnings = () =>
-      errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
-        .length;
+    const debugTraces = () =>
+      errorSpy.mock.calls.filter(
+        (call) =>
+          String(call[0]).includes('OS keychain unavailable') && String(call[0]).includes('[DEBUG]')
+      ).length;
 
     try {
-      // First "process": full warning
-      const first = await loadKeychain();
-      await first.storeKeychainSessionHeaders('sess', { token: 'a' });
-      expect(countWarnings()).toBe(1);
-
-      // Second "process" with --verbose: the warning is suppressed by the
-      // marker, but a debug-level trace is still emitted on every occurrence.
-      const second = await loadKeychain();
+      const keychain = await loadKeychain();
       const { setVerbose } = await import('../../../../src/lib/logger.js');
       setVerbose(true);
-      await second.readKeychainSessionHeaders('sess');
-      expect(countWarnings()).toBe(2);
-      expect(String(errorSpy.mock.calls.at(-1)?.[0])).toContain('[DEBUG]');
+      await keychain.readKeychainSessionHeaders('sess');
+      expect(debugTraces()).toBe(1);
     } finally {
       errorSpy.mockRestore();
     }
   });
 
-  it('warns again after the keychain recovers and then breaks again', async () => {
+  it('warns again when the fallback file is removed', async () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const countWarnings = () =>
       errorSpy.mock.calls.filter((call) => String(call[0]).includes('OS keychain unavailable'))
         .length;
 
     try {
-      // Keychain broken: warning shown, marker written
       const first = await loadKeychain();
       await first.storeKeychainSessionHeaders('sess', { token: 'a' });
       expect(countWarnings()).toBe(1);
 
-      // Keychain recovered: successful probe clears the marker
-      keychainThrows = false;
+      // Fallback file deleted (e.g. user cleaned ~/.mcpc) → next write re-warns
+      await rm(credFile(), { force: true });
       const second = await loadKeychain();
       await second.storeKeychainSessionHeaders('sess', { token: 'b' });
-      await expect(stat(warningMarkerFile())).rejects.toThrow();
-
-      // Keychain broken again: warning shows once more
-      keychainThrows = true;
-      const third = await loadKeychain();
-      await third.readKeychainSessionHeaders('sess');
       expect(countWarnings()).toBe(2);
     } finally {
       errorSpy.mockRestore();


### PR DESCRIPTION
The "OS keychain unavailable" warning printed on every `mcpc` command: the existing dedup was per-process, but each invocation is a fresh process. The warning is now shown exactly once, at the moment `~/.mcpc/credentials.json` is about to be created — i.e. when credentials first get stored outside the OS keychain. No extra state file is needed; the fallback file itself is the marker.

- Read-only fallback (no credentials stored) no longer warns at all — nothing is at risk
- Every fallback occurrence is still logged at debug level, so `--verbose` and log files record it every time
- Added unit tests for warn-on-creation, silence on reads and later writes, the verbose trace, and re-warning after the fallback file is removed

https://claude.ai/code/session_011pnNfTg453Q2h4mgPyCmUr