### PR TITLE
Support MCP protocol 2026-07-28 with automatic version negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to 2025-11-25 automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
+
 ### Changed
+
+- On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
 
 - Installing mcpc is now much smaller and faster: the viem library used by the experimental x402 payment feature is bundled into a single ~650 KB tree-shaken file at build time instead of installing its ~70 MB dependency tree, and the npm package no longer ships README media (download shrinks from ~7 MB to ~0.4 MB).
 - Commands start much faster (typically ~150 ms instead of ~700 ms): x402/viem, the OAuth login stack, spinners, and the proxy layer are now loaded only when actually used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to 2025-11-25 automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
+- Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
 
 ### Changed
 
 - On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
+
+### Deprecated
+
+- The `logging-set-level` command is deprecated and will be removed in a future release: MCP 2026-07-28 removed the underlying `logging/setLevel` request. It keeps working on 2025-11-25 servers during the deprecation window.
 
 ## [0.5.0] - 2026-07-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,7 +110,8 @@ mcpc/
 
 **1. Core Module (`src/core/`)**
 
-- Thin, runtime-agnostic wrapper around the official `@modelcontextprotocol/sdk` client (works with Node.js ≥22.12 and Bun ≥1)
+- Thin, runtime-agnostic wrapper around the official TypeScript SDK v2 client (`@modelcontextprotocol/client`, works with Node.js ≥22.12 and Bun ≥1)
+- Protocol version negotiation is automatic: the client probes servers with `server/discover` and speaks `2026-07-28` (stateless era) when supported, falling back to the `2025-11-25` `initialize` handshake on the same connection
 - Transport abstraction: Streamable HTTP and stdio (both created via the SDK's transports)
 - Captures negotiated protocol version and MCP session ID after connect
 - Streamable HTTP connection management with reconnection delegated to the SDK (exponential backoff: 1s → 30s max, up to 10 retries)
@@ -204,7 +205,7 @@ Run `mcpc --help` and `mcpc help <command>` for the authoritative, always-curren
 
 **Streamable HTTP:**
 
-- Persistent HTTP connection with bidirectional streaming (protocol version 2025-11-25)
+- Persistent HTTP connection with bidirectional streaming (protocol version 2026-07-28, with automatic fallback to 2025-11-25)
 - Server and client can send messages in both directions over the same connection
 - Automatic reconnection with exponential backoff (1s → 30s max, up to 10 retries, handled by the SDK)
 - CLI-to-bridge IPC requests time out after 3 minutes (or `--timeout` + a 10s margin); an IPC timeout is never retried, since the request may still be executing on the server
@@ -313,13 +314,21 @@ When making changes, follow these rules to maintain the security posture:
 
 ## MCP Protocol Implementation
 
-**Protocol version:** Current latest is `2025-11-25`
+**Protocol version:** Current latest is `2026-07-28` (stateless era); `2025-11-25` remains fully supported via automatic fallback
 
-**Initialization sequence:**
+**Initialization sequence (2026-07-28, "modern" era):**
+
+1. Client probes with `server/discover`; server advertises supported protocol versions, capabilities, and identity
+2. No handshake or session ID — every request carries protocol version, client info, and capabilities in `_meta`
+3. Change notifications are opt-in via a `subscriptions/listen` stream
+
+**Initialization sequence (2025-11-25, "legacy" era fallback):**
 
 1. Client sends `initialize` request with protocol version and client capabilities
 2. Server responds with agreed version and server capabilities
 3. Client sends `initialized` notification to activate session
+
+**Era-dependent behavior in mcpc:** `ping` maps to `server/discover` on modern connections; `logging-set-level` and the task commands are 2025-11-25-only (tasks moved to the `io.modelcontextprotocol/tasks` extension, which the SDK does not implement yet); `resources-subscribe` uses `subscriptions/listen` on modern connections and `resources/subscribe` on legacy ones.
 
 **MCP Primitives:**
 
@@ -575,7 +584,8 @@ All state files are stored in `~/.mcpc/` directory (unless overridden by `MCPC_H
 
 ## Key Dependencies
 
-- `@modelcontextprotocol/sdk` - Official MCP SDK for client/server implementation
+- `@modelcontextprotocol/client` + `@modelcontextprotocol/core` - Official MCP TypeScript SDK v2 (client side; supports protocols 2026-07-28 and 2025-11-25)
+- `@modelcontextprotocol/sdk` - Official MCP SDK v1, used only by the `--proxy` MCP server and the e2e test server (migration to the v2 server packages is a planned follow-up)
 - `commander` - Command-line argument parsing and CLI framework
 - `chalk` - Terminal string styling and colors
 - `@napi-rs/keyring` - OS keychain integration for secure credential storage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ mcpc/
 **1. Core Module (`src/core/`)**
 
 - Thin, runtime-agnostic wrapper around the official TypeScript SDK v2 client (`@modelcontextprotocol/client`, works with Node.js ≥22.12 and Bun ≥1)
-- Protocol version negotiation is automatic: the client probes servers with `server/discover` and speaks `2026-07-28` (stateless era) when supported, falling back to the `2025-11-25` `initialize` handshake on the same connection
+- Protocol version negotiation is automatic: the client probes servers with `server/discover` and speaks `2026-07-28` (stateless era) when supported, falling back to the legacy `initialize` handshake on the same connection (which negotiates `2025-11-25` down to `2024-10-07`)
 - Transport abstraction: Streamable HTTP and stdio (both created via the SDK's transports)
 - Captures negotiated protocol version and MCP session ID after connect
 - Streamable HTTP connection management with reconnection delegated to the SDK (exponential backoff: 1s → 30s max, up to 10 retries)
@@ -314,7 +314,7 @@ When making changes, follow these rules to maintain the security posture:
 
 ## MCP Protocol Implementation
 
-**Protocol version:** Current latest is `2026-07-28` (stateless era); `2025-11-25` remains fully supported via automatic fallback
+**Protocol version:** Current latest is `2026-07-28` (stateless era); `2025-11-25` and older versions (down to `2024-10-07`) remain fully supported via automatic fallback
 
 **Initialization sequence (2026-07-28, "modern" era):**
 

--- a/README.md
+++ b/README.md
@@ -822,7 +822,7 @@ Where `mcpc` stands on each part of the MCP specification:
 
 | **Feature**                                          | **Status**                                                       |
 |:-----------------------------------------------------|:-----------------------------------------------------------------|
-| 📜 **Protocol version**                              | ✅ 2026-07-28 (auto-negotiated), falls back to 2025-11-25         |
+| 📜 **Protocol version**                              | ✅ 2026-07-28 (auto-negotiated), falls back to 2025-11-25 or older |
 | 🔌 **Transport**                                     | ✅ stdio and Streamable HTTP                                      |
 | 🔑 [**Authorization**](#authentication)              | ✅ Bearer + OAuth 2.1 (client credentials, DCR, CIMD, auth code)  |
 | 🔄 [**Sessions**](#sessions)                         | ✅ Supported (with automatic keepalive)                           |
@@ -832,14 +832,14 @@ Where `mcpc` stands on each part of the MCP specification:
 | 💬 [**Prompts**](#prompts)                           | ✅ Supported (incl. list changed notifications)                   |
 | 📦 [**Resources**](#resources)                       | ✅ Supported (incl. subscriptions and list changed notifications) |
 | 🧠 [**Skills**](#skills)                             | 🧪 Experimental (SEP-2640)                                       |
-| 📝 [**Logging**](#server-logs)                       | ✅ Supported (deprecated by MCP)                                  |
+| 📝 [**Logging**](#server-logs)                       | ⚠️ Deprecated (removed by MCP 2026-07-28)                         |
 | 🔔 [**Notifications**](#list-change-notifications)   | ✅ Supported                                                      |
 | 📄 [**Pagination**](#pagination)                     | ✅ Supported                                                      |
 | 🏓 [**Ping**](#ping)                                 | ✅ Supported                                                      |
 | 📁 **Roots**                                         | ❌ Not planned (deprecated by MCP)                                |
 | ❓ **Elicitation**                                   | 🚧 Planned                                                       |
 | 🔤 **Completion**                                    | 🚧 Planned                                                       |
-| 🤖 **Sampling**                                      | ❌ Not applicable (no LLM access)                                 |
+| 🤖 **Sampling**                                      | ❌ Not planned (deprecated by MCP)                                |
 
 Beyond the interactive browser login, the **Authorization** row above also covers the OAuth
 **client-credentials** grant (the [`io.modelcontextprotocol/oauth-client-credentials`](https://modelcontextprotocol.io/extensions/auth/oauth-client-credentials)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MCP through the most universal interface there is: the UNIX shell.
 **Key features:**
 
 - 🔧 [**Full MCP support**](#mcp-support) - Tools, prompts, resources, async tasks, skills, notifications, and logging over stdio and Streamable HTTP.
-- 🔄 **Persistent sessions** - Keep multiple stateful connections to different servers alive in parallel.
+- 🔄 **Persistent sessions** - Keep connections to multiple servers alive in parallel, whether the server protocol is stateful or stateless.
 - 🗺️ **Progressive tool discovery** - Find relevant MCP tools on the fly to save tokens and increase accuracy.
 - 🔌 **Code mode** - JSON output composes with `jq`, `xargs`, and shell pipelines for MCP workflows as shell scripts.
 - 🔒 **Secure** - Full OAuth 2.1 support with CIMD and DCR, uses OS keychain for credentials storage.
@@ -328,11 +328,20 @@ Note that `--json` is not available for `mcpc --help`. For `login`, `--json` pri
 
 ## Sessions
 
-MCP is a [stateful protocol](https://modelcontextprotocol.io/specification/latest/basic/lifecycle):
-clients and servers negotiate protocol version and capabilities, and then communicate within a persistent session.
-To support these sessions, `mcpc` can start a lightweight **bridge process** that maintains the connection and state.
-This is more efficient than forcing every MCP command to reconnect and reinitialize,
-and enables long-term stateful sessions.
+Up to protocol version `2025-11-25`, MCP was a [stateful protocol](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle):
+clients and servers negotiate protocol version and capabilities in an `initialize` handshake,
+and then communicate within a persistent session. Protocol version `2026-07-28` made MCP
+stateless — there is no handshake or server-side session anymore, and every request stands on its own.
+
+`mcpc` keeps one session-based workflow on top of both: you first `connect` a named session,
+then interact with the server through it. On stateful servers the session maps directly to the
+protocol-level MCP session. On stateless (`2026-07-28`) servers the session abstracts the
+protocol away — a lightweight **bridge process** still holds the connection, the negotiated
+protocol version, and client-side state, so everything built on "connect first, then interact"
+keeps working the same: cached tool listings, [searching across sessions](#grep-search-across-sessions)
+with `grep`, server keepalive and status checks by [periodic probing](#ping), change
+notifications, resource-to-file syncs, and automatic OAuth token refresh. It is also more
+efficient than forcing every MCP command to rediscover the server and reauthenticate.
 
 Sessions are given names prefixed with `@` (e.g. `@apify`),
 which then serve as unique references in commands.
@@ -360,7 +369,8 @@ mcpc @apify close      # or: mcpc close @apify
 
 Session metadata is saved in `~/.mcpc/sessions.json`, [authentication tokens](#authentication)
 in the OS keychain. The bridge process keeps the session alive with periodic [pings](#ping)
-and auto-reconnects on network failures or its own crashes (10s cooldown on failed retries).
+(`server/discover` probes on `2026-07-28` servers) and auto-reconnects on network failures
+or its own crashes (10s cooldown on failed retries).
 
 **Session states:**
 
@@ -372,11 +382,12 @@ and auto-reconnects on network failures or its own crashes (10s cooldown on fail
 | 🟡`disconnected` | Bridge process running but server unreachable; auto-recovers when server responds               |
 | 🟡`crashed`      | Bridge process crashed or was killed; auto-reconnects in the background                         |
 | 🔴`unauthorized` | Server rejected authentication (401/403) or token refresh failed; re-run `login` then `restart` |
-| 🔴`expired`      | Server rejected session ID (404); requires `restart`                                            |
+| 🔴`expired`      | Server rejected session ID (404, stateful servers only); requires `restart`                     |
 
 `mcpc` never removes sessions automatically — failed ones stay flagged with a recovery hint
-in the error message. Use `mcpc @apify restart` to kill the bridge and open a fresh
-`MCP-Session-Id`, or `mcpc @apify close` to remove the session entirely.
+in the error message. Use `mcpc @apify restart` to kill the bridge and open a fresh connection
+(with a fresh `MCP-Session-Id` on stateful servers), or `mcpc @apify close` to remove the
+session entirely.
 You can also remove dead sessions by running `mcpc clean`,
 and all sessions by running `mcpc clean all` (see [Cleanup](#cleanup)).
 
@@ -536,7 +547,8 @@ mcpc connect mcp.apify.com @apify --x402
 For stronger isolation, `mcpc` can expose an MCP session as a new local proxy MCP server using the `--proxy` option.
 The proxy forwards all MCP requests to the upstream server but **never exposes the original authentication tokens** to the client.
 This is useful when you want to give someone or something MCP access without revealing your credentials.
-See also [AI sandboxes](#ai-sandboxes).
+The proxy itself serves protocol `2025-11-25` to its clients, regardless of the protocol
+version negotiated with the upstream server. See also [AI sandboxes](#ai-sandboxes).
 
 ```bash
 # Human authenticates to a remote server
@@ -876,7 +888,7 @@ and includes the `_mcpc` field with relevant server/session metadata.
       "tools": { "listChangedAt": "2026-01-01T00:42:58.049Z" }
     }
   },
-  "protocolVersion": "2025-06-18",
+  "protocolVersion": "2026-07-28",
   "capabilities": {
     "logging": {},
     "prompts": {},
@@ -977,7 +989,9 @@ the resource to the file; afterwards the session bridge rewrites the file whenev
 sends a `notifications/resources/updated` notification for the URI (the bridge re-reads the
 resource, as the notification carries no content). Requires the server capability
 `resources.subscribe`; subscriptions are re-established automatically when the session
-reconnects or restarts, and are listed in `mcpc @session` output.
+reconnects or restarts, and are listed in `mcpc @session` output. On the wire, mcpc uses
+`resources/subscribe` on `2025-11-25` servers and a `subscriptions/listen` stream on
+`2026-07-28` servers (re-opened automatically if it drops) — the commands are identical.
 
 ```bash
 # Keep ./config.json in sync with the server resource
@@ -1025,7 +1039,8 @@ never executes hooks, scripts, or other frontmatter-declared behavior.
 #### List change notifications
 
 When connected via a [session](#sessions), `mcpc` automatically handles `list_changed`
-notifications for tools, resources, and prompts.
+notifications for tools, resources, and prompts (delivered over the `subscriptions/listen`
+stream on `2026-07-28` servers, and as unsolicited notifications on `2025-11-25` ones).
 The bridge process tracks when each notification type was last received.
 The timestamps are available in the JSON output of `mcpc @session --json` under the `_mcpc.notifications`
 field - see [Server instructions](#server-instructions).
@@ -1049,6 +1064,10 @@ mcpc @apify logging-set-level error
 Note that this sets the logging level on the **server side**.
 The actual log output depends on the server's implementation.
 
+> ⚠️ **Deprecated.** MCP `2026-07-28` removed `logging/setLevel`, so `logging-set-level` works
+> only on servers using protocol `2025-11-25` or older and will be removed in a future mcpc
+> release. Server log messages (`notifications/message`) are still recorded in the bridge log.
+
 #### Pagination
 
 MCP servers may return paginated results for list operations
@@ -1066,6 +1085,10 @@ Send a ping to check if a server connection is alive:
 mcpc @apify ping
 mcpc @apify ping --json
 ```
+
+Protocol version `2026-07-28` removed the `ping` request, so on servers using it `mcpc`
+sends a `server/discover` probe instead — same round trip, same liveness signal, and the
+command works identically on both protocol versions.
 
 #### Async tasks
 
@@ -1100,6 +1123,10 @@ completes.
 
 `tools-list` and `tools-get` show task support annotations per tool:
 `[task:optional]`, `[task:required]`, or `[task:forbidden]`.
+
+Task commands require a server using protocol `2025-11-25`. In `2026-07-28` tasks moved to
+the `io.modelcontextprotocol/tasks` extension, which `mcpc` does not support yet — task
+commands on such servers return an error explaining this.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -822,12 +822,13 @@ Where `mcpc` stands on each part of the MCP specification:
 
 | **Feature**                                          | **Status**                                                       |
 |:-----------------------------------------------------|:-----------------------------------------------------------------|
+| 📜 **Protocol version**                              | ✅ 2026-07-28 (auto-negotiated), falls back to 2025-11-25         |
 | 🔌 **Transport**                                     | ✅ stdio and Streamable HTTP                                      |
 | 🔑 [**Authorization**](#authentication)              | ✅ Bearer + OAuth 2.1 (client credentials, DCR, CIMD, auth code)  |
 | 🔄 [**Sessions**](#sessions)                         | ✅ Supported (with automatic keepalive)                           |
 | 📖 [**Server instructions**](#server-instructions)   | ✅ Supported                                                      |
 | 🔧 [**Tools**](#tools)                               | ✅ Supported (incl. list changed notifications)                   |
-| ⏳ [**Async tasks**](#async-tasks)                   | ✅ Supported                                                      |
+| ⏳ [**Async tasks**](#async-tasks)                   | ✅ Supported (2025-11-25 servers; 2026-07-28 tasks extension planned) |
 | 💬 [**Prompts**](#prompts)                           | ✅ Supported (incl. list changed notifications)                   |
 | 📦 [**Resources**](#resources)                       | ✅ Supported (incl. subscriptions and list changed notifications) |
 | 🧠 [**Skills**](#skills)                             | 🧪 Experimental (SEP-2640)                                       |

--- a/README.md
+++ b/README.md
@@ -1039,8 +1039,13 @@ never executes hooks, scripts, or other frontmatter-declared behavior.
 #### List change notifications
 
 When connected via a [session](#sessions), `mcpc` automatically handles `list_changed`
-notifications for tools, resources, and prompts (delivered over the `subscriptions/listen`
-stream on `2026-07-28` servers, and as unsolicited notifications on `2025-11-25` ones).
+notifications for tools, resources, and prompts. On `2025-11-25` servers these arrive as
+unsolicited notifications; on `2026-07-28` servers (where unsolicited notifications no
+longer exist) the session bridge opts in by opening a `subscriptions/listen` stream at
+connect and re-opens it automatically if it drops — the behavior is identical from the
+outside. As a safety net on `2026-07-28` connections, the bridge's tools cache also
+expires after 60 seconds, so a missed notification can never leave `tools-list` or
+[`grep`](#grep-search-across-sessions) stale for long.
 The bridge process tracks when each notification type was last received.
 The timestamps are available in the JSON output of `mcpc @session --json` under the `_mcpc.notifications`
 field - see [Server instructions](#server-instructions).

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "release:pre": "bash scripts/publish.sh --pre-release"
   },
   "dependencies": {
+    "@modelcontextprotocol/client": "2.0.0-beta.4",
+    "@modelcontextprotocol/core": "2.0.0-beta.4",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "^5.6.2",
@@ -66,13 +68,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "esbuild": "^0.28.1",
     "@types/node": "^25.9.4",
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",
     "@vitest/coverage-v8": "4.1.9",
     "c8": "^11.0.0",
     "doctoc": "^2.5.0",
+    "esbuild": "^0.28.1",
     "eslint": "^10.6.0",
     "globals": "^17.7.0",
     "markdown-link-check": "^3.14.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/client':
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4
+      '@modelcontextprotocol/core':
+        specifier: 2.0.0-beta.4
+        version: 2.0.0-beta.4
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -420,6 +426,14 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/client@2.0.0-beta.4':
+    resolution: {integrity: sha512-VNHA/UXDk7mCpVl+jOg5B4WMRRD2OEl+it360Lhi6HiCbrIB2f6pZ0cqSDKXQVUtZvqnhdQHzZAM9h8EKWhq/A==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0-beta.4':
+    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
+    engines: {node: '>=20'}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2916,6 +2930,20 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/client@2.0.0-beta.4':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.4
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      jose: 6.2.3
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@modelcontextprotocol/core@2.0.0-beta.4':
+    dependencies:
+      zod: 4.4.3
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -239,7 +239,7 @@ mcpc @apify skills-get <name> --raw    # print the SKILL.md markdown (pipe to a 
 mcpc --verbose @apify tools-call <tool>   # protocol-level detail (JSON-RPC, transport)
 mcpc @apify logs                          # bridge log; -n <N>, --follow, --since 1h
 mcpc @apify ping                          # round-trip health check
-mcpc @apify logging-set-level debug       # ask the server to log more (2025-11-25 servers only)
+mcpc @apify logging-set-level debug       # deprecated; 2025-11-25 servers only, will be removed
 mcpc clean                                # tidy stale sessions/logs (also: mcpc clean all)
 ```
 

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -165,6 +165,9 @@ mcpc @apify tasks-result <taskId>               # block until the final result i
 mcpc @apify tasks-cancel <taskId>
 ```
 
+Task commands need a server on MCP protocol 2025-11-25; on 2026-07-28 servers
+they return an error (the new tasks extension is not supported yet).
+
 ## Authentication
 
 ```bash
@@ -236,7 +239,7 @@ mcpc @apify skills-get <name> --raw    # print the SKILL.md markdown (pipe to a 
 mcpc --verbose @apify tools-call <tool>   # protocol-level detail (JSON-RPC, transport)
 mcpc @apify logs                          # bridge log; -n <N>, --follow, --since 1h
 mcpc @apify ping                          # round-trip health check
-mcpc @apify logging-set-level debug       # ask the server to log more (server-side level)
+mcpc @apify logging-set-level debug       # ask the server to log more (2025-11-25 servers only)
 mcpc clean                                # tidy stale sessions/logs (also: mcpc clean all)
 ```
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1368,13 +1368,19 @@ class BridgeProcess {
           if (!this.resourceSync) {
             throw new NetworkError('MCP client not connected');
           }
-          const details = await this.client.getServerDetails();
-          if (!details.capabilities?.resources?.subscribe) {
-            throw new ClientError(
-              `Server does not support resource subscriptions (no resources.subscribe capability).\n` +
-                `To download the resource once instead, run:\n` +
-                `  mcpc ${this.options.sessionName} resources-read ${params.uri} -o <file>`
-            );
+          // The resources.subscribe capability flag exists only in the 2025-era protocol.
+          // On 2026-07-28 connections subscription support is signalled by the
+          // subscriptions/listen acknowledgment instead, so let the subscribe attempt
+          // decide there — it fails loudly when the server does not honor the URI.
+          if (this.client.getProtocolEra() !== 'modern') {
+            const details = await this.client.getServerDetails();
+            if (!details.capabilities?.resources?.subscribe) {
+              throw new ClientError(
+                `Server does not support resource subscriptions (no resources.subscribe capability).\n` +
+                  `To download the resource once instead, run:\n` +
+                  `  mcpc ${this.options.sessionName} resources-read ${params.uri} -o <file>`
+              );
+            }
           }
           await this.client.subscribeResource(params.uri);
           try {

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -35,18 +35,11 @@ import { getSession, loadSessions, updateSession } from '../lib/sessions.js';
 import type { AuthCredentials, X402WalletCredentials } from '../lib/types.js';
 import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { OAuthProvider } from '../lib/auth/oauth-provider.js';
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { OAuthClientProvider } from '@modelcontextprotocol/client';
 import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/auth/keychain.js';
 import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
 import { createClientCredentialsProvider } from '../lib/auth/client-credentials.js';
-import {
-  LoggingMessageNotificationSchema,
-  ResourceUpdatedNotificationSchema,
-  type Tool,
-  type Resource,
-  type Prompt,
-  type Task,
-} from '@modelcontextprotocol/sdk/types.js';
+import type { Tool, Resource, Prompt, Task } from '@modelcontextprotocol/client';
 import { ResourceSyncManager } from './resource-sync.js';
 import type { TaskUpdate } from '../lib/types.js';
 import { createRequire } from 'module';
@@ -59,7 +52,7 @@ import type { ProxyConfig } from '../lib/types.js';
 // only here and load the implementations lazily at the x402-gated call sites.
 import type { X402PaymentCache } from '../lib/x402/fetch-middleware.js';
 import type { SignerWallet } from '../lib/x402/signer.js';
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { FetchLike } from '@modelcontextprotocol/client';
 
 // HTTP proxy and TLS settings are configured in main() after parsing --insecure flag
 
@@ -692,11 +685,9 @@ class BridgeProcess {
     logger.debug('MCP client created successfully, authProvider was:', !!clientConfig.authProvider);
 
     // Record server logging messages in the bridge log (viewable via `mcpc @session logs`)
-    this.client
-      .getSDKClient()
-      .setNotificationHandler(LoggingMessageNotificationSchema, (notification) => {
-        logger.info('[server log]', notification.params);
-      });
+    this.client.getSDKClient().setNotificationHandler('notifications/message', (notification) => {
+      logger.info('[server log]', notification.params);
+    });
 
     // Resource→file sync (resources-subscribe): load persisted subscriptions and
     // re-sync local files when the server announces a resource changed. Per the MCP
@@ -712,7 +703,7 @@ class BridgeProcess {
     this.resourceSync.load(sessionData?.resourceSubscriptions);
     this.client
       .getSDKClient()
-      .setNotificationHandler(ResourceUpdatedNotificationSchema, (notification) => {
+      .setNotificationHandler('notifications/resources/updated', (notification) => {
         logger.debug(`Resource updated notification: ${notification.params.uri}`);
         this.resourceSync?.handleUpdated(notification.params.uri);
       });
@@ -933,11 +924,15 @@ class BridgeProcess {
   private async handlePossibleExpiration(error: Error): Promise<void> {
     // ServerError wraps errors from mcp-client.ts methods. Check the original error
     // to distinguish application-level JSON-RPC errors (tool not found, etc.) from
-    // transport-level errors (HTTP 401/403/404). The SDK's McpError class (name: 'McpError')
-    // indicates a JSON-RPC error response — these are application-level and should be skipped.
+    // transport-level errors (HTTP 401/403/404). The SDK's ProtocolError class (named
+    // 'McpError' in SDK v1) indicates a JSON-RPC error response — these are
+    // application-level and should be skipped.
     if (error instanceof ServerError) {
       const originalError = (error.details as { originalError?: Error } | undefined)?.originalError;
-      if (originalError && originalError.name === 'McpError') {
+      if (
+        originalError &&
+        (originalError.name === 'ProtocolError' || originalError.name === 'McpError')
+      ) {
         return;
       }
     }

--- a/src/bridge/resource-sync.ts
+++ b/src/bridge/resource-sync.ts
@@ -12,7 +12,7 @@
  * re-syncs on startup.
  */
 
-import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ReadResourceResult } from '@modelcontextprotocol/client';
 import type { ResourceSubscriptionEntry, ResourceSyncResult } from '../lib/types.js';
 import { selectResourceContent, writeResourceFile } from '../lib/resource-content.js';
 import { ClientError } from '../lib/errors.js';

--- a/src/cli/commands/logging.ts
+++ b/src/cli/commands/logging.ts
@@ -3,7 +3,7 @@
  */
 
 import type { LoggingLevel, CommandOptions } from '../../lib/types.js';
-import { formatOutput, formatSuccess } from '../output.js';
+import { formatOutput, formatSuccess, formatWarning } from '../output.js';
 import { ClientError } from '../../lib/errors.js';
 import { withMcpClient } from '../helpers.js';
 
@@ -39,6 +39,12 @@ export async function setLogLevel(
 
     if (options.outputMode === 'human') {
       console.log(formatSuccess(`Server log level set to: ${level}`));
+      console.error(
+        formatWarning(
+          'logging-set-level is deprecated (MCP removed logging/setLevel in 2026-07-28) ' +
+            'and will be removed in a future mcpc release.'
+        )
+      );
     } else {
       console.log(formatOutput({ level }, 'json'));
     }

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -19,7 +19,7 @@
  */
 
 import type { CommandOptions, IMcpClient } from '../../lib/types.js';
-import type { ReadResourceResult, Resource } from '@modelcontextprotocol/sdk/types.js';
+import type { ReadResourceResult, Resource } from '@modelcontextprotocol/client';
 import { ServerError, ClientError } from '../../lib/errors.js';
 import { fetchAllPages } from '../../lib/utils.js';
 import { withMcpClient } from '../helpers.js';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -503,7 +503,8 @@ ${chalk.bold('Stdio servers (command-based, run locally):')}
 
 ${chalk.bold('Protocol version:')}
   mcpc negotiates MCP 2026-07-28 with servers that support it and falls
-  back to 2025-11-25 automatically. Run mcpc @session to see the version.
+  back to older versions (2025-11-25 down to 2024-10-07) automatically.
+  Run mcpc @session to see the negotiated version.
 ${jsonHelp(
   'Array of `InitializeResult` objects (one per session), extended with `toolNames` and `_mcpc` metadata',
   '`[{ protocolVersion?, capabilities?, serverInfo?, instructions?, toolNames?, _mcpc: { sessionName, server?, ... }]`',
@@ -1369,7 +1370,10 @@ ${jsonHelp('`GetPromptResult` object', '`{ description?, messages: [{ role, cont
   // Logging commands
   program
     .command('logging-set-level <level>')
-    .description('Set MCP server logging level (2025-11-25 servers only; removed in 2026-07-28).')
+    .description(
+      'Set MCP server logging level (deprecated: removed in MCP 2026-07-28, works on ' +
+        '2025-11-25 servers only, and will be removed in a future mcpc release).'
+    )
     .addHelpText('after', jsonHelp('`{ level: string }`'))
     .action(async (level, _options, command) => {
       await logging.setLogLevel(session, level, getOptionsFromCommand(command));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -500,6 +500,10 @@ ${chalk.bold('Stdio servers (command-based, run locally):')}
   Config entries spawn the command on connect, even if the handshake
   later fails — only connect to configs you trust. Bulk connects skip
   stdio by default; pass --stdio to include them.
+
+${chalk.bold('Protocol version:')}
+  mcpc negotiates MCP 2026-07-28 with servers that support it and falls
+  back to 2025-11-25 automatically. Run mcpc @session to see the version.
 ${jsonHelp(
   'Array of `InitializeResult` objects (one per session), extended with `toolNames` and `_mcpc` metadata',
   '`[{ protocolVersion?, capabilities?, serverInfo?, instructions?, toolNames?, _mcpc: { sessionName, server?, ... }]`',
@@ -1113,6 +1117,8 @@ ${chalk.bold('Async tasks (--task, --detach):')}
   If you press Ctrl+C, the task keeps running and a hint with the task ID
   is printed so you can fetch or cancel it later.
   --detach returns the task ID immediately without waiting.
+  Tasks require a server using MCP protocol 2025-11-25 (on 2026-07-28
+  servers tasks are an extension not yet supported by mcpc).
 
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)
@@ -1363,7 +1369,7 @@ ${jsonHelp('`GetPromptResult` object', '`{ description?, messages: [{ role, cont
   // Logging commands
   program
     .command('logging-set-level <level>')
-    .description('Set MCP server logging level.')
+    .description('Set MCP server logging level (2025-11-25 servers only; removed in 2026-07-28).')
     .addHelpText('after', jsonHelp('`{ level: string }`'))
     .action(async (level, _options, command) => {
       await logging.setLogLevel(session, level, getOptionsFromCommand(command));
@@ -1372,7 +1378,7 @@ ${jsonHelp('`GetPromptResult` object', '`{ description?, messages: [{ role, cont
   // Server commands
   program
     .command('ping')
-    .description('Ping the MCP server.')
+    .description('Ping the MCP server (uses server/discover on 2026-07-28 servers).')
     .addHelpText('after', jsonHelp('`{ success: true, durationMs: number }`'))
     .action(async (_options, command) => {
       await utilities.ping(session, getOptionsFromCommand(command));

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -9,7 +9,7 @@ import type {
   PromptMessage,
   ContentBlock,
   ReadResourceResult,
-} from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/client';
 import type { OutputMode } from '../lib/index.js';
 import type {
   Tool,
@@ -1321,13 +1321,21 @@ function findDuplicateTextBlocks(
 export function formatCallToolResultHuman(result: CallToolResult): string {
   const lines: string[] = [];
 
-  // Identify text blocks that are just a JSON dump of structuredContent
+  // Identify text blocks that are just a JSON dump of structuredContent.
+  // Since protocol 2026-07-28 (SEP-2106), structuredContent may be any JSON value,
+  // so narrow to a plain object before key-based duplicate detection.
   const sc = result.structuredContent;
-  const hasStructuredContent = !!sc && Object.keys(sc).length > 0;
+  const scObject =
+    typeof sc === 'object' && sc !== null && !Array.isArray(sc)
+      ? (sc as Record<string, unknown>)
+      : undefined;
+  const hasStructuredContent = scObject
+    ? Object.keys(scObject).length > 0
+    : sc !== undefined && sc !== null;
   const content = result.content;
   let skipIndices = new Set<number>();
-  if (hasStructuredContent && content && sc) {
-    skipIndices = findDuplicateTextBlocks(content, sc);
+  if (hasStructuredContent && content && scObject) {
+    skipIndices = findDuplicateTextBlocks(content, scObject);
   }
 
   const visibleContent = content?.filter((_, i) => !skipIndices.has(i)) ?? [];

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -2,7 +2,7 @@
  * Client capabilities advertised by mcpc during connection.
  */
 
-import type { ClientCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import type { ClientCapabilities } from '@modelcontextprotocol/client';
 
 /**
  * Capability key advertising client-credentials auth support, per the MCP extension

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -135,6 +135,14 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     ...(options.serverConfig.command && { stdioTransport: true }),
   };
 
+  // Tolerate tool schemas stamped with pre-2020-12 dialects (draft-07 etc.), which the
+  // SDK's default validator rejects outright — most 2025-era servers emit them.
+  // Loaded dynamically so the bundled AJV engine is only paid for when a client is created.
+  if (!clientOptions.jsonSchemaValidator) {
+    const { DialectAwareJsonSchemaValidator } = await import('./json-schema-validator.js');
+    clientOptions.jsonSchemaValidator = new DialectAwareJsonSchemaValidator();
+  }
+
   const client = new McpClient(options.clientInfo, clientOptions);
 
   // Create and connect transport if autoConnect is true

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -2,9 +2,12 @@
  * Factory functions for creating MCP clients with transports
  */
 
-import type { ClientCapabilities, ListChangedHandlers } from '@modelcontextprotocol/sdk/types.js';
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type {
+  ClientCapabilities,
+  ListChangedHandlers,
+  OAuthClientProvider,
+  FetchLike,
+} from '@modelcontextprotocol/client';
 import { McpClient, type McpClientOptions } from './mcp-client.js';
 import { createTransportFromConfig } from './transports.js';
 import { type ServerConfig } from '../lib/types.js';
@@ -127,6 +130,9 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     ...(options.serverConfig.timeout && {
       requestTimeoutMillis: options.serverConfig.timeout * 1000,
     }),
+    // Cap the version-negotiation probe timeout on stdio (local servers answer fast;
+    // some legacy ones never answer pre-initialize requests at all)
+    ...(options.serverConfig.command && { stdioTransport: true }),
   };
 
   const client = new McpClient(options.clientInfo, clientOptions);

--- a/src/core/json-schema-validator.ts
+++ b/src/core/json-schema-validator.ts
@@ -24,8 +24,15 @@ import {
   addFormats,
 } from '@modelcontextprotocol/client/validators/ajv';
 
-/** `$schema` URIs of pre-2020-12 dialects routed to the draft-07 engine. */
-const LEGACY_DIALECT_PATTERN = /^https?:\/\/json-schema\.org\/draft-0[467]\/schema#?$/;
+/**
+ * `$schema` URIs of pre-2020-12 dialects routed to the tolerant draft-07 engine.
+ * Includes draft 2019-09: the SDK's default engine rejects its dialect URI outright,
+ * while the draft-07 engine (strict mode off, schema self-validation off) compiles it
+ * and simply ignores the few 2019-09-only keywords — validating is strictly better
+ * than failing every call to such a tool.
+ */
+const LEGACY_DIALECT_PATTERN =
+  /^https?:\/\/json-schema\.org\/(draft-0[467]|draft\/2019-09)\/schema#?$/;
 
 export class DialectAwareJsonSchemaValidator implements jsonSchemaValidator {
   /** SDK default engine (JSON Schema 2020-12), constructed lazily by the SDK itself. */

--- a/src/core/json-schema-validator.ts
+++ b/src/core/json-schema-validator.ts
@@ -1,0 +1,55 @@
+/**
+ * Dialect-aware JSON Schema validator for tool output validation.
+ *
+ * Protocol 2026-07-28 (SEP-2106) standardizes tool schemas on JSON Schema 2020-12, and the
+ * SDK's default validator hard-fails any schema stamped with an older `$schema` dialect.
+ * Most existing 2025-era servers, however, generate their `outputSchema` with
+ * zod-to-json-schema, which stamps `"$schema": "http://json-schema.org/draft-07/schema#"` —
+ * with the default validator every `tools/call` against such a tool fails before the request
+ * is even sent (e.g. @modelcontextprotocol/server-filesystem's `read_file`).
+ *
+ * This provider routes schemas declaring a legacy dialect to a draft-07 AJV engine (the
+ * SDK v1 behavior, using the engine the SDK re-exports for exactly this purpose) and
+ * everything else to the SDK's default 2020-12 engine. Engines are constructed lazily.
+ */
+
+import type {
+  JsonSchemaType,
+  JsonSchemaValidator,
+  jsonSchemaValidator,
+} from '@modelcontextprotocol/client';
+import {
+  Ajv,
+  AjvJsonSchemaValidator,
+  addFormats,
+} from '@modelcontextprotocol/client/validators/ajv';
+
+/** `$schema` URIs of pre-2020-12 dialects routed to the draft-07 engine. */
+const LEGACY_DIALECT_PATTERN = /^https?:\/\/json-schema\.org\/draft-0[467]\/schema#?$/;
+
+export class DialectAwareJsonSchemaValidator implements jsonSchemaValidator {
+  /** SDK default engine (JSON Schema 2020-12), constructed lazily by the SDK itself. */
+  private modernValidator = new AjvJsonSchemaValidator();
+  /** Draft-07 engine for legacy-stamped schemas, constructed on first use. */
+  private legacyValidator: AjvJsonSchemaValidator | undefined;
+
+  getValidator<T>(schema: JsonSchemaType): JsonSchemaValidator<T> {
+    const dialect = (schema as { $schema?: unknown }).$schema;
+    if (typeof dialect === 'string' && LEGACY_DIALECT_PATTERN.test(dialect)) {
+      if (!this.legacyValidator) {
+        // The documented v1-equivalent construction: validateSchema off so a stamped
+        // `$schema` never fails engine-side, formats registered to keep `format` checks.
+        const ajv = new Ajv({
+          strict: false,
+          validateFormats: true,
+          validateSchema: false,
+          allErrors: true,
+        });
+        addFormats(ajv);
+        this.legacyValidator = new AjvJsonSchemaValidator(ajv);
+      }
+      return this.legacyValidator.getValidator<T>(schema);
+    }
+    return this.modernValidator.getValidator<T>(schema);
+  }
+}

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -554,7 +554,19 @@ export class McpClient implements IMcpClient {
       this.logger.debug(`Subscribing to resource: ${uri}`);
       if (this.getProtocolEra() === 'modern') {
         this.modernSubscribedUris.add(uri);
-        await this.reopenModernListen();
+        try {
+          await this.reopenModernListen();
+        } catch (error) {
+          // Roll back so re-listen attempts don't keep requesting the rejected URI,
+          // and restore the stream for any previously honored subscriptions.
+          this.modernSubscribedUris.delete(uri);
+          if (this.modernSubscribedUris.size > 0) {
+            await this.reopenModernListen().catch((reopenError) => {
+              this.logger.warn('Failed to restore listen stream after rollback:', reopenError);
+            });
+          }
+          throw error;
+        }
       } else {
         await this.client.subscribeResource({ uri }, this.getRequestOptions());
       }
@@ -608,6 +620,22 @@ export class McpClient implements IMcpClient {
       { resourceSubscriptions: [...this.modernSubscribedUris] },
       this.getRequestOptions()
     );
+
+    // The listen acknowledgment is the 2026-07-28 signal for subscription support
+    // (there is no resources.subscribe capability flag anymore) — fail loudly when
+    // the server did not agree to deliver updates for a requested URI.
+    const honoredUris = new Set(subscription.honoredFilter.resourceSubscriptions ?? []);
+    const unhonoredUris = [...this.modernSubscribedUris].filter((uri) => !honoredUris.has(uri));
+    if (unhonoredUris.length > 0) {
+      await subscription.close().catch((error) => {
+        this.logger.debug('Error closing unhonored listen stream (ignored):', error);
+      });
+      throw new ServerError(
+        `Server does not support subscriptions for ${unhonoredUris.join(', ')} ` +
+          `(not honored in the subscriptions/listen acknowledgment)`
+      );
+    }
+
     this.modernListen = subscription;
 
     // Re-listen only on unexpected drops; 'local' and 'graceful' closes are deliberate.

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -4,7 +4,12 @@
  */
 
 import { Client as SDKClient, type ClientOptions } from '@modelcontextprotocol/client';
-import type { Transport, McpSubscription, ProtocolEra } from '@modelcontextprotocol/client';
+import type {
+  Transport,
+  McpSubscription,
+  ProtocolEra,
+  SubscriptionFilter,
+} from '@modelcontextprotocol/client';
 import type {
   Implementation,
   ListToolsResult,
@@ -258,6 +263,11 @@ export class McpClient implements IMcpClient {
         this.mcpSessionId = transport.sessionId;
         this.logger.debug(`MCP session ID: ${this.mcpSessionId}`);
       }
+
+      // On 2026-07-28 connections the SDK auto-opens a subscriptions/listen stream for
+      // the configured listChanged handlers, but never re-opens it after a drop —
+      // without this watch, list-change notifications would silently stop.
+      this.watchListChangedStream(this.client.autoOpenedSubscription);
 
       const serverVersion = this.client.getServerVersion();
       const serverCapabilities = this.client.getServerCapabilities();
@@ -646,7 +656,37 @@ export class McpClient implements IMcpClient {
     });
   }
 
-  /** Re-establish the listen stream after a remote drop, backing off 1s → 30s. */
+  /**
+   * Re-open the listChanged `subscriptions/listen` stream when it drops unexpectedly
+   * (2026-07-28 connections). Notifications on the new stream dispatch to the handlers
+   * the SDK registered at connect, so delivery resumes transparently.
+   */
+  private watchListChangedStream(subscription: McpSubscription | undefined): void {
+    if (!subscription) return;
+    void subscription.closed.then((reason) => {
+      if (reason !== 'remote' || this.isClosing) return;
+      void this.relistenListChangedWithBackoff(subscription.honoredFilter);
+    });
+  }
+
+  /** Re-establish the listChanged listen stream after a remote drop, backing off 1s → 30s. */
+  private async relistenListChangedWithBackoff(filter: SubscriptionFilter): Promise<void> {
+    let delayMillis = RELISTEN_INITIAL_DELAY_MILLIS;
+    while (!this.isClosing) {
+      await new Promise((resolve) => setTimeout(resolve, delayMillis));
+      try {
+        const subscription = await this.client.listen(filter, this.getRequestOptions());
+        this.watchListChangedStream(subscription);
+        this.logger.debug('listChanged listen stream re-established');
+        return;
+      } catch (error) {
+        this.logger.debug(`listChanged re-listen failed, retrying in ${delayMillis * 2}ms:`, error);
+        delayMillis = Math.min(delayMillis * 2, RELISTEN_MAX_DELAY_MILLIS);
+      }
+    }
+  }
+
+  /** Re-establish the resource-subscription listen stream after a remote drop, backing off 1s → 30s. */
   private async relistenWithBackoff(): Promise<void> {
     let delayMillis = RELISTEN_INITIAL_DELAY_MILLIS;
     while (!this.isClosing && this.modernSubscribedUris.size > 0 && !this.modernListen) {

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -1,10 +1,10 @@
 /**
  * MCP Client wrapper
- * Wraps the @modelcontextprotocol/sdk Client class with additional functionality
+ * Wraps the @modelcontextprotocol/client (SDK v2) Client class with additional functionality
  */
 
-import { Client as SDKClient, type ClientOptions } from '@modelcontextprotocol/sdk/client/index.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { Client as SDKClient, type ClientOptions } from '@modelcontextprotocol/client';
+import type { Transport, McpSubscription, ProtocolEra } from '@modelcontextprotocol/client';
 import type {
   Implementation,
   ListToolsResult,
@@ -19,8 +19,14 @@ import type {
   ListTasksResult,
   CancelTaskResult,
   Tool,
-} from '@modelcontextprotocol/sdk/types.js';
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/client';
+import {
+  CallToolResultSchema,
+  CreateTaskResultSchema,
+  ListTasksResultSchema,
+  GetTaskResultSchema,
+  CancelTaskResultSchema,
+} from '@modelcontextprotocol/core';
 import { createNoOpLogger, type Logger } from '../lib/logger.js';
 import { ServerError, NetworkError, isShutdownError } from '../lib/errors.js';
 import { fetchAllPages } from '../lib/utils.js';
@@ -36,7 +42,7 @@ function getRootCauseMessage(error: Error): string {
   return current.message;
 }
 import type { IMcpClient, ServerDetails, ConnectionMode, TaskUpdate } from '../lib/types.js';
-import type { Task } from '@modelcontextprotocol/sdk/types.js';
+import type { Task } from '@modelcontextprotocol/client';
 
 /**
  * Convert an SDK Task to a TaskUpdate, handling exactOptionalPropertyTypes
@@ -84,6 +90,12 @@ export interface McpClientOptions extends ClientOptions {
    * Defaults to DEFAULT_REQUEST_TIMEOUT_MILLIS (60 seconds) when not specified.
    */
   requestTimeoutMillis?: number;
+
+  /**
+   * Set when the client will connect over a stdio transport. Caps the
+   * version-negotiation probe timeout (see STDIO_PROBE_TIMEOUT_MILLIS).
+   */
+  stdioTransport?: boolean;
 }
 
 /**
@@ -104,6 +116,23 @@ interface TransportWithTermination extends Transport {
 const DEFAULT_REQUEST_TIMEOUT_MILLIS = 60_000;
 
 /**
+ * Backoff bounds for re-opening the `subscriptions/listen` stream (2026-07-28 connections)
+ * after an unexpected remote drop. Mirrors the Streamable HTTP reconnection policy (1s → 30s).
+ */
+const RELISTEN_INITIAL_DELAY_MILLIS = 1_000;
+const RELISTEN_MAX_DELAY_MILLIS = 30_000;
+
+/**
+ * Timeout for the connect-time `server/discover` version-negotiation probe on stdio
+ * transports. Some stdio servers never answer unknown pre-`initialize` requests; the SDK
+ * treats a probe timeout on a local pipe as "legacy server" and falls back to `initialize`
+ * on the same stream, so a short timeout keeps connecting to such servers fast instead of
+ * waiting out the full request timeout. Not applied to HTTP, where probe silence means an
+ * outage and the SDK rejects instead of falling back.
+ */
+const STDIO_PROBE_TIMEOUT_MILLIS = 5_000;
+
+/**
  * MCP Client wrapper class
  * Provides a convenient interface to the MCP SDK Client with error handling and logging
  * Implements IMcpClient interface for compatibility with SessionClient
@@ -120,6 +149,11 @@ export class McpClient implements IMcpClient {
   private readonly configuredRequestTimeoutMillis: number;
   private cachedTools: Tool[] | null = null;
   private cachedToolsExpiresAt: number | null = null;
+  private isClosing = false;
+  /** Resource URIs subscribed on a 2026-07-28 connection (served by one listen stream). */
+  private modernSubscribedUris = new Set<string>();
+  /** The open `subscriptions/listen` stream backing modernSubscribedUris, if any. */
+  private modernListen: McpSubscription | undefined;
 
   constructor(clientInfo: Implementation, options: McpClientOptions = {}) {
     this.logger = options.logger || createNoOpLogger();
@@ -130,6 +164,12 @@ export class McpClient implements IMcpClient {
 
     this.client = new SDKClient(clientInfo, {
       capabilities: options.capabilities || {},
+      // Probe servers with `server/discover` and talk 2026-07-28 when they support it,
+      // falling back to the 2025-11-25 `initialize` handshake on the same connection.
+      versionNegotiation: {
+        mode: 'auto',
+        ...(options.stdioTransport ? { probe: { timeoutMs: STDIO_PROBE_TIMEOUT_MILLIS } } : {}),
+      },
       ...options,
     });
 
@@ -200,12 +240,16 @@ export class McpClient implements IMcpClient {
 
       this.hasConnected = true;
 
-      // Capture negotiated protocol version from transport if available
-      // StreamableHTTPClientTransport exposes protocolVersion after initialization
+      // Capture the negotiated protocol version (the client knows it for both eras;
+      // fall back to the transport for safety).
       const transportWithVersion = transport as TransportWithProtocolVersion;
-      if (transportWithVersion.protocolVersion) {
-        this.negotiatedProtocolVersion = transportWithVersion.protocolVersion;
-        this.logger.debug(`Negotiated protocol version: ${this.negotiatedProtocolVersion}`);
+      const negotiatedVersion =
+        this.client.getNegotiatedProtocolVersion() ?? transportWithVersion.protocolVersion;
+      if (negotiatedVersion) {
+        this.negotiatedProtocolVersion = negotiatedVersion;
+        this.logger.debug(
+          `Negotiated protocol version: ${this.negotiatedProtocolVersion} (${this.getProtocolEra() ?? 'unknown'} era)`
+        );
       }
 
       // Capture MCP session ID from transport if available (for session resumption)
@@ -239,8 +283,18 @@ export class McpClient implements IMcpClient {
    */
   async close(): Promise<void> {
     this.logger.debug('Closing connection...');
+    this.isClosing = true;
 
     try {
+      // Tear down the listen stream first on 2026-07-28 connections so its
+      // closed promise resolves 'local' and no re-listen is attempted.
+      if (this.modernListen) {
+        const listen = this.modernListen;
+        this.modernListen = undefined;
+        await listen.close().catch((error) => {
+          this.logger.debug('Error closing listen stream (ignored):', error);
+        });
+      }
       // For HTTP transport, terminate the session first (sends HTTP DELETE)
       // This is separate from close() in the SDK - terminateSession() sends the DELETE,
       // while close() just cleans up the client without notifying the server
@@ -294,6 +348,14 @@ export class McpClient implements IMcpClient {
   }
 
   /**
+   * Protocol era of the connection: 'modern' for 2026-07-28+ (negotiated via
+   * server/discover), 'legacy' for the 2025-era initialize handshake.
+   */
+  getProtocolEra(): ProtocolEra | undefined {
+    return this.client.getProtocolEra();
+  }
+
+  /**
    * Get the MCP session ID assigned by the server (if any)
    * This can be used for session resumption after bridge restart
    */
@@ -318,12 +380,19 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * Ping the server
+   * Ping the server.
+   * The `ping` method was removed in protocol 2026-07-28, so on modern connections the
+   * liveness probe is a `server/discover` request instead (same round-trip semantics).
    */
   async ping(): Promise<void> {
     try {
-      this.logger.debug('Sending ping...');
-      await this.client.ping(this.getRequestOptions());
+      if (this.getProtocolEra() === 'modern') {
+        this.logger.debug('Sending server/discover (2026-07-28 liveness probe)...');
+        await this.client.discover(this.getRequestOptions());
+      } else {
+        this.logger.debug('Sending ping...');
+        await this.client.ping(this.getRequestOptions());
+      }
       this.logger.debug('Ping successful');
     } catch (error) {
       this.logger.error('Ping failed:', error);
@@ -412,11 +481,7 @@ export class McpClient implements IMcpClient {
       if (meta) {
         callParams._meta = meta;
       }
-      const result = (await this.client.callTool(
-        callParams,
-        undefined, // resultSchema - use default
-        this.getRequestOptions()
-      )) as CallToolResult;
+      const result = await this.client.callTool(callParams, this.getRequestOptions());
       this.logger.debug(`Tool ${name} completed`);
       return result;
     } catch (error) {
@@ -479,12 +544,20 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * Subscribe to resource updates
+   * Subscribe to resource updates.
+   * On 2025-era connections this issues `resources/subscribe`; protocol 2026-07-28 replaced
+   * that with a `subscriptions/listen` stream, so on modern connections one listen stream
+   * is maintained carrying all subscribed URIs (re-opened whenever the set changes).
    */
   async subscribeResource(uri: string): Promise<void> {
     try {
       this.logger.debug(`Subscribing to resource: ${uri}`);
-      await this.client.subscribeResource({ uri }, this.getRequestOptions());
+      if (this.getProtocolEra() === 'modern') {
+        this.modernSubscribedUris.add(uri);
+        await this.reopenModernListen();
+      } else {
+        await this.client.subscribeResource({ uri }, this.getRequestOptions());
+      }
       this.logger.debug(`Subscribed to resource ${uri}`);
     } catch (error) {
       this.logger.error(`Failed to subscribe to resource ${uri}:`, error);
@@ -495,12 +568,17 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * Unsubscribe from resource updates
+   * Unsubscribe from resource updates (see subscribeResource for the per-era mechanics)
    */
   async unsubscribeResource(uri: string): Promise<void> {
     try {
       this.logger.debug(`Unsubscribing from resource: ${uri}`);
-      await this.client.unsubscribeResource({ uri }, this.getRequestOptions());
+      if (this.getProtocolEra() === 'modern') {
+        this.modernSubscribedUris.delete(uri);
+        await this.reopenModernListen();
+      } else {
+        await this.client.unsubscribeResource({ uri }, this.getRequestOptions());
+      }
       this.logger.debug(`Unsubscribed from resource ${uri}`);
     } catch (error) {
       this.logger.error(`Failed to unsubscribe from resource ${uri}:`, error);
@@ -508,6 +586,51 @@ export class McpClient implements IMcpClient {
         `Failed to unsubscribe from resource ${uri}: ${(error as Error).message}`,
         { originalError: error }
       );
+    }
+  }
+
+  /**
+   * (Re-)open the `subscriptions/listen` stream so it carries exactly the current
+   * modernSubscribedUris set. Notifications delivered on the stream dispatch to the
+   * handlers registered via setNotificationHandler, same as 2025-era unsolicited ones.
+   */
+  private async reopenModernListen(): Promise<void> {
+    const previous = this.modernListen;
+    this.modernListen = undefined;
+    if (previous) {
+      await previous.close().catch((error) => {
+        this.logger.debug('Error closing previous listen stream (ignored):', error);
+      });
+    }
+    if (this.modernSubscribedUris.size === 0 || this.isClosing) return;
+
+    const subscription = await this.client.listen(
+      { resourceSubscriptions: [...this.modernSubscribedUris] },
+      this.getRequestOptions()
+    );
+    this.modernListen = subscription;
+
+    // Re-listen only on unexpected drops; 'local' and 'graceful' closes are deliberate.
+    void subscription.closed.then((reason) => {
+      if (reason !== 'remote' || this.modernListen !== subscription || this.isClosing) return;
+      this.modernListen = undefined;
+      void this.relistenWithBackoff();
+    });
+  }
+
+  /** Re-establish the listen stream after a remote drop, backing off 1s → 30s. */
+  private async relistenWithBackoff(): Promise<void> {
+    let delayMillis = RELISTEN_INITIAL_DELAY_MILLIS;
+    while (!this.isClosing && this.modernSubscribedUris.size > 0 && !this.modernListen) {
+      await new Promise((resolve) => setTimeout(resolve, delayMillis));
+      try {
+        await this.reopenModernListen();
+        this.logger.debug('Listen stream re-established');
+        return;
+      } catch (error) {
+        this.logger.debug(`Re-listen failed, retrying in ${delayMillis * 2}ms:`, error);
+        delayMillis = Math.min(delayMillis * 2, RELISTEN_MAX_DELAY_MILLIS);
+      }
     }
   }
 
@@ -552,9 +675,18 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * Set the logging level on the server
+   * Set the logging level on the server.
+   * Protocol 2026-07-28 removed `logging/setLevel` (log level is per-request `_meta` there),
+   * so this only works on 2025-era connections.
    */
   async setLoggingLevel(level: LoggingLevel): Promise<void> {
+    if (this.getProtocolEra() === 'modern') {
+      throw new ServerError(
+        `logging/setLevel was removed in MCP ${this.negotiatedProtocolVersion}; ` +
+          `this server no longer supports a session-wide log level. ` +
+          `Use --verbose for client-side logging instead.`
+      );
+    }
     try {
       this.logger.debug(`Setting log level to: ${level}`);
       await this.client.setLoggingLevel(level, this.getRequestOptions());
@@ -571,25 +703,60 @@ export class McpClient implements IMcpClient {
    * Check if the server supports task-augmented tool calls
    */
   supportsTasksForToolCall(): boolean {
+    if (this.getProtocolEra() === 'modern') return false;
     const capabilities = this.client.getServerCapabilities();
     return !!capabilities?.tasks?.requests?.tools?.call;
   }
 
   /**
-   * Single access point for the SDK's task API. The `2025-11-25` experimental Tasks API
-   * (`experimental.tasks`) is superseded by the `2026-07-28` Tasks extension (SEP-2663:
-   * `tasks/get` polling, `tasks/update`, returnless `tasks/cancel`, and removal of
-   * `tasks/list`). Keeping every task call funnelled through here means that migration is a
-   * change to this one accessor rather than scattered across the file.
+   * Tasks were an experimental core feature in `2025-11-25` and moved to the
+   * `io.modelcontextprotocol/tasks` extension in `2026-07-28` (SEP-2663). The v2 SDK
+   * dropped the v1 experimental client API and does not implement the extension yet, so
+   * mcpc issues the `2025-11-25` task requests directly via `client.request()` — the wire
+   * vocabulary is still part of the SDK's legacy-era schema set. All task traffic is
+   * funnelled through the few methods below, so adopting the SDK's tasks extension API
+   * once it ships is a change to these methods only.
    */
-  private get tasksApi(): SDKClient['experimental']['tasks'] {
-    return this.client.experimental.tasks;
+  private assertTasksAvailable(): void {
+    if (this.getProtocolEra() === 'modern') {
+      throw new ServerError(
+        `Tasks are not available on this connection: MCP ${this.negotiatedProtocolVersion} moved tasks ` +
+          `to the io.modelcontextprotocol/tasks extension, which is not supported yet. ` +
+          `Task commands currently work only on servers using protocol 2025-11-25.`
+      );
+    }
   }
 
   /**
-   * Call a tool with task-augmented execution
-   * Uses the SDK's experimental callToolStream which handles task creation,
-   * polling, and result retrieval automatically via an AsyncGenerator.
+   * Issue a task-augmented `tools/call` and return the created task.
+   * The tool keeps running on the server after this returns.
+   */
+  private async createToolTask(
+    name: string,
+    args?: Record<string, unknown>,
+    meta?: Record<string, unknown>
+  ): Promise<TaskUpdate> {
+    this.assertTasksAvailable();
+    const params: Record<string, unknown> = {
+      name,
+      arguments: args || {},
+      task: {},
+    };
+    if (meta) {
+      params._meta = meta;
+    }
+    const result = await this.client.request(
+      { method: 'tools/call', params },
+      CreateTaskResultSchema,
+      this.getRequestOptions()
+    );
+    this.logger.debug(`Task created: ${result.task.taskId}`);
+    return taskToUpdate(result.task);
+  }
+
+  /**
+   * Call a tool with task-augmented execution: create the task, poll its status until it
+   * reaches a terminal state, then fetch the tool result.
    */
   async callToolWithTask(
     name: string,
@@ -599,91 +766,9 @@ export class McpClient implements IMcpClient {
   ): Promise<CallToolResult> {
     try {
       this.logger.debug(`Calling tool with task: ${name}`, args);
-
-      // Track latest task info so progress notifications can reference it
-      let currentTaskId: string | undefined;
-      let currentStatus: TaskUpdate['status'] = 'working';
-
-      const onprogress = onUpdate
-        ? (progress: {
-            progress: number;
-            total?: number | undefined;
-            message?: string | undefined;
-          }): void => {
-            if (!currentTaskId) return;
-            this.logger.debug(
-              `Task ${currentTaskId} progress: ${progress.progress}/${progress.total ?? '?'}${progress.message ? ` - ${progress.message}` : ''}`
-            );
-            const update: TaskUpdate = {
-              taskId: currentTaskId,
-              status: currentStatus,
-            };
-            if (progress.message) {
-              update.progressMessage = progress.message;
-            }
-            update.progress = progress.progress;
-            if (progress.total !== undefined) {
-              update.progressTotal = progress.total;
-            }
-            onUpdate(update);
-          }
-        : undefined;
-
-      const requestOptions = { ...this.getRequestOptions(), task: {} };
-      if (onprogress) {
-        (requestOptions as Record<string, unknown>).onprogress = onprogress;
-      }
-
-      const callParams: {
-        name: string;
-        arguments: Record<string, unknown>;
-        _meta?: Record<string, unknown>;
-      } = {
-        name,
-        arguments: args || {},
-      };
-      if (meta) {
-        callParams._meta = meta;
-      }
-
-      const stream = this.tasksApi.callToolStream(callParams, CallToolResultSchema, requestOptions);
-
-      let result: CallToolResult | undefined;
-
-      for await (const message of stream) {
-        switch (message.type) {
-          case 'taskCreated':
-            this.logger.debug(`Task created: ${message.task.taskId}`);
-            currentTaskId = message.task.taskId;
-            currentStatus = message.task.status;
-            onUpdate?.(taskToUpdate(message.task));
-            break;
-
-          case 'taskStatus':
-            this.logger.debug(`Task ${message.task.taskId} status: ${message.task.status}`);
-            currentTaskId = message.task.taskId;
-            currentStatus = message.task.status;
-            onUpdate?.(taskToUpdate(message.task));
-            break;
-
-          case 'result':
-            this.logger.debug(`Task completed with result for tool ${name}`);
-            result = message.result;
-            break;
-
-          case 'error':
-            this.logger.error(`Task error for tool ${name}:`, message.error);
-            throw new ServerError(`Tool ${name} task failed: ${message.error.message}`, {
-              originalError: message.error,
-            });
-        }
-      }
-
-      if (!result) {
-        throw new ServerError(`Tool ${name} task completed without a result`);
-      }
-
-      return result;
+      const created = await this.createToolTask(name, args, meta);
+      onUpdate?.(created);
+      return await this.pollTask(created.taskId, onUpdate);
     } catch (error) {
       if (error instanceof ServerError) throw error;
       this.logger.error(`Failed to call tool ${name} with task:`, error);
@@ -704,38 +789,7 @@ export class McpClient implements IMcpClient {
   ): Promise<TaskUpdate> {
     try {
       this.logger.debug(`Calling tool detached: ${name}`, args);
-      const callParams: {
-        name: string;
-        arguments: Record<string, unknown>;
-        _meta?: Record<string, unknown>;
-      } = {
-        name,
-        arguments: args || {},
-      };
-      if (meta) {
-        callParams._meta = meta;
-      }
-      const stream = this.tasksApi.callToolStream(callParams, CallToolResultSchema, {
-        ...this.getRequestOptions(),
-        task: {},
-      });
-
-      for await (const message of stream) {
-        if (message.type === 'taskCreated') {
-          this.logger.debug(`Task created (detached): ${message.task.taskId}`);
-          const update = taskToUpdate(message.task);
-          // Break out of the generator — this closes the stream
-          // The task continues running on the server
-          return update;
-        }
-        if (message.type === 'error') {
-          throw new ServerError(`Tool ${name} task failed: ${message.error.message}`, {
-            originalError: message.error,
-          });
-        }
-      }
-
-      throw new ServerError(`Tool ${name} task stream ended without creating a task`);
+      return await this.createToolTask(name, args, meta);
     } catch (error) {
       if (error instanceof ServerError) throw error;
       this.logger.error(`Failed to call tool ${name} detached:`, error);
@@ -781,6 +835,12 @@ export class McpClient implements IMcpClient {
           );
         }
 
+        // input_required: tasks/result delivers the queued server messages and
+        // blocks until the task reaches a terminal state.
+        if (task.status === 'input_required') {
+          return await this.getTaskResult(taskId);
+        }
+
         await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MILLIS));
       }
     } catch (error) {
@@ -798,7 +858,12 @@ export class McpClient implements IMcpClient {
   async listTasks(cursor?: string): Promise<ListTasksResult> {
     try {
       this.logger.debug('Listing tasks...', cursor ? { cursor } : {});
-      const result = await this.tasksApi.listTasks(cursor, this.getRequestOptions());
+      this.assertTasksAvailable();
+      const result = await this.client.request(
+        { method: 'tasks/list', ...(cursor ? { params: { cursor } } : {}) },
+        ListTasksResultSchema,
+        this.getRequestOptions()
+      );
       this.logger.debug(`Found ${result.tasks.length} tasks`);
       return result;
     } catch (error) {
@@ -815,7 +880,12 @@ export class McpClient implements IMcpClient {
   async getTask(taskId: string): Promise<GetTaskResult> {
     try {
       this.logger.debug(`Getting task: ${taskId}`);
-      const result = await this.tasksApi.getTask(taskId, this.getRequestOptions());
+      this.assertTasksAvailable();
+      const result = await this.client.request(
+        { method: 'tasks/get', params: { taskId } },
+        GetTaskResultSchema,
+        this.getRequestOptions()
+      );
       this.logger.debug(`Task ${taskId} status: ${result.status}`);
       return result;
     } catch (error) {
@@ -834,8 +904,9 @@ export class McpClient implements IMcpClient {
   async getTaskResult(taskId: string): Promise<CallToolResult> {
     try {
       this.logger.debug(`Getting task result: ${taskId}`);
-      const result = await this.tasksApi.getTaskResult(
-        taskId,
+      this.assertTasksAvailable();
+      const result = await this.client.request(
+        { method: 'tasks/result', params: { taskId } },
         CallToolResultSchema,
         this.getRequestOptions()
       );
@@ -855,7 +926,12 @@ export class McpClient implements IMcpClient {
   async cancelTask(taskId: string): Promise<CancelTaskResult> {
     try {
       this.logger.debug(`Cancelling task: ${taskId}`);
-      const result = await this.tasksApi.cancelTask(taskId, this.getRequestOptions());
+      this.assertTasksAvailable();
+      const result = await this.client.request(
+        { method: 'tasks/cancel', params: { taskId } },
+        CancelTaskResultSchema,
+        this.getRequestOptions()
+      );
       this.logger.debug(`Task ${taskId} cancelled`);
       return result;
     } catch (error) {

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -1,41 +1,36 @@
 /**
  * MCP Transport implementations
- * Re-exports and wraps transports from @modelcontextprotocol/sdk
+ * Re-exports and wraps transports from the @modelcontextprotocol/client SDK (v2)
  */
 
 // Re-export transport types and classes from SDK
-export type {
-  Transport,
-  TransportSendOptions,
-  FetchLike,
-} from '@modelcontextprotocol/sdk/shared/transport.js';
+export type { Transport, TransportSendOptions, FetchLike } from '@modelcontextprotocol/client';
 
 export {
   StdioClientTransport,
   type StdioServerParameters,
   getDefaultEnvironment,
-} from '@modelcontextprotocol/sdk/client/stdio.js';
+} from '@modelcontextprotocol/client/stdio';
 
 export {
   StreamableHTTPClientTransport,
   type StreamableHTTPClientTransportOptions,
   type StreamableHTTPReconnectionOptions,
-  StreamableHTTPError,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+  SdkHttpError,
+} from '@modelcontextprotocol/client';
 
 // Re-export auth-related types if needed
-export type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+export type { OAuthClientProvider } from '@modelcontextprotocol/client';
 
-import type { Transport, FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type { Transport, FetchLike, OAuthClientProvider } from '@modelcontextprotocol/client';
 import {
   StdioClientTransport,
   type StdioServerParameters,
-} from '@modelcontextprotocol/sdk/client/stdio.js';
+} from '@modelcontextprotocol/client/stdio';
 import {
   StreamableHTTPClientTransport,
   type StreamableHTTPClientTransportOptions,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+} from '@modelcontextprotocol/client';
 import { createLogger, getVerbose } from '../lib/logger.js';
 import type { ServerConfig } from '../lib/types.js';
 import { ClientError } from '../lib/errors.js';

--- a/src/lib/auth/client-credentials.ts
+++ b/src/lib/auth/client-credentials.ts
@@ -18,14 +18,12 @@ import { readFile } from 'fs/promises';
 import {
   ClientCredentialsProvider,
   PrivateKeyJwtProvider,
-} from '@modelcontextprotocol/sdk/client/auth-extensions.js';
-import {
   fetchToken,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
-} from '@modelcontextprotocol/sdk/client/auth.js';
-import type { AuthorizationServerMetadata } from '@modelcontextprotocol/sdk/shared/auth.js';
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
+  type AuthorizationServerMetadata,
+  type FetchLike,
+} from '@modelcontextprotocol/client';
 import type { AuthProfile } from '../types.js';
 import { AuthError, ClientError } from '../errors.js';
 import { proxyFetch } from '../proxy.js';
@@ -156,10 +154,11 @@ function buildPinnedDiscoveryState(tokenEndpoint: string): OAuthDiscoveryState {
  * Build a human-readable reason from an error thrown by the SDK's token request.
  *
  * OAuth failures from the authorization server (e.g. a wrong client secret) arrive
- * as an OAuthError subclass carrying a machine-readable `errorCode` such as
- * `invalid_client`. When the server omits `error_description` the SDK leaves
- * `error.message` empty, so fall back to that code rather than reporting a bare,
- * empty reason. Non-OAuth errors fall back to their message or string form.
+ * as an OAuthError carrying a machine-readable `code` such as `invalid_client`
+ * (named `errorCode` in SDK v1, still checked for compatibility). When the server
+ * omits `error_description` the SDK leaves `error.message` empty, so fall back to
+ * that code rather than reporting a bare, empty reason. Non-OAuth errors fall back
+ * to their message or string form.
  */
 export function describeAuthError(error: unknown): string {
   if (error instanceof Error) {
@@ -167,7 +166,7 @@ export function describeAuthError(error: unknown): string {
     if (message) {
       return message;
     }
-    const code = (error as { errorCode?: unknown }).errorCode;
+    const code = (error as { code?: unknown }).code ?? (error as { errorCode?: unknown }).errorCode;
     if (typeof code === 'string' && code) {
       return code;
     }

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -9,8 +9,7 @@ import type { Socket } from 'net';
 import { URL } from 'url';
 import { createInterface } from 'readline';
 import { randomBytes } from 'crypto';
-import { auth as sdkAuth } from '@modelcontextprotocol/sdk/client/auth.js';
-import { OAuthError as SdkOAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { auth as sdkAuth, OAuthError as SdkOAuthError } from '@modelcontextprotocol/client';
 import { OAuthProvider, type OAuthProviderOptions } from './oauth-provider.js';
 import { getServerHost } from '../utils.js';
 import { AuthError, ClientError } from '../errors.js';
@@ -26,6 +25,17 @@ import {
 import { renderAuthPage } from './auth-page.js';
 
 const logger = createLogger('oauth-flow');
+
+/**
+ * Parameters extracted from the authorization callback. `iss` is the RFC 9207
+ * issuer identifier; when present the SDK validates it against the discovered
+ * authorization server before redeeming the code (mix-up attack defense).
+ */
+interface CallbackResult {
+  code: string;
+  state?: string;
+  iss?: string;
+}
 
 /** Matches the MCP SDK error thrown when a server exposes no `registration_endpoint`. */
 const DCR_UNSUPPORTED_PATTERN = /does not support dynamic client registration/i;
@@ -93,7 +103,7 @@ export function explainOAuthRegistrationFailure(
   const rejectedByServer =
     status === '401' ||
     status === '403' ||
-    (error instanceof SdkOAuthError && CLIENT_REJECTED_CODES.has(error.errorCode));
+    (error instanceof SdkOAuthError && CLIENT_REJECTED_CODES.has(error.code));
 
   if (!dcrUnsupported && !isRegistrationError && !rejectedByServer) {
     return error;
@@ -251,13 +261,13 @@ function startCallbackServer(
   context: { serverUrl: string; profileName: string; scope?: string }
 ): {
   server: Server;
-  codePromise: Promise<{ code: string; state?: string }>;
+  codePromise: Promise<CallbackResult>;
   destroyConnections: () => void;
 } {
-  let resolveCode: (value: { code: string; state?: string }) => void;
+  let resolveCode: (value: CallbackResult) => void;
   let rejectCode: (error: Error) => void;
 
-  const codePromise = new Promise<{ code: string; state?: string }>((resolve, reject) => {
+  const codePromise = new Promise<CallbackResult>((resolve, reject) => {
     resolveCode = resolve;
     rejectCode = reject;
   });
@@ -284,6 +294,8 @@ function startCallbackServer(
       const error = url.searchParams.get('error');
       const errorDescription = url.searchParams.get('error_description');
       const state = url.searchParams.get('state') || undefined;
+      // RFC 9207 issuer identification — validated by the SDK before redeeming the code
+      const iss = url.searchParams.get('iss') || undefined;
 
       const info = [
         { label: 'Server', value: getServerHost(context.serverUrl) },
@@ -331,9 +343,12 @@ function startCallbackServer(
           info,
         })
       );
-      const result: { code: string; state?: string } = { code };
+      const result: CallbackResult = { code };
       if (state !== undefined) {
         result.state = state;
+      }
+      if (iss !== undefined) {
+        result.iss = iss;
       }
       resolveCode(result);
     } else {
@@ -426,10 +441,10 @@ async function tryOpenBrowser(url: string): Promise<boolean> {
 }
 
 /**
- * Extract authorization code and state from a callback URL
+ * Extract authorization code, state, and issuer (RFC 9207 `iss`) from a callback URL
  * Parses URLs like: http://localhost:8000/callback?code=abc123&state=xyz
  */
-function extractCodeFromUrl(callbackUrl: string): { code: string; state?: string } {
+function extractCodeFromUrl(callbackUrl: string): CallbackResult {
   try {
     // Handle both full URLs and just query strings
     const url = callbackUrl.startsWith('http')
@@ -440,6 +455,7 @@ function extractCodeFromUrl(callbackUrl: string): { code: string; state?: string
     const error = url.searchParams.get('error');
     const errorDescription = url.searchParams.get('error_description');
     const state = url.searchParams.get('state') || undefined;
+    const iss = url.searchParams.get('iss') || undefined;
 
     if (error) {
       const message = errorDescription || error;
@@ -452,9 +468,12 @@ function extractCodeFromUrl(callbackUrl: string): { code: string; state?: string
       );
     }
 
-    const result: { code: string; state?: string } = { code };
+    const result: CallbackResult = { code };
     if (state !== undefined) {
       result.state = state;
+    }
+    if (iss !== undefined) {
+      result.iss = iss;
     }
     return result;
   } catch (e) {
@@ -470,7 +489,7 @@ function extractCodeFromUrl(callbackUrl: string): { code: string; state?: string
  * Uses readline (not raw mode) so it works in all terminal environments
  */
 function promptForCallbackUrl(): {
-  promise: Promise<{ code: string; state?: string }>;
+  promise: Promise<CallbackResult>;
   cleanup: () => void;
 } {
   const rl = createInterface({
@@ -485,7 +504,7 @@ function promptForCallbackUrl(): {
     rl.close();
   };
 
-  const promise = new Promise<{ code: string; state?: string }>((resolve, reject) => {
+  const promise = new Promise<CallbackResult>((resolve, reject) => {
     rl.question('\nPaste the callback URL from your browser here:\n> ', (answer: string) => {
       cleanup();
       const trimmed = answer.trim();
@@ -692,7 +711,7 @@ export async function performOAuthFlow(
       if (result === 'REDIRECT') {
         // Wait for callback with authorization code, or user pressing Escape
         logger.debug('Waiting for authorization code...');
-        const racers: Promise<{ code: string; state?: string }>[] = [codePromise];
+        const racers: Promise<CallbackResult>[] = [codePromise];
 
         if (browserFailed) {
           // Browser didn't open - also accept pasted callback URL
@@ -700,19 +719,28 @@ export async function performOAuthFlow(
           pasteHandlerRef.current = urlHandler;
           racers.push(urlHandler.promise);
         } else if (escapeHandlerRef.current) {
-          racers.push(escapeHandlerRef.current.promise as Promise<{ code: string }>);
+          racers.push(escapeHandlerRef.current.promise as Promise<CallbackResult>);
         }
 
-        const { code } = await Promise.race(racers);
+        const { code, iss } = await Promise.race(racers);
 
-        // Exchange code for tokens
+        // Exchange code for tokens. The `iss` callback parameter (RFC 9207) is passed
+        // through so the SDK validates the issuer before redeeming the code.
         logger.debug('Exchanging authorization code for tokens...');
-        const tokenOptions: { serverUrl: string; authorizationCode: string; scope?: string } = {
+        const tokenOptions: {
+          serverUrl: string;
+          authorizationCode: string;
+          scope?: string;
+          iss?: string;
+        } = {
           serverUrl: normalizedServerUrl,
           authorizationCode: code,
         };
         if (scope !== undefined) {
           tokenOptions.scope = scope;
+        }
+        if (iss !== undefined) {
+          tokenOptions.iss = iss;
         }
         await sdkAuth(provider, tokenOptions);
       }

--- a/src/lib/auth/oauth-provider.ts
+++ b/src/lib/auth/oauth-provider.ts
@@ -12,12 +12,12 @@
  *    - No keychain I/O during runtime (token manager handles state)
  */
 
-import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
 import type {
+  OAuthClientProvider,
   OAuthClientMetadata,
   OAuthClientInformationMixed,
   OAuthTokens,
-} from '@modelcontextprotocol/sdk/shared/auth.js';
+} from '@modelcontextprotocol/client';
 import { OAuthTokenManager } from './oauth-token-manager.js';
 import {
   readKeychainOAuthTokenInfo,

--- a/src/lib/resource-content.ts
+++ b/src/lib/resource-content.ts
@@ -9,7 +9,7 @@
 
 import { stat, unlink, writeFile } from 'fs/promises';
 import { basename, dirname, isAbsolute, join } from 'path';
-import type { ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ReadResourceResult } from '@modelcontextprotocol/client';
 import { atomicRename, ensureDir } from './utils.js';
 import { ClientError, ServerError } from './errors.js';
 

--- a/src/lib/session-client.ts
+++ b/src/lib/session-client.ts
@@ -29,7 +29,7 @@ import type {
   ResourceSyncResult,
   ResourceUnsubscribeResult,
 } from './types.js';
-import type { ListResourceTemplatesResult } from '@modelcontextprotocol/sdk/types.js';
+import type { ListResourceTemplatesResult } from '@modelcontextprotocol/client';
 import { BridgeClient } from './bridge-client.js';
 import { ensureBridgeReady, restartBridge } from './bridge-manager.js';
 import { updateSession } from './sessions.js';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,6 @@
 import type {
   Tool,
   Resource,
-  ResourceTemplate,
   Prompt,
   PromptArgument,
   Implementation,
@@ -35,13 +34,18 @@ import type {
   GetTaskResult,
   ListTasksResult,
   CancelTaskResult,
-} from '@modelcontextprotocol/sdk/types.js';
+} from '@modelcontextprotocol/client';
+
+/**
+ * A single resource template entry. The SDK v2 does not export this type directly,
+ * so it is derived from the list result it appears in.
+ */
+export type ResourceTemplate = ListResourceTemplatesResult['resourceTemplates'][number];
 
 // Re-export core MCP types for external use
 export type {
   Tool,
   Resource,
-  ResourceTemplate,
   Prompt,
   PromptArgument,
   Implementation,

--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -16,8 +16,7 @@
  * This middleware is injected into the transport via the SDK's `fetch` option.
  */
 
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
-import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import type { FetchLike, Tool } from '@modelcontextprotocol/client';
 import {
   signPayment,
   parsePaymentRequired,

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -2230,6 +2230,50 @@ describe('formatCallToolResultHuman', () => {
     expect(output).not.toContain('Structured content');
   });
 
+  // Since protocol 2026-07-28 (SEP-2106), structuredContent may be any JSON value,
+  // not just an object — non-object values must render without key-based dedup logic.
+  it('should show an array structuredContent when content is empty (SEP-2106)', () => {
+    const result = {
+      content: [],
+      structuredContent: [1, 2, 3],
+    };
+    const output = formatCallToolResultHuman(result);
+    expect(output).toContain('Structured content:');
+    expect(output).toContain('1');
+    expect(output).toContain('3');
+  });
+
+  it('should show a primitive structuredContent when content is empty (SEP-2106)', () => {
+    const result = {
+      content: [],
+      structuredContent: 42,
+    };
+    const output = formatCallToolResultHuman(result);
+    expect(output).toContain('Structured content:');
+    expect(output).toContain('42');
+  });
+
+  it('should keep text content untouched alongside a non-object structuredContent', () => {
+    const result = {
+      content: [{ type: 'text' as const, text: 'summary' }],
+      structuredContent: ['a', 'b'],
+    };
+    const output = formatCallToolResultHuman(result);
+    expect(output).toContain('Content:');
+    expect(output).toContain('summary');
+    expect(output).not.toContain('Structured content');
+  });
+
+  it('should treat a null structuredContent as absent (SEP-2106)', () => {
+    const result = {
+      content: [],
+      structuredContent: null,
+    };
+    const output = formatCallToolResultHuman(result);
+    expect(output).not.toContain('Structured content');
+    expect(output).toContain('(no content)');
+  });
+
   it('should skip the duplicate text block when it matches structuredContent', () => {
     const sc = { results: [{ title: 'Test', url: 'https://example.com' }] };
     const result = {

--- a/test/unit/core/factory.test.ts
+++ b/test/unit/core/factory.test.ts
@@ -18,19 +18,25 @@ vi.mock('../../../src/core/transports', () => ({
 }));
 
 // Mock the SDK Client
-vi.mock('@modelcontextprotocol/sdk/client/index.js', () => ({
-  Client: vi.fn(function () {
-    return {
-      connect: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-      getServerVersion: vi.fn().mockReturnValue({ name: 'test-server', version: '1.0.0' }),
-      getServerCapabilities: vi.fn().mockReturnValue({}),
-      getInstructions: vi.fn().mockReturnValue(undefined),
-      ping: vi.fn().mockResolvedValue(undefined),
-      onerror: undefined,
-    };
-  }),
-}));
+vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modelcontextprotocol/client')>();
+  return {
+    ...actual,
+    Client: vi.fn(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+        getServerVersion: vi.fn().mockReturnValue({ name: 'test-server', version: '1.0.0' }),
+        getServerCapabilities: vi.fn().mockReturnValue({}),
+        getInstructions: vi.fn().mockReturnValue(undefined),
+        getNegotiatedProtocolVersion: vi.fn().mockReturnValue('2025-11-25'),
+        getProtocolEra: vi.fn().mockReturnValue('legacy'),
+        ping: vi.fn().mockResolvedValue(undefined),
+        onerror: undefined,
+      };
+    }),
+  };
+});
 
 describe('createMcpClient', () => {
   it('should create a client with stdio transport', async () => {

--- a/test/unit/core/json-schema-validator.test.ts
+++ b/test/unit/core/json-schema-validator.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the dialect-aware JSON Schema validator
+ */
+
+import { DialectAwareJsonSchemaValidator } from '../../../src/core/json-schema-validator.js';
+
+describe('DialectAwareJsonSchemaValidator', () => {
+  const provider = new DialectAwareJsonSchemaValidator();
+
+  it('validates a draft-07-stamped schema (2025-era servers) instead of rejecting the dialect', () => {
+    // The exact shape zod-to-json-schema emits for v1 SDK servers such as
+    // @modelcontextprotocol/server-filesystem — the default SDK validator throws
+    // "unsupported dialect" for this.
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+      },
+      required: ['content'],
+      additionalProperties: false,
+    };
+
+    const validate = provider.getValidator<{ content: string }>(schema);
+
+    const good = validate({ content: 'hello' });
+    expect(good.valid).toBe(true);
+    expect(good.data).toEqual({ content: 'hello' });
+
+    const bad = validate({ content: 42 });
+    expect(bad.valid).toBe(false);
+    expect(bad.errorMessage).toBeTruthy();
+  });
+
+  it('validates an unstamped schema with the default (2020-12) engine', () => {
+    const schema = {
+      type: 'object',
+      properties: { n: { type: 'number' } },
+      required: ['n'],
+    };
+
+    const validate = provider.getValidator<{ n: number }>(schema);
+    expect(validate({ n: 1 }).valid).toBe(true);
+    expect(validate({}).valid).toBe(false);
+  });
+
+  it('validates a 2020-12-stamped schema with the default engine', () => {
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: { items: { type: 'array', prefixItems: [{ type: 'string' }] } },
+    };
+
+    const validate = provider.getValidator<{ items: unknown[] }>(schema);
+    expect(validate({ items: ['a'] }).valid).toBe(true);
+    expect(validate({ items: [42] }).valid).toBe(false);
+  });
+});

--- a/test/unit/core/json-schema-validator.test.ts
+++ b/test/unit/core/json-schema-validator.test.ts
@@ -55,4 +55,57 @@ describe('DialectAwareJsonSchemaValidator', () => {
     expect(validate({ items: ['a'] }).valid).toBe(true);
     expect(validate({ items: [42] }).valid).toBe(false);
   });
+
+  it.each([
+    'http://json-schema.org/draft-04/schema#',
+    'http://json-schema.org/draft-06/schema#',
+    'https://json-schema.org/draft-07/schema',
+  ])('validates a schema stamped with legacy dialect %s', (dialect) => {
+    const schema = {
+      $schema: dialect,
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    };
+
+    const validate = provider.getValidator<{ name: string }>(schema);
+    expect(validate({ name: 'ok' }).valid).toBe(true);
+    expect(validate({}).valid).toBe(false);
+  });
+
+  it('validates a draft-2019-09-stamped schema instead of rejecting the dialect', () => {
+    // Pinned decision: 2019-09 routes to the tolerant draft-07 engine, because the SDK's
+    // default engine rejects the 2019-09 dialect URI outright. 2019-09-only keywords are
+    // ignored rather than enforced — better than failing every call to such a tool.
+    const schema = {
+      $schema: 'https://json-schema.org/draft/2019-09/schema',
+      type: 'object',
+      properties: { count: { type: 'integer' } },
+      required: ['count'],
+    };
+
+    const validate = provider.getValidator<{ count: number }>(schema);
+    expect(validate({ count: 1 }).valid).toBe(true);
+    expect(validate({ count: 'nope' }).valid).toBe(false);
+  });
+
+  it('resolves internal $ref and composition keywords in draft-07 schemas', () => {
+    const schema = {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      definitions: {
+        entry: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] },
+      },
+      properties: {
+        entry: { $ref: '#/definitions/entry' },
+        value: { anyOf: [{ type: 'string' }, { type: 'number' }] },
+      },
+      required: ['entry', 'value'],
+    };
+
+    const validate = provider.getValidator<{ entry: { id: string }; value: unknown }>(schema);
+    expect(validate({ entry: { id: 'a' }, value: 1 }).valid).toBe(true);
+    expect(validate({ entry: { id: 'a' }, value: true }).valid).toBe(false);
+    expect(validate({ entry: {}, value: 'x' }).valid).toBe(false);
+  });
 });

--- a/test/unit/core/transports.test.ts
+++ b/test/unit/core/transports.test.ts
@@ -9,7 +9,7 @@ import { ClientError } from '../../../src/lib/errors.js';
 import { proxyFetch } from '../../../src/lib/proxy.js';
 
 // Mock the SDK transports
-vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
+vi.mock('@modelcontextprotocol/client/stdio', () => ({
   StdioClientTransport: vi.fn(function () {
     return {
       start: vi.fn().mockResolvedValue(undefined),
@@ -20,16 +20,19 @@ vi.mock('@modelcontextprotocol/sdk/client/stdio.js', () => ({
   getDefaultEnvironment: vi.fn().mockReturnValue({}),
 }));
 
-vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => ({
-  StreamableHTTPClientTransport: vi.fn(function () {
-    return {
-      start: vi.fn().mockResolvedValue(undefined),
-      send: vi.fn().mockResolvedValue(undefined),
-      close: vi.fn().mockResolvedValue(undefined),
-    };
-  }),
-  StreamableHTTPError: class StreamableHTTPError extends Error {},
-}));
+vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modelcontextprotocol/client')>();
+  return {
+    ...actual,
+    StreamableHTTPClientTransport: vi.fn(function () {
+      return {
+        start: vi.fn().mockResolvedValue(undefined),
+        send: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+    }),
+  };
+});
 
 describe('createTransportFromConfig', () => {
   it('should create stdio transport from config', () => {

--- a/test/unit/lib/auth/oauth-flow.test.ts
+++ b/test/unit/lib/auth/oauth-flow.test.ts
@@ -2,11 +2,7 @@
  * Unit tests for OAuth flow utility functions
  */
 
-import {
-  InvalidClientError,
-  InvalidClientMetadataError,
-  ServerError as SdkServerError,
-} from '@modelcontextprotocol/sdk/server/auth/errors.js';
+import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/client';
 import { validateClientMetadataUrl } from '../../../../src/lib/auth/oauth-utils.js';
 import { explainOAuthRegistrationFailure } from '../../../../src/lib/auth/oauth-flow.js';
 import { AuthError } from '../../../../src/lib/errors.js';
@@ -17,7 +13,8 @@ describe('explainOAuthRegistrationFailure', () => {
 
   it('rewrites the SDK non-JSON 403 error (Figma) into allow-list guidance', () => {
     // The exact error the MCP SDK surfaces for Figma's plain-text "Forbidden" body.
-    const raw = new SdkServerError(
+    const raw = new OAuthError(
+      OAuthErrorCode.ServerError,
       "HTTP 403: Invalid OAuth error response: SyntaxError: Unexpected token 'F', " +
         '"Forbidden" is not valid JSON. Raw body: Forbidden'
     );
@@ -46,7 +43,7 @@ describe('explainOAuthRegistrationFailure', () => {
   });
 
   it('recognizes OAuth-coded client rejections without an HTTP status', () => {
-    const raw = new InvalidClientError('mcpc is not an approved client');
+    const raw = new OAuthError(OAuthErrorCode.InvalidClient, 'mcpc is not an approved client');
 
     const result = explainOAuthRegistrationFailure(raw, preAuth);
 
@@ -68,7 +65,8 @@ describe('explainOAuthRegistrationFailure', () => {
   });
 
   it('does not claim an allow-list for a registration 5xx', () => {
-    const raw = new SdkServerError(
+    const raw = new OAuthError(
+      OAuthErrorCode.ServerError,
       'HTTP 500: Invalid OAuth error response: SyntaxError: bad. Raw body: <html>outage</html>'
     );
 
@@ -83,7 +81,7 @@ describe('explainOAuthRegistrationFailure', () => {
   });
 
   it('reports rejected client metadata without claiming an allow-list', () => {
-    const raw = new InvalidClientMetadataError('redirect_uri is not allowed');
+    const raw = new OAuthError(OAuthErrorCode.InvalidClientMetadata, 'redirect_uri is not allowed');
 
     const result = explainOAuthRegistrationFailure(raw, preAuth);
 
@@ -96,7 +94,8 @@ describe('explainOAuthRegistrationFailure', () => {
 
   it('truncates oversized response bodies in the message but keeps details intact', () => {
     const body = 'x'.repeat(2000);
-    const raw = new SdkServerError(
+    const raw = new OAuthError(
+      OAuthErrorCode.ServerError,
       `HTTP 403: Invalid OAuth error response: bad. Raw body: ${body}`
     );
 
@@ -110,7 +109,10 @@ describe('explainOAuthRegistrationFailure', () => {
 
   it('leaves the error unchanged once authorization has been reached', () => {
     // A 403 after the redirect is a token-exchange failure, not registration.
-    const raw = new SdkServerError('HTTP 403: Invalid OAuth error response. Raw body: Forbidden');
+    const raw = new OAuthError(
+      OAuthErrorCode.ServerError,
+      'HTTP 403: Invalid OAuth error response. Raw body: Forbidden'
+    );
 
     const result = explainOAuthRegistrationFailure(raw, { serverUrl, reachedAuthorization: true });
 


### PR DESCRIPTION
Adds support for MCP protocol version 2026-07-28 ([release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/)) by migrating the client stack to the TypeScript SDK v2 beta (`@modelcontextprotocol/client`). mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to 2025-11-25 automatically on the same connection.

- Resource subscriptions and list-change notifications use `subscriptions/listen` streams on 2026-07-28 connections (opened only for capabilities the server declares, re-established with backoff on drops); legacy connections keep `resources/subscribe` and unsolicited notifications
- `ping` maps to `server/discover` on 2026-07-28 servers; `logging-set-level` errors there (both were removed from the protocol)
- Task commands are reimplemented on raw 2025-11-25 requests (the v2 SDK dropped the experimental tasks API); they report the tasks extension as not yet supported on 2026-07-28 servers
- OAuth ported to the v2 auth API, including RFC 9207 `iss` validation of authorization callbacks
- The `--proxy` MCP server and e2e test server stay on SDK v1 (still serving 2025-11-25) until the v2 server packages are adopted — planned follow-up

E2E suite passes at parity with `main`.

## Follow-ups (separate PRs)

- **E2E protocol-version matrix**: add a second test server built on `@modelcontextprotocol/server@beta` (mirroring the current server's surface, ideally with a v2-only/`legacy: reject` mode to prove pure 2026-07-28 operation), parameterize the e2e framework with a `--server-protocol` flag, and run the protocol-agnostic suites against both servers in CI plus era-specific suites for fallback (v1) and listen-stream behavior incl. re-listen and resource file-sync (v2). Each future MCP revision then adds a matrix column instead of a rewrite, guarding backward compatibility as versions accumulate. The current suite covers the legacy-fallback path only; the modern path was verified manually against a real v2 server ([review](https://github.com/apify/mcpc/pull/314#issuecomment-5044044746)).
- **Tasks extension**: stop advertising the v1-shaped `tasks: {list, cancel}` client capability on 2026-07-28 connections — capabilities are declared before version negotiation, so the clean fix is moving tasks to the negotiated `extensions` map once the SDK ships the `io.modelcontextprotocol/tasks` extension.
- **v2 server packages**: migrate the `--proxy` MCP server (and the e2e servers above) off SDK v1.

https://claude.ai/code/session_013kwM8qhutYS3ZmQATcaQ9C