### PR TITLE
Add e2e protocol-version matrix and update MCP SDK to beta.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,31 @@ jobs:
         # specific storage backend.
         run: ./test/e2e/run.sh --no-build --parallel 6
 
+  e2e-node-modern:
+    name: E2E tests (Node.js, MCP 2026-07-28 server)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests (modern-protocol test server)
+        # Protocol-version matrix column: the same suites against the SDK v2
+        # test server speaking pure MCP 2026-07-28 (legacy requests rejected).
+        # Era-specific suites skip themselves via require_server_protocol.
+        run: ./test/e2e/run.sh --no-build --parallel 6 --server-protocol modern
+
   e2e-bun:
     name: E2E tests (Bun)
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -34,6 +34,31 @@ jobs:
         # specific storage backend.
         run: ./test/e2e/run.sh --no-build --parallel 6
 
+  e2e-linux-node-modern:
+    name: E2E tests (Linux, Node.js, MCP 2026-07-28 server)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Install pnpm and dependencies
+        uses: apify/actions/pnpm-install@v1.1.2
+
+      - name: Build
+        run: pnpm run build
+
+      - name: E2E tests (modern-protocol test server)
+        # Protocol-version matrix column: the same suites against the SDK v2
+        # test server speaking pure MCP 2026-07-28 (legacy requests rejected).
+        # Era-specific suites skip themselves via require_server_protocol.
+        run: ./test/e2e/run.sh --no-build --parallel 6 --server-protocol modern
+
   e2e-linux-bun:
     name: E2E tests (Linux, Bun)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
+- Updated the MCP TypeScript SDK v2 to `2.0.0-beta.5`, which fixes interoperability with 2026-07-28 servers built on the latest SDK betas (they require the new `Mcp-Method` request header that older clients did not send).
 
 ### Deprecated
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ mcpc/
 │   └── mcpc-bridge     # Bridge process executable
 └── test/
     └── e2e/
-        └── server/     # Test MCP server for E2E tests
+        └── server/     # Test MCP servers for E2E tests (2025-11-25 + 2026-07-28)
 ```
 
 ### Core Components
@@ -430,10 +430,11 @@ Environment variable substitution supported: `${VAR_NAME}`
 
 - Real MCP server implementations
 - Cross-runtime testing (Node.js and Bun)
+- Protocol-version matrix: the suites run against two test servers — `test/e2e/server/index.ts` (MCP SDK v1, protocol 2025-11-25) and `test/e2e/server/index-v2.ts` (MCP SDK v2, pure 2026-07-28, legacy requests rejected) — selected via `./test/e2e/run.sh --server-protocol legacy|modern` (default: legacy). Both serve the same surface from shared `fixtures.ts`; era-specific suites skip themselves with `require_server_protocol <era>`. Each future MCP revision adds a matrix column instead of a rewrite.
 
 **Test utilities:**
 
-- `test/e2e/server/` - Test MCP server
+- `test/e2e/server/` - Test MCP servers (one per protocol era) + shared fixtures
 - `test/e2e/lib/framework.sh` - Shell test framework for E2E suites
 
 ## Runtime Requirements

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build": "tsc && node scripts/bundle-viem.mjs",
     "build:watch": "tsc --watch",
     "build:readme": "./scripts/update-readme.sh",
-    "test": "pnpm run build && pnpm run test:unit && ./test/e2e/run.sh --no-build --parallel 8 && ./test/e2e/run.sh --no-build --parallel 8 --runtime bun",
+    "test": "pnpm run build && pnpm run test:unit && ./test/e2e/run.sh --no-build --parallel 8 && ./test/e2e/run.sh --no-build --parallel 8 --server-protocol modern && ./test/e2e/run.sh --no-build --parallel 8 --runtime bun",
     "test:unit": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "pnpm run test:coverage:unit && pnpm run test:coverage:e2e && pnpm run test:coverage:merge",
@@ -40,6 +40,7 @@
     "test:coverage:e2e": "./test/e2e/run.sh --coverage",
     "test:coverage:merge": "test/coverage/coverage-merge.sh",
     "test:e2e": "./test/e2e/run.sh --keep",
+    "test:e2e:modern": "./test/e2e/run.sh --keep --server-protocol modern",
     "test:e2e:bun": "./test/e2e/run.sh --no-build --runtime bun",
     "test:conformance": "pnpm run build && npx -y @modelcontextprotocol/conformance client --command \"node test/conformance/client.mjs\" --scenario initialize",
     "lint": "eslint src && prettier --check \"src/**/*.ts\" \"test/**/*.ts\"",
@@ -55,8 +56,8 @@
     "release:pre": "bash scripts/publish.sh --pre-release"
   },
   "dependencies": {
-    "@modelcontextprotocol/client": "2.0.0-beta.4",
-    "@modelcontextprotocol/core": "2.0.0-beta.4",
+    "@modelcontextprotocol/client": "2.0.0-beta.5",
+    "@modelcontextprotocol/core": "2.0.0-beta.5",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@napi-rs/keyring": "^1.3.0",
     "chalk": "^5.6.2",
@@ -68,6 +69,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@modelcontextprotocol/node": "2.0.0-beta.5",
+    "@modelcontextprotocol/server": "2.0.0-beta.5",
     "@types/node": "^25.9.4",
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@eslint/js": "^10.0.1",
     "@modelcontextprotocol/node": "2.0.0-beta.5",
     "@modelcontextprotocol/server": "2.0.0-beta.5",
+    "@modelcontextprotocol/server-filesystem": "2026.7.10",
     "@types/node": "^25.9.4",
     "@types/proper-lockfile": "^4.1.4",
     "@types/qrcode-terminal": "^0.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/client':
-        specifier: 2.0.0-beta.4
-        version: 2.0.0-beta.4
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5
       '@modelcontextprotocol/core':
-        specifier: 2.0.0-beta.4
-        version: 2.0.0-beta.4
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -42,6 +42,12 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
+      '@modelcontextprotocol/node':
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5(@modelcontextprotocol/server@2.0.0-beta.5)(hono@4.12.22)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0-beta.5
+        version: 2.0.0-beta.5
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
@@ -427,13 +433,23 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/client@2.0.0-beta.4':
-    resolution: {integrity: sha512-VNHA/UXDk7mCpVl+jOg5B4WMRRD2OEl+it360Lhi6HiCbrIB2f6pZ0cqSDKXQVUtZvqnhdQHzZAM9h8EKWhq/A==}
+  '@modelcontextprotocol/client@2.0.0-beta.5':
+    resolution: {integrity: sha512-YuuNm5f2TMoFQRje1UqVP8TJRjijCXMz4ckvoVpx1cUXuBEmykWQ2d8R536pek6UKcXT41T5nWc4qR1JFIbEmg==}
     engines: {node: '>=20'}
 
-  '@modelcontextprotocol/core@2.0.0-beta.4':
-    resolution: {integrity: sha512-nsMXd4wQBKzmph6r+WOhum+mXjDYljTAqwY/XUg3hLtvNOQ8+JVqBSJOVCMJvx9lXhTpTOPrGZ3BuNiaNPjSvg==}
+  '@modelcontextprotocol/core@2.0.0-beta.5':
+    resolution: {integrity: sha512-HKbY9XTbsDy1Y6r2I55TGE3JEapM0vg96e1MUmBIF9LGjos5gjhcIrTz1yvBPLg2aFKHjwhUAQfRdrCEnPxNew==}
     engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0-beta.5':
+    resolution: {integrity: sha512-flrOzx5qFLBM9I8IYRGfYUY02erFmxOvYQ9sEE6iSj/ZZpRYKorXWscM/qrfW9rwlcGLyymHhnP2AaDbMB1lIA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0-beta.5
+      hono: ^4.11.4
+    peerDependenciesMeta:
+      hono:
+        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -444,6 +460,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0-beta.5':
+    resolution: {integrity: sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==}
+    engines: {node: '>=20'}
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     resolution: {integrity: sha512-pl76hJvdYUBn6I24bXiOBMA9nbDapo3I5B+f3OorjDU4dUMSypXeKbOVehJe8fhgTiH24flMyTS3aAIy43xegQ==}
@@ -2931,9 +2951,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/client@2.0.0-beta.4':
+  '@modelcontextprotocol/client@2.0.0-beta.5':
     dependencies:
-      '@modelcontextprotocol/core': 2.0.0-beta.4
+      '@modelcontextprotocol/core': 2.0.0-beta.5
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
@@ -2941,9 +2961,16 @@ snapshots:
       pkce-challenge: 5.0.1
       zod: 4.4.3
 
-  '@modelcontextprotocol/core@2.0.0-beta.4':
+  '@modelcontextprotocol/core@2.0.0-beta.5':
     dependencies:
       zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0-beta.5(@modelcontextprotocol/server@2.0.0-beta.5)(hono@4.12.22)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.22)
+      '@modelcontextprotocol/server': 2.0.0-beta.5
+    optionalDependencies:
+      hono: 4.12.22
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -2966,6 +2993,11 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0-beta.5':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0-beta.5
+      zod: 4.4.3
 
   '@napi-rs/keyring-darwin-arm64@1.3.0':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@modelcontextprotocol/server':
         specifier: 2.0.0-beta.5
         version: 2.0.0-beta.5
+      '@modelcontextprotocol/server-filesystem':
+        specifier: 2026.7.10
+        version: 2026.7.10(zod@4.4.3)
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
@@ -409,6 +412,10 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@istanbuljs/load-nyc-config@1.1.0':
     resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
     engines: {node: '>=8'}
@@ -460,6 +467,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server-filesystem@2026.7.10':
+    resolution: {integrity: sha512-Mmjg4anFBD5OzbPnGJOA0jPPN8645ERhQk38HQLpSenx1ox9bfdPkmAzUnNjeQtqQGFLtKe13J20RtLBmUKMZA==}
+    hasBin: true
 
   '@modelcontextprotocol/server@2.0.0-beta.5':
     resolution: {integrity: sha512-i1E5l75rQKsgY/AKAIspgMBH1vEL7dqiK7tHr0L+raYcb0SWOziqNGJXGIG6NY4AlXDWIKGJQGB7Nqfs3oUi5g==}
@@ -582,6 +593,10 @@ packages:
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
@@ -900,6 +915,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   append-transform@2.0.0:
     resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
     engines: {node: '>=8'}
@@ -930,6 +949,9 @@ packages:
   bail@1.0.5:
     resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -952,6 +974,9 @@ packages:
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
+
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -1136,6 +1161,10 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
   doctoc@2.5.0:
     resolution: {integrity: sha512-xWb2P8mQw9x+T9xPYToytRP0/bA68oexdsY0anMG72RdhZGTVPx6oHJfI57gbZe9LsOSfQUNNLwxSspdoTlJIQ==}
     hasBin: true
@@ -1167,6 +1196,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1178,6 +1210,9 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
@@ -1440,6 +1475,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -1632,6 +1672,9 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
@@ -1780,6 +1823,9 @@ packages:
   longest-streak@2.0.4:
     resolution: {integrity: sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.5.0:
     resolution: {integrity: sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==}
     engines: {node: 20 || >=22}
@@ -1907,6 +1953,10 @@ packages:
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -2063,6 +2113,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -2325,6 +2379,10 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string-width@8.2.1:
     resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
@@ -2600,6 +2658,10 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -2922,6 +2984,15 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@istanbuljs/load-nyc-config@1.1.0':
     dependencies:
       camelcase: 5.3.1
@@ -2993,6 +3064,17 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server-filesystem@2026.7.10(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      diff: 8.0.4
+      glob: 10.5.0
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+      - zod
 
   '@modelcontextprotocol/server@2.0.0-beta.5':
     dependencies:
@@ -3083,6 +3165,9 @@ snapshots:
   '@oozcitak/util@10.0.0': {}
 
   '@oxc-project/types@0.129.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
@@ -3407,6 +3492,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   append-transform@2.0.0:
     dependencies:
       default-require-extensions: 3.0.1
@@ -3435,6 +3522,8 @@ snapshots:
 
   bail@1.0.5: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.32: {}
@@ -3458,6 +3547,10 @@ snapshots:
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
+
+  brace-expansion@2.1.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.6:
     dependencies:
@@ -3634,6 +3727,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  diff@8.0.4: {}
+
   doctoc@2.5.0:
     dependencies:
       '@textlint/markdown-to-ast': 15.7.1
@@ -3684,6 +3779,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.361: {}
@@ -3691,6 +3788,8 @@ snapshots:
   emoji-regex@10.6.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encodeurl@2.0.0: {}
 
@@ -4005,6 +4104,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -4187,6 +4295,12 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jose@6.2.3: {}
 
   js-tokens@10.0.0: {}
@@ -4302,6 +4416,8 @@ snapshots:
   loglevel@1.9.2: {}
 
   longest-streak@2.0.4: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.5.0: {}
 
@@ -4494,6 +4610,10 @@ snapshots:
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -4692,6 +4812,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -4989,6 +5114,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
   string-width@8.2.1:
     dependencies:
       get-east-asian-width: 1.6.0
@@ -5228,6 +5359,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,16 @@
 # nx self-replicator, etc.). 7200 minutes = 5 days.
 minimumReleaseAge: 7200
 
+# The MCP TypeScript SDK v2 betas ship fast and mcpc tracks them closely (the
+# 2026-07-28 protocol support depends on the latest beta), so exempt the SDK
+# packages from the release-age gate. Scoped to the official
+# @modelcontextprotocol org only; everything else keeps the 5-day quarantine.
+minimumReleaseAgeExclude:
+  - "@modelcontextprotocol/client"
+  - "@modelcontextprotocol/core"
+  - "@modelcontextprotocol/server"
+  - "@modelcontextprotocol/node"
+
 # @napi-rs/keyring ships a native node binding that needs to be built/copied
 # into place on install. Without this entry pnpm v10 refuses to run its
 # postinstall script and the keychain feature breaks at runtime.

--- a/test/e2e/lib/framework.sh
+++ b/test/e2e/lib/framework.sh
@@ -633,6 +633,24 @@ _TEST_SERVER_PID=""
 _PROXY_SERVER_PID=""
 _HTTPS_WRAPPER_PID=""
 
+# Protocol era served by the test server (the protocol-version test matrix):
+#   legacy - test/e2e/server/index.ts (MCP SDK v1, protocol 2025-11-25)
+#   modern - test/e2e/server/index-v2.ts (MCP SDK v2, protocol 2026-07-28)
+# Set by run.sh --server-protocol; defaults to legacy.
+E2E_SERVER_PROTOCOL="${E2E_SERVER_PROTOCOL:-legacy}"
+
+# Skip the whole test unless the active test-server protocol era matches.
+# Call right after test_init in era-specific tests:
+#   require_server_protocol legacy   # e.g. sessions, tasks, logging-set-level
+#   require_server_protocol modern   # e.g. pure-2026-07-28 behaviors
+require_server_protocol() {
+  local required="$1"
+  if [[ "$E2E_SERVER_PROTOCOL" != "$required" ]]; then
+    echo "# SKIP: test requires the $required-protocol test server (active: $E2E_SERVER_PROTOCOL)"
+    exit 0
+  fi
+}
+
 # Start test MCP server
 # Usage: start_test_server [env_vars...]
 # Example: start_test_server PAGINATION_SIZE=2 LATENCY_MS=100
@@ -648,9 +666,15 @@ start_test_server() {
     env_str+=" $var"
   done
 
+  # Pick the server implementation for the active protocol era
+  local server_script="test/e2e/server/index.ts"
+  if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+    server_script="test/e2e/server/index-v2.ts"
+  fi
+
   # Start server
   cd "$PROJECT_ROOT"
-  env $env_str npx tsx test/e2e/server/index.ts >"$_TEST_RUN_DIR/server.log" 2>&1 &
+  env $env_str npx tsx "$server_script" >"$_TEST_RUN_DIR/server.log" 2>&1 &
   _TEST_SERVER_PID=$!
 
   # Wait for server to be ready
@@ -923,12 +947,20 @@ create_stdio_config() {
   local config_file="$TEST_TMP/config-$name.json"
   local args_json=$(printf '%s\n' "${native_args[@]}" | jq -R . | jq -s .)
 
+  # Forward proxy/TLS settings to the spawned server. The MCP SDK gives stdio
+  # children a minimal env whitelist (HOME, PATH, ...) that drops proxy and CA
+  # vars, so in proxied/TLS-intercepted environments an `npx`-launched server
+  # would stall retrying npm registry requests. Empty when none are set.
+  local env_json
+  env_json=$(jq -n 'env | {HTTP_PROXY, HTTPS_PROXY, NO_PROXY, http_proxy, https_proxy, no_proxy, NODE_EXTRA_CA_CERTS, SSL_CERT_FILE} | with_entries(select(.value != null))')
+
   cat > "$config_file" <<EOF
 {
   "mcpServers": {
     "$name": {
       "command": "$command",
-      "args": $args_json
+      "args": $args_json,
+      "env": $env_json
     }
   }
 }

--- a/test/e2e/lib/framework.sh
+++ b/test/e2e/lib/framework.sh
@@ -971,9 +971,13 @@ EOF
 
 # Create config for filesystem server
 # Usage: create_fs_config [path]
+# Runs the pnpm-pinned copy from node_modules instead of `npx -y` so tests
+# never hit the npm registry at runtime — a fresh npx install of the latest
+# version is slow and occasionally lands a broken dependency tree in CI.
 create_fs_config() {
   local path="${1:-$TEST_TMP}"
-  create_stdio_config "fs" "npx" "-y" "@modelcontextprotocol/server-filesystem" "$path"
+  create_stdio_config "fs" "node" \
+    "$PROJECT_ROOT/node_modules/@modelcontextprotocol/server-filesystem/dist/index.js" "$path"
 }
 
 # ============================================================================

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -9,6 +9,7 @@
 #
 # Options:
 #   -p, --parallel N   Max parallel tests (default: 8)
+#   -s, --server-protocol <p>  Test server protocol era: legacy (default) or modern
 #   -i, --isolated     Force all tests to use isolated home directories
 #   -c, --coverage     Collect code coverage
 #   -k, --keep         Keep test run directory after tests
@@ -30,6 +31,7 @@ VERBOSE=false
 LIST_ONLY=false
 SKIP_BUILD=false
 RUNTIME="node"
+SERVER_PROTOCOL="${E2E_SERVER_PROTOCOL:-legacy}"
 PATTERNS=()
 
 # Per-test timeout (seconds). A single hung test (e.g. an mcpc invocation that
@@ -87,6 +89,10 @@ while [[ $# -gt 0 ]]; do
       RUNTIME="$2"
       shift 2
       ;;
+    -s|--server-protocol)
+      SERVER_PROTOCOL="$2"
+      shift 2
+      ;;
     -b|--no-build)
       SKIP_BUILD=true
       shift
@@ -97,6 +103,8 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  -p, --parallel N   Max parallel tests (default: 16)"
       echo "  -r, --runtime <r>  Runtime for mcpc: node (default) or bun"
+      echo "  -s, --server-protocol <p>  Test server protocol era: legacy (default, MCP 2025-11-25)"
+      echo "                     or modern (MCP 2026-07-28); era-specific tests are skipped"
       echo "  -i, --isolated     Force all tests to use isolated home directories"
       echo "  -c, --coverage     Collect code coverage"
       echo "  -b, --no-build     Skip building mcpc (assumes dist/ is up to date)"
@@ -194,6 +202,16 @@ case "$RUNTIME" in
 esac
 export E2E_RUNTIME="$RUNTIME"
 
+# Validate test-server protocol era
+case "$SERVER_PROTOCOL" in
+  legacy|modern) ;;
+  *)
+    echo "Unknown server protocol: $SERVER_PROTOCOL (valid options: legacy, modern)" >&2
+    exit 1
+    ;;
+esac
+export E2E_SERVER_PROTOCOL="$SERVER_PROTOCOL"
+
 # List mode
 if [[ "$LIST_ONLY" == "true" ]]; then
   echo "Available tests:"
@@ -222,6 +240,7 @@ echo "Run dir:   $RUN_DIR"
 echo "Tests:     ${#TESTS[@]}"
 echo "Parallel:  $PARALLEL"
 echo "Runtime:   $RUNTIME_VERSION"
+echo "Server:    $SERVER_PROTOCOL protocol ($([[ "$SERVER_PROTOCOL" == "modern" ]] && echo "MCP 2026-07-28" || echo "MCP 2025-11-25"))"
 if [[ "$ISOLATED_ALL" == "true" ]]; then
   echo "Home dirs: isolated (per-test)"
 else
@@ -385,7 +404,7 @@ run_test() {
   echo "$result" > "$test_dir/result"
 }
 
-export SCRIPT_DIR SUITES_DIR E2E_RUN_ID E2E_RUNS_DIR E2E_SHARED_HOME E2E_ISOLATED_ALL E2E_RUNTIME PROJECT_ROOT NODE_V8_COVERAGE PER_TEST_TIMEOUT
+export SCRIPT_DIR SUITES_DIR E2E_RUN_ID E2E_RUNS_DIR E2E_SHARED_HOME E2E_ISOLATED_ALL E2E_RUNTIME E2E_SERVER_PROTOCOL PROJECT_ROOT NODE_V8_COVERAGE PER_TEST_TIMEOUT
 
 # Run tests
 echo -e "${BLUE}Running tests...${NC}"
@@ -591,6 +610,7 @@ cleanup_test_servers() {
     :
   else
     pkill -f "test/e2e/server/index.ts" 2>/dev/null || true
+    pkill -f "test/e2e/server/index-v2.ts" 2>/dev/null || true
   fi
   sleep 0.2
 }

--- a/test/e2e/server/fixtures.ts
+++ b/test/e2e/server/fixtures.ts
@@ -1,0 +1,607 @@
+/**
+ * Shared fixtures and pure helpers for the E2E test servers.
+ *
+ * Two test servers serve this identical surface (tools, resources, prompts,
+ * skills, OAuth endpoints):
+ *   - index.ts    — MCP SDK v1, protocol 2025-11-25 ("legacy" era)
+ *   - index-v2.ts — MCP SDK v2, protocol 2026-07-28 ("modern" era)
+ *
+ * Everything here is SDK-agnostic (plain objects and pure functions) so both
+ * servers stay in lockstep: a fixture change automatically applies to both
+ * columns of the protocol-version test matrix.
+ */
+
+import type http from 'http';
+
+// Deterministic binary payload for test://static/binary (not valid UTF-8)
+export const BINARY_PAYLOAD = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xfc, 0xfd, 0xfe, 0xff]);
+
+// Test data
+export const TOOLS = [
+  {
+    name: 'echo',
+    description: 'Returns the input message',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        message: { type: 'string', description: 'Message to echo' },
+      },
+      required: ['message'],
+    },
+    annotations: {
+      title: 'Echo Tool',
+      readOnlyHint: true,
+    },
+  },
+  {
+    name: 'add',
+    description: 'Adds two numbers',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        a: { type: 'number', description: 'First number' },
+        b: { type: 'number', description: 'Second number' },
+      },
+      required: ['a', 'b'],
+    },
+    annotations: {
+      title: 'Add Numbers',
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+  },
+  {
+    name: 'fail',
+    description: 'Always fails with an error',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        message: { type: 'string', description: 'Error message' },
+      },
+    },
+  },
+  {
+    name: 'slow',
+    description: 'Waits for specified milliseconds then returns',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ms: { type: 'number', description: 'Milliseconds to wait', default: 1000 },
+      },
+    },
+  },
+  {
+    name: 'write-file',
+    description: 'Simulates writing to a file (destructive)',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        path: { type: 'string', description: 'File path' },
+        content: { type: 'string', description: 'File content' },
+      },
+      required: ['path', 'content'],
+    },
+    annotations: {
+      title: 'Write File',
+      destructiveHint: true,
+    },
+  },
+  {
+    name: 'slow-task',
+    description: 'Long-running tool that supports async task execution',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {
+        ms: { type: 'number', description: 'Duration in milliseconds', default: 3000 },
+        steps: { type: 'number', description: 'Number of progress steps', default: 3 },
+      },
+    },
+  },
+];
+
+export const RESOURCES = [
+  {
+    uri: 'test://static/hello',
+    name: 'Hello Resource',
+    description: 'A static test resource',
+    mimeType: 'text/plain',
+  },
+  {
+    uri: 'test://static/json',
+    name: 'JSON Resource',
+    description: 'A JSON test resource',
+    mimeType: 'application/json',
+  },
+  {
+    uri: 'test://dynamic/time',
+    name: 'Current Time',
+    description: 'Returns current timestamp',
+    mimeType: 'text/plain',
+  },
+  {
+    uri: 'test://dynamic/counter',
+    name: 'Counter Resource',
+    description: 'Mutable counter for subscription tests (bump via /control/bump-counter)',
+    mimeType: 'text/plain',
+  },
+  {
+    uri: 'test://static/binary',
+    name: 'Binary Resource',
+    description: 'A small binary test resource (blob content)',
+    mimeType: 'application/octet-stream',
+  },
+];
+
+export const RESOURCE_TEMPLATES = [
+  {
+    uriTemplate: 'test://file/{path}',
+    name: 'File Template',
+    description: 'Access files by path',
+    mimeType: 'application/octet-stream',
+  },
+];
+
+// Skills (experimental MCP extension: io.modelcontextprotocol/skills, SEP-2640)
+// Each skill is served as one or more `skill://...` resources. The resource
+// list always includes the skill file entries; the well-known
+// `skill://index.json` is included only when the noIndex flag is unset, so
+// tests can exercise both the index path and the resource-scan fallback.
+
+const SKILL_GIT_BODY = `---
+name: git-workflow
+description: Helpers for everyday Git workflows
+---
+
+# Git workflow
+
+Stash, commit, push. The usual.
+`;
+
+const SKILL_REFUNDS_BODY = `---
+name: refunds
+description: How acme processes refund requests
+---
+
+# Refunds
+
+Acme's refund flow lives at \`acme/billing/refunds\`.
+`;
+
+// Extra non-SKILL.md file under a skill prefix — used to verify that the
+// resource-scan fallback only picks up SKILL.md entries.
+const SKILL_GIT_NOTES_BODY = `# Notes
+
+Reference notes for the git-workflow skill.
+`;
+
+const SKILL_INDEX_BODY = JSON.stringify(
+  {
+    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
+    skills: [
+      {
+        name: 'git-workflow',
+        type: 'skill-md',
+        description: 'Helpers for everyday Git workflows',
+        url: 'skill://git-workflow/SKILL.md',
+      },
+      {
+        name: 'refunds',
+        type: 'skill-md',
+        description: 'How acme processes refund requests',
+        url: 'skill://acme/billing/refunds/SKILL.md',
+      },
+      // SEP-2640 type: bundled skill delivered as a single archive resource.
+      {
+        name: 'big-skill',
+        type: 'archive',
+        description: 'A bundled skill delivered as .tar.gz',
+        url: 'skill://big-skill/big-skill.tar.gz',
+      },
+      // Entry with unrecognized type — clients SHOULD skip it.
+      {
+        name: 'future-thing',
+        type: 'something-not-in-spec',
+        description: 'Reserved for a future spec version',
+        url: 'skill://future-thing/SKILL.md',
+      },
+    ],
+  },
+  null,
+  2
+);
+
+// Skill file resources always exposed when skills are enabled
+const SKILL_FILE_RESOURCES = [
+  {
+    uri: 'skill://git-workflow/SKILL.md',
+    name: 'git-workflow',
+    description: 'Helpers for everyday Git workflows',
+    mimeType: 'text/markdown',
+  },
+  {
+    uri: 'skill://acme/billing/refunds/SKILL.md',
+    name: 'refunds',
+    description: 'How acme processes refund requests',
+    mimeType: 'text/markdown',
+  },
+  {
+    uri: 'skill://git-workflow/references/notes.md',
+    name: 'git-workflow notes',
+    description: 'Supporting notes for git-workflow',
+    mimeType: 'text/markdown',
+  },
+];
+
+const SKILL_INDEX_RESOURCE = {
+  uri: 'skill://index.json',
+  name: 'Skills index',
+  description: 'Skills discovery index (SEP-2640)',
+  mimeType: 'application/json',
+};
+
+/** Resource list entry shape shared by RESOURCES and the skills fixtures. */
+export type TestResource = {
+  uri: string;
+  name?: string;
+  description?: string;
+  mimeType?: string;
+};
+
+/**
+ * Compute the effective skills resource list and content map for the given
+ * env configuration (WITH_SKILLS / SKILLS_NO_INDEX).
+ */
+export function computeSkillsFixtures(
+  withSkills: boolean,
+  noIndex: boolean
+): {
+  resources: TestResource[];
+  contents: Record<string, { mimeType: string; text: string }>;
+} {
+  if (!withSkills) {
+    return { resources: [], contents: {} };
+  }
+  return {
+    resources: noIndex
+      ? [...SKILL_FILE_RESOURCES]
+      : [SKILL_INDEX_RESOURCE, ...SKILL_FILE_RESOURCES],
+    contents: {
+      'skill://git-workflow/SKILL.md': { mimeType: 'text/markdown', text: SKILL_GIT_BODY },
+      'skill://acme/billing/refunds/SKILL.md': {
+        mimeType: 'text/markdown',
+        text: SKILL_REFUNDS_BODY,
+      },
+      'skill://git-workflow/references/notes.md': {
+        mimeType: 'text/markdown',
+        text: SKILL_GIT_NOTES_BODY,
+      },
+      ...(noIndex
+        ? {}
+        : { 'skill://index.json': { mimeType: 'application/json', text: SKILL_INDEX_BODY } }),
+    },
+  };
+}
+
+export const PROMPTS = [
+  {
+    name: 'greeting',
+    description: 'Generate a greeting message',
+    arguments: [
+      { name: 'name', description: 'Name to greet', required: true },
+      { name: 'style', description: 'Greeting style (formal/casual)', required: false },
+    ],
+  },
+  {
+    name: 'summarize',
+    description: 'Summarize text',
+    arguments: [
+      { name: 'text', description: 'Text to summarize', required: true },
+      { name: 'maxLength', description: 'Maximum length', required: false },
+    ],
+  },
+];
+
+/**
+ * Paginate a fixture list. pageSize <= 0 disables pagination.
+ * The cursor is the stringified start index of the next page.
+ */
+export function paginate<T>(
+  items: T[],
+  cursor: string | undefined,
+  pageSize: number
+): { items: T[]; nextCursor?: string } {
+  if (pageSize <= 0) {
+    return { items };
+  }
+
+  const startIndex = cursor ? parseInt(cursor, 10) : 0;
+  const endIndex = startIndex + pageSize;
+  const pageItems = items.slice(startIndex, endIndex);
+
+  // Only include nextCursor when there are more items (exactOptionalPropertyTypes compatibility)
+  if (endIndex < items.length) {
+    return { items: pageItems, nextCursor: String(endIndex) };
+  }
+  return { items: pageItems };
+}
+
+/** Read a request body to a string (for the form-encoded /token endpoint). */
+export function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+/** Text tool-call result shared by both servers. */
+export type TestToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+};
+
+/**
+ * Execute one of the shared test tools (synchronous semantics only — the v1
+ * server intercepts task-augmented `slow-task` calls before delegating here).
+ * Throws on tool failure or unknown tool name, mirroring server-side errors.
+ */
+export async function callTestTool(
+  name: string,
+  args: Record<string, unknown> | undefined
+): Promise<TestToolResult> {
+  switch (name) {
+    case 'echo':
+      return {
+        content: [{ type: 'text', text: String(args?.message || '') }],
+      };
+
+    case 'add': {
+      const a = Number(args?.a || 0);
+      const b = Number(args?.b || 0);
+      return {
+        content: [{ type: 'text', text: String(a + b) }],
+      };
+    }
+
+    case 'fail':
+      throw new Error(String(args?.message || 'Tool intentionally failed'));
+
+    case 'slow': {
+      const ms = Number(args?.ms || 1000);
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      return {
+        content: [{ type: 'text', text: `Waited ${ms}ms` }],
+      };
+    }
+
+    case 'write-file':
+      // Simulate write (don't actually write)
+      return {
+        content: [{ type: 'text', text: `Would write to ${args?.path}` }],
+      };
+
+    case 'slow-task': {
+      // Synchronous execution (task-augmented execution is v1-server-only)
+      const ms = Number(args?.ms || 3000);
+      const steps = Number(args?.steps || 3);
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      return {
+        content: [{ type: 'text', text: `Completed ${steps} steps in ${ms}ms` }],
+      };
+    }
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+}
+
+/** Resource read result contents shared by both servers. */
+export type TestResourceContents = {
+  contents: Array<
+    | { uri: string; mimeType: string; text: string }
+    | { uri: string; mimeType: string; blob: string }
+  >;
+};
+
+/**
+ * Read one of the shared test resources. Returns null when the URI is not a
+ * known resource (each server maps that to its own not-found error).
+ */
+export function readTestResource(
+  uri: string,
+  counterValue: number,
+  skillContents: Record<string, { mimeType: string; text: string }>
+): TestResourceContents | null {
+  if (uri === 'test://static/hello') {
+    return {
+      contents: [{ uri, mimeType: 'text/plain', text: 'Hello, World!' }],
+    };
+  }
+
+  if (uri === 'test://static/json') {
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/json',
+          text: JSON.stringify({ test: true, value: 42 }),
+        },
+      ],
+    };
+  }
+
+  if (uri === 'test://dynamic/time') {
+    return {
+      contents: [{ uri, mimeType: 'text/plain', text: new Date().toISOString() }],
+    };
+  }
+
+  if (uri === 'test://dynamic/counter') {
+    return {
+      contents: [{ uri, mimeType: 'text/plain', text: `counter=${counterValue}` }],
+    };
+  }
+
+  if (uri === 'test://static/binary') {
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: 'application/octet-stream',
+          blob: BINARY_PAYLOAD.toString('base64'),
+        },
+      ],
+    };
+  }
+
+  // Skill resources (SEP-2640). May include the well-known
+  // skill://index.json plus per-skill SKILL.md files.
+  const skillContent = skillContents[uri];
+  if (skillContent) {
+    return {
+      contents: [{ uri, mimeType: skillContent.mimeType, text: skillContent.text }],
+    };
+  }
+
+  return null;
+}
+
+/** Prompt result shared by both servers. */
+export type TestPromptResult = {
+  messages: Array<{ role: 'user'; content: { type: 'text'; text: string } }>;
+};
+
+/**
+ * Build one of the shared test prompts. Returns null when the prompt name is
+ * unknown (each server maps that to its own not-found error).
+ */
+export function getTestPrompt(
+  name: string,
+  args: Record<string, string> | undefined
+): TestPromptResult | null {
+  if (name === 'greeting') {
+    const userName = args?.name || 'World';
+    const style = args?.style || 'casual';
+    const greeting = style === 'formal' ? `Good day, ${userName}.` : `Hey ${userName}!`;
+
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: greeting },
+        },
+      ],
+    };
+  }
+
+  if (name === 'summarize') {
+    const text = args?.text || '';
+    const maxLength = args?.maxLength ? parseInt(args.maxLength, 10) : 100;
+
+    return {
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: `Please summarize the following text in ${maxLength} characters or less:\n\n${text}`,
+          },
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+/** Configuration for the OAuth client-credentials test endpoints. */
+export interface OAuthEndpointsConfig {
+  port: number;
+  clientId: string;
+  clientSecret: string;
+  /** Serve /token but NOT the .well-known metadata (forces --token-endpoint). */
+  noMetadata: boolean;
+}
+
+/**
+ * Serve the OAuth client-credentials test endpoints (RFC 8414 metadata +
+ * /token). Returns true when the request was handled. These endpoints must be
+ * reachable without a Bearer token, so call this before any auth check.
+ */
+export async function handleOAuthEndpoints(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: URL,
+  config: OAuthEndpointsConfig
+): Promise<boolean> {
+  if (
+    !config.noMetadata &&
+    url.pathname === '/.well-known/oauth-authorization-server' &&
+    req.method === 'GET'
+  ) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        issuer: `http://localhost:${config.port}`,
+        // authorization_endpoint + response_types_supported are required by RFC 8414;
+        // the SDK validates the full metadata document even for the token-only path.
+        authorization_endpoint: `http://localhost:${config.port}/authorize`,
+        token_endpoint: `http://localhost:${config.port}/token`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['client_credentials'],
+        token_endpoint_auth_methods_supported: ['client_secret_basic', 'private_key_jwt'],
+      })
+    );
+    return true;
+  }
+
+  if (url.pathname === '/token' && req.method === 'POST') {
+    const params = new URLSearchParams(await readBody(req));
+    if (params.get('grant_type') !== 'client_credentials') {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'unsupported_grant_type' }));
+      return true;
+    }
+
+    // Accept either client_secret_basic, client_secret_post, or private_key_jwt.
+    // The JWT assertion's signature is not verified here — presence is enough to
+    // prove the client (mcpc + SDK) built and sent it correctly.
+    let authed = false;
+    const authz = req.headers.authorization;
+    if (authz?.startsWith('Basic ')) {
+      const decoded = Buffer.from(authz.slice('Basic '.length), 'base64').toString('utf8');
+      const sep = decoded.indexOf(':');
+      const id = decodeURIComponent(decoded.slice(0, sep));
+      const secret = decodeURIComponent(decoded.slice(sep + 1));
+      authed = id === config.clientId && secret === config.clientSecret;
+    } else if (params.get('client_assertion') && params.get('client_assertion_type')) {
+      authed = true;
+    } else if (params.get('client_id') && params.get('client_secret')) {
+      authed =
+        params.get('client_id') === config.clientId &&
+        params.get('client_secret') === config.clientSecret;
+    }
+
+    if (!authed) {
+      res.writeHead(401, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'invalid_client' }));
+      return true;
+    }
+
+    const scope = params.get('scope');
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        access_token: `cc-token-${Date.now()}`,
+        token_type: 'Bearer',
+        expires_in: 3600,
+        ...(scope ? { scope } : {}),
+      })
+    );
+    return true;
+  }
+
+  return false;
+}

--- a/test/e2e/server/index-v2.ts
+++ b/test/e2e/server/index-v2.ts
@@ -1,0 +1,424 @@
+#!/usr/bin/env npx tsx
+/**
+ * Configurable MCP test server for E2E testing (MCP SDK v2, protocol
+ * 2026-07-28 — the "modern" era column of the protocol-version test matrix;
+ * see index.ts for the 2025-11-25 counterpart serving the same surface).
+ *
+ * Serves the same tools, resources, prompts, skills, and control endpoints as
+ * index.ts (shared via fixtures.ts), over the stateless 2026-07-28 protocol:
+ * no sessions, per-request identity `_meta`, and `subscriptions/listen`
+ * streams instead of `resources/subscribe` + unsolicited notifications.
+ *
+ * Environment variables: same as index.ts, plus
+ *   LEGACY_MODE - how 2025-era requests are answered (default: reject)
+ *     reject    - v2-only strict mode: legacy requests get the
+ *                 unsupported-protocol-version error, proving that clients
+ *                 talk pure 2026-07-28 to this server
+ *     stateless - serve 2025-era requests statelessly (no session IDs)
+ *
+ * Control endpoints: same as index.ts where applicable. Session-oriented
+ * endpoints (get-active-sessions, get-deleted-sessions, get-subscriptions,
+ * expire-session) respond with 501 — the 2026-07-28 protocol has no session
+ * state; suites that need them are legacy-era-specific.
+ */
+
+import { Server, createMcpHandler, type ServerCapabilities } from '@modelcontextprotocol/server';
+import { toNodeHandler } from '@modelcontextprotocol/node';
+import http from 'http';
+import {
+  TOOLS,
+  RESOURCES,
+  RESOURCE_TEMPLATES,
+  PROMPTS,
+  computeSkillsFixtures,
+  paginate,
+  callTestTool,
+  readTestResource,
+  getTestPrompt,
+  handleOAuthEndpoints,
+} from './fixtures.js';
+
+// Configuration from environment (same variables as index.ts)
+const PORT = parseInt(process.env.PORT || '13456', 10);
+const PAGINATION_SIZE = parseInt(process.env.PAGINATION_SIZE || '0', 10);
+const LATENCY_MS = parseInt(process.env.LATENCY_MS || '0', 10);
+const REQUIRE_AUTH = process.env.REQUIRE_AUTH === 'true';
+const NO_TOOLS = process.env.NO_TOOLS === 'true';
+const NO_RESOURCES = process.env.NO_RESOURCES === 'true';
+const NO_PROMPTS = process.env.NO_PROMPTS === 'true';
+const WITH_SKILLS = process.env.WITH_SKILLS === 'true';
+const SKILLS_NO_INDEX = process.env.SKILLS_NO_INDEX === 'true';
+const WITH_OAUTH = process.env.WITH_OAUTH === 'true';
+const OAUTH_CLIENT_ID = process.env.OAUTH_CLIENT_ID || 'test-client';
+const OAUTH_CLIENT_SECRET = process.env.OAUTH_CLIENT_SECRET || 's3cr3t';
+const OAUTH_NO_METADATA = process.env.OAUTH_NO_METADATA === 'true';
+const LEGACY_MODE = process.env.LEGACY_MODE === 'stateless' ? 'stateless' : 'reject';
+
+// Control state (manipulated via /control/* endpoints). Module-level so it is
+// shared across the per-request server instances the factory creates.
+let failNextCount = 0;
+
+// Mutable counter resource state (bumped via /control/bump-counter)
+let counterValue = 0;
+
+// Compute the effective skills resource list and content map at startup.
+const { resources: SKILLS_RESOURCES, contents: SKILL_CONTENTS } = computeSkillsFixtures(
+  WITH_SKILLS,
+  SKILLS_NO_INDEX
+);
+
+// Helper for artificial latency
+async function maybeDelay(): Promise<void> {
+  if (LATENCY_MS > 0) {
+    await new Promise((resolve) => setTimeout(resolve, LATENCY_MS));
+  }
+}
+
+// Helper to check if we should fail
+function shouldFail(): boolean {
+  if (failNextCount > 0) {
+    failNextCount--;
+    return true;
+  }
+  return false;
+}
+
+// Create a new MCP server instance. createMcpHandler calls this once per HTTP
+// request (the stateless 2026-07-28 serving model), so it must be cheap and
+// all mutable state must live at module level.
+function createTestServer(): Server {
+  // Build capabilities based on env config. No `tasks` capability: the
+  // 2025-11-25 experimental tasks moved to the io.modelcontextprotocol/tasks
+  // extension in 2026-07-28, which the v2 SDK does not implement yet.
+  const capabilities: ServerCapabilities = {
+    logging: {},
+  };
+  if (!NO_TOOLS) {
+    capabilities.tools = { listChanged: true };
+  }
+  if (!NO_RESOURCES) {
+    capabilities.resources = { subscribe: true, listChanged: true };
+  }
+  if (!NO_PROMPTS) {
+    capabilities.prompts = { listChanged: true };
+  }
+  // Advertise the experimental skills extension when skill resources are
+  // exposed (SEP-2640), mirroring index.ts.
+  if (WITH_SKILLS && !NO_RESOURCES) {
+    const SKILLS_KEY = 'io.modelcontextprotocol/skills';
+    capabilities.extensions = { [SKILLS_KEY]: {} };
+    capabilities.experimental = { [SKILLS_KEY]: {} };
+  }
+
+  const server = new Server(
+    {
+      name: 'e2e-test-server',
+      version: '2.0.0',
+    },
+    {
+      capabilities,
+      instructions:
+        'E2E test server for mcpc. Provides sample tools, resources, and prompts for testing.',
+    }
+  );
+
+  // Tools (only register handlers if capability is enabled)
+  if (!NO_TOOLS) {
+    server.setRequestHandler('tools/list', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { items, nextCursor } = paginate(TOOLS, request.params?.cursor, PAGINATION_SIZE);
+      return { tools: items, ...(nextCursor !== undefined ? { nextCursor } : {}) };
+    });
+
+    server.setRequestHandler('tools/call', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { name, arguments: args } = request.params;
+      return callTestTool(name, args);
+    });
+  }
+
+  // Resources (only register handlers if capability is enabled)
+  if (!NO_RESOURCES) {
+    server.setRequestHandler('resources/list', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const all = [...RESOURCES, ...SKILLS_RESOURCES];
+      const { items, nextCursor } = paginate(all, request.params?.cursor, PAGINATION_SIZE);
+      return { resources: items, ...(nextCursor !== undefined ? { nextCursor } : {}) };
+    });
+
+    server.setRequestHandler('resources/templates/list', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { items, nextCursor } = paginate(
+        RESOURCE_TEMPLATES,
+        request.params?.cursor,
+        PAGINATION_SIZE
+      );
+      return { resourceTemplates: items, ...(nextCursor !== undefined ? { nextCursor } : {}) };
+    });
+
+    server.setRequestHandler('resources/read', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { uri } = request.params;
+      const contents = readTestResource(uri, counterValue, SKILL_CONTENTS);
+      if (!contents) {
+        throw new Error(`Resource not found: ${uri}`);
+      }
+      return contents;
+    });
+
+    // resources/subscribe and resources/unsubscribe exist only in the 2025-era
+    // protocol (2026-07-28 uses subscriptions/listen streams, which
+    // createMcpHandler serves itself). Registered for the legacy-stateless
+    // serving mode; never reached in the default v2-only reject mode.
+    server.setRequestHandler('resources/subscribe', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { uri } = request.params;
+      const known = [...RESOURCES, ...SKILLS_RESOURCES].some((r) => r.uri === uri);
+      if (!known) {
+        throw new Error(`Resource not found: ${uri}`);
+      }
+      return {};
+    });
+
+    server.setRequestHandler('resources/unsubscribe', async () => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      return {};
+    });
+  }
+
+  // Prompts (only register handlers if capability is enabled)
+  if (!NO_PROMPTS) {
+    server.setRequestHandler('prompts/list', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { items, nextCursor } = paginate(PROMPTS, request.params?.cursor, PAGINATION_SIZE);
+      return { prompts: items, ...(nextCursor !== undefined ? { nextCursor } : {}) };
+    });
+
+    server.setRequestHandler('prompts/get', async (request) => {
+      await maybeDelay();
+      if (shouldFail()) {
+        throw new Error('Simulated failure');
+      }
+
+      const { name, arguments: args } = request.params;
+      const prompt = getTestPrompt(name, args);
+      if (!prompt) {
+        throw new Error(`Prompt not found: ${name}`);
+      }
+      return prompt;
+    });
+  }
+
+  return server;
+}
+
+// Create HTTP server with the MCP handler and control endpoints
+async function main() {
+  const mcpHandler = createMcpHandler(() => createTestServer(), {
+    legacy: LEGACY_MODE,
+    onerror: (error) => {
+      console.error('MCP handler error:', error.message);
+    },
+  });
+  const nodeHandler = toNodeHandler(mcpHandler);
+
+  const httpServer = http.createServer(async (req, res) => {
+    const url = new URL(req.url || '/', `http://localhost:${PORT}`);
+
+    // Health check
+    if (url.pathname === '/health' && req.method === 'GET') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    // Control endpoints
+    if (url.pathname.startsWith('/control/')) {
+      const action = url.pathname.slice('/control/'.length);
+
+      // Session-oriented endpoints have no 2026-07-28 analogue (stateless
+      // protocol, no session IDs) — answer 501 loudly so a suite that should
+      // be marked legacy-era-specific fails visibly instead of silently.
+      if (
+        action === 'get-deleted-sessions' ||
+        action === 'get-active-sessions' ||
+        action === 'get-subscriptions' ||
+        action === 'expire-session'
+      ) {
+        res.writeHead(501, { 'Content-Type': 'application/json' });
+        res.end(
+          JSON.stringify({ error: `${action} is not applicable to the 2026-07-28 test server` })
+        );
+        return;
+      }
+
+      if (req.method !== 'POST') {
+        res.writeHead(404);
+        res.end('Unknown control action');
+        return;
+      }
+
+      switch (action) {
+        case 'fail-next': {
+          const count = parseInt(url.searchParams.get('count') || '1', 10);
+          failNextCount = count;
+          res.writeHead(200);
+          res.end(`Will fail next ${count} requests`);
+          return;
+        }
+
+        case 'reset':
+          failNextCount = 0;
+          counterValue = 0;
+          res.writeHead(200);
+          res.end('State reset');
+          return;
+
+        // Change notifications are published onto the handler's
+        // subscriptions/listen bus: every open listen stream that opted in to
+        // the notification type receives it (the 2026-07-28 delivery model).
+        case 'notify-tools-changed':
+          mcpHandler.notify.toolsChanged();
+          res.writeHead(200);
+          res.end('Sent tools/list_changed notification');
+          return;
+
+        case 'notify-prompts-changed':
+          mcpHandler.notify.promptsChanged();
+          res.writeHead(200);
+          res.end('Sent prompts/list_changed notification');
+          return;
+
+        case 'notify-resources-changed':
+          mcpHandler.notify.resourcesChanged();
+          res.writeHead(200);
+          res.end('Sent resources/list_changed notification');
+          return;
+
+        case 'bump-counter': {
+          // Increment the counter resource and notify listen streams
+          // subscribed to it
+          counterValue++;
+          mcpHandler.notify.resourceUpdated('test://dynamic/counter');
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ counter: counterValue }));
+          return;
+        }
+
+        case 'notify-resource-updated': {
+          // Publish resources/updated for an arbitrary URI. Unlike the v1
+          // server there is no "all sessions" fan-out to bypass: the bus
+          // delivers only to listen streams whose honored filter includes the
+          // URI (server-side filtering is inherent to the 2026-07-28 model).
+          const uri = url.searchParams.get('uri') || 'test://dynamic/counter';
+          mcpHandler.notify.resourceUpdated(uri);
+          res.writeHead(200);
+          res.end(`Sent resources/updated for ${uri}`);
+          return;
+        }
+
+        default:
+          res.writeHead(404);
+          res.end('Unknown control action');
+          return;
+      }
+    }
+
+    // OAuth client-credentials endpoints (opt-in via WITH_OAUTH). These must be
+    // reachable without a Bearer token, so they precede the REQUIRE_AUTH check.
+    if (WITH_OAUTH) {
+      const handled = await handleOAuthEndpoints(req, res, url, {
+        port: PORT,
+        clientId: OAUTH_CLIENT_ID,
+        clientSecret: OAUTH_CLIENT_SECRET,
+        noMetadata: OAUTH_NO_METADATA,
+      });
+      if (handled) {
+        return;
+      }
+    }
+
+    // Auth check
+    if (REQUIRE_AUTH) {
+      const auth = req.headers.authorization;
+      if (!auth || !auth.startsWith('Bearer ')) {
+        res.writeHead(401, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Unauthorized' }));
+        return;
+      }
+    }
+
+    // MCP endpoint
+    if (url.pathname === '/' || url.pathname === '/mcp') {
+      await nodeHandler(req, res);
+      return;
+    }
+
+    // 404 for unknown paths
+    res.writeHead(404);
+    res.end('Not found');
+  });
+
+  httpServer.listen(PORT, () => {
+    console.log(`E2E test server (2026-07-28) running on http://localhost:${PORT}`);
+    console.log(
+      `  Pagination: ${PAGINATION_SIZE > 0 ? `${PAGINATION_SIZE} items/page` : 'disabled'}`
+    );
+    console.log(`  Latency: ${LATENCY_MS}ms`);
+    console.log(`  Auth required: ${REQUIRE_AUTH}`);
+    console.log(`  Legacy (2025-era) requests: ${LEGACY_MODE}`);
+    if (NO_TOOLS) console.log(`  Tools: DISABLED`);
+    if (NO_RESOURCES) console.log(`  Resources: DISABLED`);
+    if (NO_PROMPTS) console.log(`  Prompts: DISABLED`);
+    if (WITH_SKILLS) {
+      console.log(`  Skills: ENABLED${SKILLS_NO_INDEX ? ' (index OFF, fallback only)' : ''}`);
+    }
+  });
+
+  // Graceful shutdown
+  const shutdown = () => {
+    console.log('Shutting down...');
+    void mcpHandler.close().catch(() => {});
+    httpServer.close();
+    process.exit(0);
+  };
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+}
+
+main().catch((error) => {
+  console.error('Server error:', error);
+  process.exit(1);
+});

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env npx ts-node
 /**
- * Configurable MCP test server for E2E testing
+ * Configurable MCP test server for E2E testing (MCP SDK v1, protocol
+ * 2025-11-25 — the "legacy" era column of the protocol-version test matrix;
+ * see index-v2.ts for the 2026-07-28 counterpart serving the same surface).
  *
  * Environment variables:
  *   PORT - HTTP port (default: 13456)
@@ -50,6 +52,18 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { randomUUID } from 'crypto';
 import http from 'http';
+import {
+  TOOLS,
+  RESOURCES,
+  RESOURCE_TEMPLATES,
+  PROMPTS,
+  computeSkillsFixtures,
+  paginate,
+  callTestTool,
+  readTestResource,
+  getTestPrompt,
+  handleOAuthEndpoints,
+} from './fixtures.js';
 
 // Configuration from environment
 const PORT = parseInt(process.env.PORT || '13456', 10);
@@ -78,314 +92,21 @@ const deletedSessions: string[] = [];
 // Mutable counter resource state (bumped via /control/bump-counter)
 let counterValue = 0;
 
-// Deterministic binary payload for test://static/binary (not valid UTF-8)
-const BINARY_PAYLOAD = Buffer.from([0x00, 0x01, 0x02, 0x03, 0xfc, 0xfd, 0xfe, 0xff]);
-
 // Resource URIs subscribed per MCP server instance (resources/subscribe)
 const serverSubscriptions = new WeakMap<Server, Set<string>>();
 
-// Test data
-const TOOLS = [
-  {
-    name: 'echo',
-    description: 'Returns the input message',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        message: { type: 'string', description: 'Message to echo' },
-      },
-      required: ['message'],
-    },
-    annotations: {
-      title: 'Echo Tool',
-      readOnlyHint: true,
-    },
-  },
-  {
-    name: 'add',
-    description: 'Adds two numbers',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        a: { type: 'number', description: 'First number' },
-        b: { type: 'number', description: 'Second number' },
-      },
-      required: ['a', 'b'],
-    },
-    annotations: {
-      title: 'Add Numbers',
-      readOnlyHint: true,
-      idempotentHint: true,
-    },
-  },
-  {
-    name: 'fail',
-    description: 'Always fails with an error',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        message: { type: 'string', description: 'Error message' },
-      },
-    },
-  },
-  {
-    name: 'slow',
-    description: 'Waits for specified milliseconds then returns',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        ms: { type: 'number', description: 'Milliseconds to wait', default: 1000 },
-      },
-    },
-  },
-  {
-    name: 'write-file',
-    description: 'Simulates writing to a file (destructive)',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        path: { type: 'string', description: 'File path' },
-        content: { type: 'string', description: 'File content' },
-      },
-      required: ['path', 'content'],
-    },
-    annotations: {
-      title: 'Write File',
-      destructiveHint: true,
-    },
-  },
-  {
-    name: 'slow-task',
-    description: 'Long-running tool that supports async task execution',
-    inputSchema: {
-      type: 'object' as const,
-      properties: {
-        ms: { type: 'number', description: 'Duration in milliseconds', default: 3000 },
-        steps: { type: 'number', description: 'Number of progress steps', default: 3 },
-      },
-    },
-    execution: {
-      taskSupport: 'optional' as const,
-    },
-  },
-];
-
-const RESOURCES = [
-  {
-    uri: 'test://static/hello',
-    name: 'Hello Resource',
-    description: 'A static test resource',
-    mimeType: 'text/plain',
-  },
-  {
-    uri: 'test://static/json',
-    name: 'JSON Resource',
-    description: 'A JSON test resource',
-    mimeType: 'application/json',
-  },
-  {
-    uri: 'test://dynamic/time',
-    name: 'Current Time',
-    description: 'Returns current timestamp',
-    mimeType: 'text/plain',
-  },
-  {
-    uri: 'test://dynamic/counter',
-    name: 'Counter Resource',
-    description: 'Mutable counter for subscription tests (bump via /control/bump-counter)',
-    mimeType: 'text/plain',
-  },
-  {
-    uri: 'test://static/binary',
-    name: 'Binary Resource',
-    description: 'A small binary test resource (blob content)',
-    mimeType: 'application/octet-stream',
-  },
-];
-
-const RESOURCE_TEMPLATES = [
-  {
-    uriTemplate: 'test://file/{path}',
-    name: 'File Template',
-    description: 'Access files by path',
-    mimeType: 'application/octet-stream',
-  },
-];
-
-// Skills (experimental MCP extension: io.modelcontextprotocol/skills, SEP-2640)
-// Each skill is served as one or more `skill://...` resources. The resource
-// list always includes the skill file entries; the well-known
-// `skill://index.json` is included only when SKILLS_NO_INDEX is unset, so
-// tests can exercise both the index path and the resource-scan fallback.
-
-const SKILL_GIT_BODY = `---
-name: git-workflow
-description: Helpers for everyday Git workflows
----
-
-# Git workflow
-
-Stash, commit, push. The usual.
-`;
-
-const SKILL_REFUNDS_BODY = `---
-name: refunds
-description: How acme processes refund requests
----
-
-# Refunds
-
-Acme's refund flow lives at \`acme/billing/refunds\`.
-`;
-
-// Extra non-SKILL.md file under a skill prefix — used to verify that the
-// resource-scan fallback only picks up SKILL.md entries.
-const SKILL_GIT_NOTES_BODY = `# Notes
-
-Reference notes for the git-workflow skill.
-`;
-
-const SKILL_INDEX_BODY = JSON.stringify(
-  {
-    $schema: 'https://schemas.agentskills.io/discovery/0.2.0/schema.json',
-    skills: [
-      {
-        name: 'git-workflow',
-        type: 'skill-md',
-        description: 'Helpers for everyday Git workflows',
-        url: 'skill://git-workflow/SKILL.md',
-      },
-      {
-        name: 'refunds',
-        type: 'skill-md',
-        description: 'How acme processes refund requests',
-        url: 'skill://acme/billing/refunds/SKILL.md',
-      },
-      // SEP-2640 type: bundled skill delivered as a single archive resource.
-      {
-        name: 'big-skill',
-        type: 'archive',
-        description: 'A bundled skill delivered as .tar.gz',
-        url: 'skill://big-skill/big-skill.tar.gz',
-      },
-      // Entry with unrecognized type — clients SHOULD skip it.
-      {
-        name: 'future-thing',
-        type: 'something-not-in-spec',
-        description: 'Reserved for a future spec version',
-        url: 'skill://future-thing/SKILL.md',
-      },
-    ],
-  },
-  null,
-  2
+// The task-augmented slow-task tool advertises optional task support
+// (2025-11-25 experimental tasks — v1 server only; tasks moved to an
+// extension in 2026-07-28 that the v2 SDK does not implement yet).
+const V1_TOOLS = TOOLS.map((tool) =>
+  tool.name === 'slow-task' ? { ...tool, execution: { taskSupport: 'optional' as const } } : tool
 );
 
-// Skill file resources always exposed (when NO_SKILLS is unset)
-const SKILL_FILE_RESOURCES = [
-  {
-    uri: 'skill://git-workflow/SKILL.md',
-    name: 'git-workflow',
-    description: 'Helpers for everyday Git workflows',
-    mimeType: 'text/markdown',
-  },
-  {
-    uri: 'skill://acme/billing/refunds/SKILL.md',
-    name: 'refunds',
-    description: 'How acme processes refund requests',
-    mimeType: 'text/markdown',
-  },
-  {
-    uri: 'skill://git-workflow/references/notes.md',
-    name: 'git-workflow notes',
-    description: 'Supporting notes for git-workflow',
-    mimeType: 'text/markdown',
-  },
-];
-
-const SKILL_INDEX_RESOURCE = {
-  uri: 'skill://index.json',
-  name: 'Skills index',
-  description: 'Skills discovery index (SEP-2640)',
-  mimeType: 'application/json',
-};
-
 // Compute the effective skills resource list and content map at startup.
-const SKILLS_RESOURCES: Array<{
-  uri: string;
-  name?: string;
-  description?: string;
-  mimeType?: string;
-}> = !WITH_SKILLS
-  ? []
-  : SKILLS_NO_INDEX
-    ? [...SKILL_FILE_RESOURCES]
-    : [SKILL_INDEX_RESOURCE, ...SKILL_FILE_RESOURCES];
-
-const SKILL_CONTENTS: Record<string, { mimeType: string; text: string }> = !WITH_SKILLS
-  ? {}
-  : {
-      'skill://git-workflow/SKILL.md': { mimeType: 'text/markdown', text: SKILL_GIT_BODY },
-      'skill://acme/billing/refunds/SKILL.md': {
-        mimeType: 'text/markdown',
-        text: SKILL_REFUNDS_BODY,
-      },
-      'skill://git-workflow/references/notes.md': {
-        mimeType: 'text/markdown',
-        text: SKILL_GIT_NOTES_BODY,
-      },
-      ...(SKILLS_NO_INDEX
-        ? {}
-        : { 'skill://index.json': { mimeType: 'application/json', text: SKILL_INDEX_BODY } }),
-    };
-
-const PROMPTS = [
-  {
-    name: 'greeting',
-    description: 'Generate a greeting message',
-    arguments: [
-      { name: 'name', description: 'Name to greet', required: true },
-      { name: 'style', description: 'Greeting style (formal/casual)', required: false },
-    ],
-  },
-  {
-    name: 'summarize',
-    description: 'Summarize text',
-    arguments: [
-      { name: 'text', description: 'Text to summarize', required: true },
-      { name: 'maxLength', description: 'Maximum length', required: false },
-    ],
-  },
-];
-
-// Helper for pagination
-function paginate<T>(items: T[], cursor?: string): { items: T[]; nextCursor?: string } {
-  if (PAGINATION_SIZE <= 0) {
-    return { items };
-  }
-
-  const startIndex = cursor ? parseInt(cursor, 10) : 0;
-  const endIndex = startIndex + PAGINATION_SIZE;
-  const pageItems = items.slice(startIndex, endIndex);
-
-  // Only include nextCursor when there are more items (exactOptionalPropertyTypes compatibility)
-  if (endIndex < items.length) {
-    return { items: pageItems, nextCursor: String(endIndex) };
-  }
-  return { items: pageItems };
-}
-
-// Read a request body to a string (for the form-encoded /token endpoint).
-function readBody(req: http.IncomingMessage): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let data = '';
-    req.on('data', (chunk) => {
-      data += chunk;
-    });
-    req.on('end', () => resolve(data));
-    req.on('error', reject);
-  });
-}
+const { resources: SKILLS_RESOURCES, contents: SKILL_CONTENTS } = computeSkillsFixtures(
+  WITH_SKILLS,
+  SKILLS_NO_INDEX
+);
 
 // Helper for artificial latency
 async function maybeDelay(): Promise<void> {
@@ -471,7 +192,7 @@ function createMcpServer(): Server {
         throw new Error('Simulated failure');
       }
 
-      const { items, nextCursor } = paginate(TOOLS, request.params?.cursor);
+      const { items, nextCursor } = paginate(V1_TOOLS, request.params?.cursor, PAGINATION_SIZE);
       return { tools: items, nextCursor };
     });
 
@@ -483,99 +204,56 @@ function createMcpServer(): Server {
 
       const { name, arguments: args } = request.params;
 
-      switch (name) {
-        case 'echo':
-          return {
-            content: [{ type: 'text', text: String(args?.message || '') }],
-          };
+      if (name === 'slow-task' && request.params.task) {
+        // Task-augmented execution: create task and run in background
+        const ms = Number(args?.ms || 3000);
+        const steps = Number(args?.steps || 3);
+        const taskId = randomUUID();
+        const now = new Date().toISOString();
+        const task: Task = {
+          taskId,
+          status: 'working',
+          ttl: null,
+          createdAt: now,
+          lastUpdatedAt: now,
+          statusMessage: 'Starting...',
+        };
+        const abortController = new AbortController();
+        taskStore.set(taskId, { task, abortController });
 
-        case 'add': {
-          const a = Number(args?.a || 0);
-          const b = Number(args?.b || 0);
-          return {
-            content: [{ type: 'text', text: String(a + b) }],
-          };
-        }
-
-        case 'fail':
-          throw new Error(String(args?.message || 'Tool intentionally failed'));
-
-        case 'slow': {
-          const ms = Number(args?.ms || 1000);
-          await new Promise((resolve) => setTimeout(resolve, ms));
-          return {
-            content: [{ type: 'text', text: `Waited ${ms}ms` }],
-          };
-        }
-
-        case 'write-file':
-          // Simulate write (don't actually write)
-          return {
-            content: [{ type: 'text', text: `Would write to ${args?.path}` }],
-          };
-
-        case 'slow-task': {
-          const ms = Number(args?.ms || 3000);
-          const steps = Number(args?.steps || 3);
-          const taskParam = request.params.task;
-
-          if (taskParam) {
-            // Task-augmented execution: create task and run in background
-            const taskId = randomUUID();
-            const now = new Date().toISOString();
-            const task: Task = {
-              taskId,
-              status: 'working',
-              ttl: null,
-              createdAt: now,
-              lastUpdatedAt: now,
-              statusMessage: 'Starting...',
-            };
-            const abortController = new AbortController();
-            taskStore.set(taskId, { task, abortController });
-
-            // Run the work in background
-            void (async () => {
-              const stepDuration = ms / steps;
-              for (let i = 1; i <= steps; i++) {
-                await new Promise((resolve) => setTimeout(resolve, stepDuration));
-                if (abortController.signal.aborted) {
-                  return;
-                }
-                const entry = taskStore.get(taskId);
-                if (entry) {
-                  entry.task.status = i < steps ? 'working' : 'completed';
-                  entry.task.statusMessage =
-                    i < steps ? `Processing step ${i}/${steps}` : `Done (${steps} steps)`;
-                  entry.task.lastUpdatedAt = new Date().toISOString();
-                  if (i === steps) {
-                    entry.result = {
-                      content: [
-                        {
-                          type: 'text',
-                          text: `Completed ${steps} steps in ${ms}ms`,
-                        },
-                      ],
-                    };
-                  }
-                }
+        // Run the work in background
+        void (async () => {
+          const stepDuration = ms / steps;
+          for (let i = 1; i <= steps; i++) {
+            await new Promise((resolve) => setTimeout(resolve, stepDuration));
+            if (abortController.signal.aborted) {
+              return;
+            }
+            const entry = taskStore.get(taskId);
+            if (entry) {
+              entry.task.status = i < steps ? 'working' : 'completed';
+              entry.task.statusMessage =
+                i < steps ? `Processing step ${i}/${steps}` : `Done (${steps} steps)`;
+              entry.task.lastUpdatedAt = new Date().toISOString();
+              if (i === steps) {
+                entry.result = {
+                  content: [
+                    {
+                      type: 'text',
+                      text: `Completed ${steps} steps in ${ms}ms`,
+                    },
+                  ],
+                };
               }
-            })();
-
-            // Return CreateTaskResult immediately
-            return { task } as unknown as { content: { type: string; text: string }[] };
+            }
           }
+        })();
 
-          // Synchronous execution (no task param)
-          await new Promise((resolve) => setTimeout(resolve, ms));
-          return {
-            content: [{ type: 'text', text: `Completed ${steps} steps in ${ms}ms` }],
-          };
-        }
-
-        default:
-          throw new Error(`Unknown tool: ${name}`);
+        // Return CreateTaskResult immediately
+        return { task } as unknown as { content: { type: string; text: string }[] };
       }
+
+      return callTestTool(name, args);
     });
 
     // Task management handlers
@@ -640,7 +318,7 @@ function createMcpServer(): Server {
       // Combine standard test resources with skill resources (when enabled)
       // so listResources can drive the skills resource-scan fallback path.
       const all = [...RESOURCES, ...SKILLS_RESOURCES];
-      const { items, nextCursor } = paginate(all, request.params?.cursor);
+      const { items, nextCursor } = paginate(all, request.params?.cursor, PAGINATION_SIZE);
       return { resources: items, nextCursor };
     });
 
@@ -650,7 +328,11 @@ function createMcpServer(): Server {
         throw new Error('Simulated failure');
       }
 
-      const { items, nextCursor } = paginate(RESOURCE_TEMPLATES, request.params?.cursor);
+      const { items, nextCursor } = paginate(
+        RESOURCE_TEMPLATES,
+        request.params?.cursor,
+        PAGINATION_SIZE
+      );
       return { resourceTemplates: items, nextCursor };
     });
 
@@ -661,59 +343,11 @@ function createMcpServer(): Server {
       }
 
       const { uri } = request.params;
-
-      if (uri === 'test://static/hello') {
-        return {
-          contents: [{ uri, mimeType: 'text/plain', text: 'Hello, World!' }],
-        };
+      const contents = readTestResource(uri, counterValue, SKILL_CONTENTS);
+      if (!contents) {
+        throw new Error(`Resource not found: ${uri}`);
       }
-
-      if (uri === 'test://static/json') {
-        return {
-          contents: [
-            {
-              uri,
-              mimeType: 'application/json',
-              text: JSON.stringify({ test: true, value: 42 }),
-            },
-          ],
-        };
-      }
-
-      if (uri === 'test://dynamic/time') {
-        return {
-          contents: [{ uri, mimeType: 'text/plain', text: new Date().toISOString() }],
-        };
-      }
-
-      if (uri === 'test://dynamic/counter') {
-        return {
-          contents: [{ uri, mimeType: 'text/plain', text: `counter=${counterValue}` }],
-        };
-      }
-
-      if (uri === 'test://static/binary') {
-        return {
-          contents: [
-            {
-              uri,
-              mimeType: 'application/octet-stream',
-              blob: BINARY_PAYLOAD.toString('base64'),
-            },
-          ],
-        };
-      }
-
-      // Skill resources (SEP-2640). May include the well-known
-      // skill://index.json plus per-skill SKILL.md files.
-      const skillContent = SKILL_CONTENTS[uri];
-      if (skillContent) {
-        return {
-          contents: [{ uri, mimeType: skillContent.mimeType, text: skillContent.text }],
-        };
-      }
-
-      throw new Error(`Resource not found: ${uri}`);
+      return contents;
     });
 
     // Resource subscriptions (resources/subscribe, resources/unsubscribe).
@@ -755,7 +389,7 @@ function createMcpServer(): Server {
         throw new Error('Simulated failure');
       }
 
-      const { items, nextCursor } = paginate(PROMPTS, request.params?.cursor);
+      const { items, nextCursor } = paginate(PROMPTS, request.params?.cursor, PAGINATION_SIZE);
       return { prompts: items, nextCursor };
     });
 
@@ -766,40 +400,11 @@ function createMcpServer(): Server {
       }
 
       const { name, arguments: args } = request.params;
-
-      if (name === 'greeting') {
-        const userName = args?.name || 'World';
-        const style = args?.style || 'casual';
-        const greeting = style === 'formal' ? `Good day, ${userName}.` : `Hey ${userName}!`;
-
-        return {
-          messages: [
-            {
-              role: 'user',
-              content: { type: 'text', text: greeting },
-            },
-          ],
-        };
+      const prompt = getTestPrompt(name, args);
+      if (!prompt) {
+        throw new Error(`Prompt not found: ${name}`);
       }
-
-      if (name === 'summarize') {
-        const text = args?.text || '';
-        const maxLength = args?.maxLength ? parseInt(args.maxLength, 10) : 100;
-
-        return {
-          messages: [
-            {
-              role: 'user',
-              content: {
-                type: 'text',
-                text: `Please summarize the following text in ${maxLength} characters or less:\n\n${text}`,
-              },
-            },
-          ],
-        };
-      }
-
-      throw new Error(`Prompt not found: ${name}`);
+      return prompt;
     });
   } // end if (!NO_PROMPTS)
 
@@ -935,70 +540,13 @@ async function main() {
     // OAuth client-credentials endpoints (opt-in via WITH_OAUTH). These must be
     // reachable without a Bearer token, so they precede the REQUIRE_AUTH check.
     if (WITH_OAUTH) {
-      if (
-        !OAUTH_NO_METADATA &&
-        url.pathname === '/.well-known/oauth-authorization-server' &&
-        req.method === 'GET'
-      ) {
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            issuer: `http://localhost:${PORT}`,
-            // authorization_endpoint + response_types_supported are required by RFC 8414;
-            // the SDK validates the full metadata document even for the token-only path.
-            authorization_endpoint: `http://localhost:${PORT}/authorize`,
-            token_endpoint: `http://localhost:${PORT}/token`,
-            response_types_supported: ['code'],
-            grant_types_supported: ['client_credentials'],
-            token_endpoint_auth_methods_supported: ['client_secret_basic', 'private_key_jwt'],
-          })
-        );
-        return;
-      }
-
-      if (url.pathname === '/token' && req.method === 'POST') {
-        const params = new URLSearchParams(await readBody(req));
-        if (params.get('grant_type') !== 'client_credentials') {
-          res.writeHead(400, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'unsupported_grant_type' }));
-          return;
-        }
-
-        // Accept either client_secret_basic, client_secret_post, or private_key_jwt.
-        // The JWT assertion's signature is not verified here — presence is enough to
-        // prove the client (mcpc + SDK) built and sent it correctly.
-        let authed = false;
-        const authz = req.headers.authorization;
-        if (authz?.startsWith('Basic ')) {
-          const decoded = Buffer.from(authz.slice('Basic '.length), 'base64').toString('utf8');
-          const sep = decoded.indexOf(':');
-          const id = decodeURIComponent(decoded.slice(0, sep));
-          const secret = decodeURIComponent(decoded.slice(sep + 1));
-          authed = id === OAUTH_CLIENT_ID && secret === OAUTH_CLIENT_SECRET;
-        } else if (params.get('client_assertion') && params.get('client_assertion_type')) {
-          authed = true;
-        } else if (params.get('client_id') && params.get('client_secret')) {
-          authed =
-            params.get('client_id') === OAUTH_CLIENT_ID &&
-            params.get('client_secret') === OAUTH_CLIENT_SECRET;
-        }
-
-        if (!authed) {
-          res.writeHead(401, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ error: 'invalid_client' }));
-          return;
-        }
-
-        const scope = params.get('scope');
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({
-            access_token: `cc-token-${Date.now()}`,
-            token_type: 'Bearer',
-            expires_in: 3600,
-            ...(scope ? { scope } : {}),
-          })
-        );
+      const handled = await handleOAuthEndpoints(req, res, url, {
+        port: PORT,
+        clientId: OAUTH_CLIENT_ID,
+        clientSecret: OAUTH_CLIENT_SECRET,
+        noMetadata: OAUTH_NO_METADATA,
+      });
+      if (handled) {
         return;
       }
     }

--- a/test/e2e/suites/basic/env-proxy.test.sh
+++ b/test/e2e/suites/basic/env-proxy.test.sh
@@ -11,9 +11,14 @@ start_proxy_server
 # HTTP_PROXY routes requests through proxy
 # =============================================================================
 
+# NO_PROXY/no_proxy are cleared on every proxied invocation: environments that
+# route all traffic through their own proxy (CI sandboxes, corporate machines)
+# commonly export NO_PROXY=localhost, which would make mcpc bypass the test
+# proxy for the localhost test server and invalidate these assertions.
+
 test_case "HTTP_PROXY routes requests through proxy"
 SESSION=$(session_name "proxy-http")
-HTTP_PROXY="$PROXY_URL" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+HTTP_PROXY="$PROXY_URL" NO_PROXY="" no_proxy="" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
 assert_success "connect with HTTP_PROXY should succeed"
 _SESSIONS_CREATED+=("$SESSION")
 run_mcpc "$SESSION" tools-list
@@ -31,7 +36,7 @@ test_case "HTTPS_PROXY does not affect HTTP connections"
 # HTTPS_PROXY points to a dead port; HTTP_PROXY points to working proxy
 # Since MCP server URL is HTTP, only HTTP_PROXY should be used — should succeed
 SESSION=$(session_name "proxy-https")
-HTTPS_PROXY="http://127.0.0.1:1" HTTP_PROXY="$PROXY_URL" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+HTTPS_PROXY="http://127.0.0.1:1" HTTP_PROXY="$PROXY_URL" NO_PROXY="" no_proxy="" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
 assert_success
 _SESSIONS_CREATED+=("$SESSION")
 run_mcpc "$SESSION" tools-list
@@ -47,7 +52,7 @@ test_pass
 
 test_case "invalid proxy causes connection failure"
 SESSION=$(session_name "proxy-broken")
-HTTP_PROXY="http://127.0.0.1:1" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+HTTP_PROXY="http://127.0.0.1:1" NO_PROXY="" no_proxy="" run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
 if [[ $EXIT_CODE -ne 0 ]]; then
   # Connect itself failed due to proxy — valid failure path
   assert_failure

--- a/test/e2e/suites/sessions/async-tasks.test.sh
+++ b/test/e2e/suites/sessions/async-tasks.test.sh
@@ -4,6 +4,10 @@
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/async-tasks"
 
+# Tasks are a 2025-11-25 experimental feature; 2026-07-28 moved them to the
+# io.modelcontextprotocol/tasks extension, which the SDK does not support yet.
+require_server_protocol legacy
+
 # Start test server
 start_test_server
 

--- a/test/e2e/suites/sessions/close.test.sh
+++ b/test/e2e/suites/sessions/close.test.sh
@@ -32,24 +32,30 @@ mcp_session_id=$(echo "$STDOUT" | jq -r '.mcpSessionId // empty')
 run_mcpc "$SESSION" close
 assert_success
 
-# Check that the server received a DELETE for this session
-deleted_sessions=$(curl -s "$TEST_SERVER_URL/control/get-deleted-sessions" | jq -r '.deletedSessions[]')
-
-# If we had an MCP session ID, verify it was deleted
-if [[ -n "$mcp_session_id" ]]; then
-  if echo "$deleted_sessions" | grep -q "$mcp_session_id"; then
-    test_pass
-  else
-    test_fail "Server did not receive DELETE for MCP session ID: $mcp_session_id (deleted: $deleted_sessions)"
-    exit 1
-  fi
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  # Stateless 2026-07-28 connections carry no MCP session ID, so there is no
+  # session for close to DELETE on the server — only the local teardown applies.
+  test_skip "HTTP DELETE applies only to 2025-era sessions"
 else
-  # If no MCP session ID was captured, at least verify some DELETE was sent
-  if [[ -n "$deleted_sessions" ]]; then
-    test_pass
+  # Check that the server received a DELETE for this session
+  deleted_sessions=$(curl -s "$TEST_SERVER_URL/control/get-deleted-sessions" | jq -r '.deletedSessions[]')
+
+  # If we had an MCP session ID, verify it was deleted
+  if [[ -n "$mcp_session_id" ]]; then
+    if echo "$deleted_sessions" | grep -q "$mcp_session_id"; then
+      test_pass
+    else
+      test_fail "Server did not receive DELETE for MCP session ID: $mcp_session_id (deleted: $deleted_sessions)"
+      exit 1
+    fi
   else
-    test_fail "Server did not receive any DELETE requests"
-    exit 1
+    # If no MCP session ID was captured, at least verify some DELETE was sent
+    if [[ -n "$deleted_sessions" ]]; then
+      test_pass
+    else
+      test_fail "Server did not receive any DELETE requests"
+      exit 1
+    fi
   fi
 fi
 

--- a/test/e2e/suites/sessions/failover.test.sh
+++ b/test/e2e/suites/sessions/failover.test.sh
@@ -4,6 +4,12 @@
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/failover"
 
+# This suite asserts the 2025-era expired-session flow: after a bridge crash the
+# server rejects the stale MCP session ID and the session must be explicitly
+# restarted. Stateless 2026-07-28 connections have no session ID to reject
+# (crash recovery there is covered by sessions/bridge-resilience).
+require_server_protocol legacy
+
 # Start test server
 start_test_server
 
@@ -35,10 +41,12 @@ test_pass
 # Test: kill bridge process
 test_case "kill bridge process"
 _kill_tree "$bridge_pid"
-sleep 1
 
-# Verify it's no longer running
+# Verify it's no longer running. The SIGTERM shutdown is graceful (session
+# DELETE + client close, each with its own timeout budget), so allow up to 10s
+# instead of a fixed sleep — on slow machines 1s is not enough (flaky).
 if is_windows; then
+  sleep 1
   if tasklist //FI "PID eq $bridge_pid" //NH 2>/dev/null | grep -q "$bridge_pid"; then
     test_fail "bridge should not be running"
     exit 1
@@ -48,7 +56,7 @@ if is_windows; then
   # to simulate the session being invalidated.
   curl -s -X POST "$TEST_SERVER_URL/control/expire-session" >/dev/null
 else
-  if kill -0 "$bridge_pid" 2>/dev/null; then
+  if ! wait_for "! kill -0 $bridge_pid 2>/dev/null" 10; then
     test_fail "bridge should not be running"
     exit 1
   fi

--- a/test/e2e/suites/sessions/mcp-session.test.sh
+++ b/test/e2e/suites/sessions/mcp-session.test.sh
@@ -4,6 +4,10 @@
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/mcp-session"
 
+# MCP session IDs (and their expiry/DELETE lifecycle) exist only in the
+# 2025-era protocol; 2026-07-28 connections are stateless.
+require_server_protocol legacy
+
 # Start test server
 start_test_server
 

--- a/test/e2e/suites/sessions/resource-sync.test.sh
+++ b/test/e2e/suites/sessions/resource-sync.test.sh
@@ -67,11 +67,16 @@ assert_eq "$(cat "$SYNC_FILE")" "counter=0" "initial sync should download curren
 test_pass
 
 test_case "server records the subscription"
-if ! wait_for_server_subscription "$COUNTER_URI" 5; then
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  # 2026-07-28 subscriptions live in the client's subscriptions/listen stream;
+  # the server keeps no per-session subscription registry to inspect.
+  test_skip "server-side subscription registry is a 2025-era concept"
+elif ! wait_for_server_subscription "$COUNTER_URI" 5; then
   test_fail "server should track the subscription: $(server_get_subscriptions)"
   exit 1
+else
+  test_pass
 fi
-test_pass
 
 test_case "session info shows the subscription"
 run_mcpc --json "$SESSION"
@@ -121,8 +126,12 @@ test_pass
 test_case "subscription survives session restart"
 run_mcpc "$SESSION" restart
 assert_success
-# The bridge re-subscribes and re-syncs in the background after reconnecting
-if ! wait_for_server_subscription "$COUNTER_URI" 10; then
+# The bridge re-subscribes and re-syncs in the background after reconnecting.
+# On the modern server there is no registry to poll, so give the re-opened
+# subscriptions/listen stream a moment to be established instead.
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  sleep 2
+elif ! wait_for_server_subscription "$COUNTER_URI" 10; then
   test_fail "subscription should be re-established on the server after restart"
   exit 1
 fi
@@ -146,12 +155,16 @@ assert_file_exists "$SYNC_FILE"
 test_pass
 
 test_case "server subscription is removed"
-SUBS_JSON=$(server_get_subscriptions)
-if [[ "$SUBS_JSON" == *"$COUNTER_URI"* ]]; then
-  test_fail "server should no longer track the subscription: $SUBS_JSON"
-  exit 1
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  test_skip "server-side subscription registry is a 2025-era concept"
+else
+  SUBS_JSON=$(server_get_subscriptions)
+  if [[ "$SUBS_JSON" == *"$COUNTER_URI"* ]]; then
+    test_fail "server should no longer track the subscription: $SUBS_JSON"
+    exit 1
+  fi
+  test_pass
 fi
-test_pass
 
 test_case "no more syncing after unsubscribe"
 server_bump_counter >/dev/null

--- a/test/e2e/suites/sessions/server-abort.test.sh
+++ b/test/e2e/suites/sessions/server-abort.test.sh
@@ -4,6 +4,10 @@
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/server-abort" --isolated
 
+# Server-side session expiry is a 2025-era concept (404 on a known session ID);
+# 2026-07-28 connections are stateless and have nothing to expire.
+require_server_protocol legacy
+
 # Start test server
 start_test_server
 

--- a/test/e2e/suites/stdio/bridge-restart.test.sh
+++ b/test/e2e/suites/stdio/bridge-restart.test.sh
@@ -52,15 +52,17 @@ test_pass
 # Test: kill the bridge process
 test_case "kill bridge process"
 _kill_tree "$original_pid"
-# Wait for process to actually die
-sleep 1
+# Wait for the process to actually die. The SIGTERM shutdown is graceful (the
+# stdio child gets close-stdin → SIGTERM → SIGKILL escalation with timeouts),
+# so allow up to 10s instead of a fixed sleep — 1s is flaky on slow machines.
 if is_windows; then
+  sleep 1
   if tasklist //FI "PID eq $original_pid" //NH 2>/dev/null | grep -q "$original_pid"; then
     test_fail "bridge process should have been killed"
     exit 1
   fi
 else
-  if kill -0 "$original_pid" 2>/dev/null; then
+  if ! wait_for "! kill -0 $original_pid 2>/dev/null" 10; then
     test_fail "bridge process should have been killed"
     exit 1
   fi


### PR DESCRIPTION
Adds the protocol-version test matrix from PR #314's follow-ups: the e2e suites now also run against a second test server speaking pure MCP 2026-07-28 (legacy requests rejected), so both protocol eras are covered in CI. The matrix immediately caught a real interop bug — SDK beta.5 servers require the new `Mcp-Method` header, which the beta.4 client never sent, so mcpc silently fell back to the 2025 handshake and failed against modern-only servers — fixed by updating the MCP SDK v2 to `2.0.0-beta.5`.

- New `test/e2e/server/index-v2.ts` on `@modelcontextprotocol/server` v2; both servers serve the same surface from shared `fixtures.ts`
- `./test/e2e/run.sh --server-protocol legacy|modern` (default: legacy) + `require_server_protocol` for era-specific suites; new CI jobs run the modern column
- Both columns fully green (47/47), incl. previously untested `subscriptions/listen` resource file-sync and re-sync paths
- MCP SDK packages exempted from pnpm's `minimumReleaseAge` gate so mcpc can track the fast-moving v2 betas
- Test-robustness fixes: proxy/CA env passthrough to npx-spawned stdio servers, `NO_PROXY` cleared in the env-proxy suite, wait-loops instead of fixed sleeps after bridge kills

## Remaining follow-ups from #314 (separate PRs)

- **Tasks extension**: stop advertising the v1-shaped `tasks: {list, cancel}` client capability on 2026-07-28 connections. Still blocked upstream: SDK `2.0.0-beta.5` ships no `io.modelcontextprotocol/tasks` extension. When it lands, the switch is confined to `src/core/capabilities.ts` (single source of truth, see comment there) plus the task methods in `src/core/mcp-client.ts`. Until then, task commands on 2026-07-28 connections already fail with a clear "moved to the tasks extension" error.
- **v2 server packages**: migrate the `--proxy` MCP server (`src/bridge/proxy-server.ts`, still SDK v1, serves 2025-11-25 downstream) to `@modelcontextprotocol/server` v2 — via `createMcpHandler` it could serve both eras to downstream clients. This is the last runtime use of SDK v1, so it also demotes `@modelcontextprotocol/sdk` from `dependencies` to a devDependency (the legacy e2e server `index.ts` and `stdio-server.mjs` keep it on purpose, as the true-v1 column of the test matrix).

Refs #314

https://claude.ai/code/session_01JsCXKviUugepDQZu8myGMn