### PR TITLE
Add enterprise-managed authorization (ID-JAG) grant support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New `mcpc login <server> --grant id-jag` for MCP's [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension: sign in once with your corporate SSO (`--idp <issuer>`), and mcpc obtains MCP server tokens via identity assertion grants (ID-JAG) without per-server consent screens.
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ mcpc/
   - Skills: `skills-list`, `skills-get`
   - Other: `grep`, `logs`, `ping`, `logging-set-level`, `restart`, `close`, `help`
 - `mcpc connect <server> @<name>` - Create a named persistent session (also bulk: `mcpc connect <file>` for all config entries, `mcpc connect` for auto-discovered configs; `--proxy` exposes the session as a local MCP HTTP server)
-- `mcpc login <server> [--profile <name>]` - Login via OAuth and save auth profile (`--grant client-credentials` for non-interactive M2M auth)
+- `mcpc login <server> [--profile <name>]` - Login via OAuth and save auth profile (`--grant client-credentials` for non-interactive M2M auth, `--grant id-jag` for enterprise-managed authorization via the corporate IdP)
 - `mcpc logout <server> [--profile <name>]` - Delete an authentication profile
 - `mcpc grep <pattern>` - Search tools/instructions (and optionally resources/prompts) across all sessions
 - `mcpc x402 <subcommand>` - Configure an x402 payment wallet (experimental)
@@ -307,7 +307,7 @@ When making changes, follow these rules to maintain the security posture:
 - Use `execFile()` (array args) instead of `exec()` (shell string) when spawning processes
 - Escape any user-controlled or server-controlled data before embedding in HTML responses
 - Send sensitive data (headers, tokens) via IPC socket, never via CLI arguments or environment variables
-- Read all keychain values needed to start a bridge in the CLI **before** `spawn()`. After spawn the bridge arms a short IPC-credential timeout; on macOS a Keychain password dialog can block longer than that timeout, so a post-spawn keychain read races the bridge timer and causes ENOENT (#55). The CLI is the only process attached to a TTY and can show the dialog without the user wondering why a background process is asking. Bridge-side keychain access is permitted only on the OAuth refresh path (`oauth-token-manager` callbacks in `src/bridge/index.ts`), where it is needed to persist rotated refresh tokens for long-running sessions
+- Read all keychain values needed to start a bridge in the CLI **before** `spawn()`. After spawn the bridge arms a short IPC-credential timeout; on macOS a Keychain password dialog can block longer than that timeout, so a post-spawn keychain read races the bridge timer and causes ENOENT (#55). The CLI is the only process attached to a TTY and can show the dialog without the user wondering why a background process is asking. Bridge-side keychain access is permitted only on the OAuth token refresh paths (the `oauth-token-manager` callbacks and the id-jag provider callbacks in `src/bridge/index.ts`), where it is needed to persist rotated refresh tokens for long-running sessions
 - Validate and sanitize all external input (URLs, session names, profile names) before use
 - Default to HTTPS; only allow HTTP for localhost/127.0.0.1
 - When adding HTTP servers (even localhost-only), validate the Host header against expected values
@@ -528,6 +528,8 @@ On failure, the error message includes instructions on how to login. This ensure
 - `src/lib/auth/oauth-token-manager.ts` - Token validation and refresh
 - `src/lib/auth/token-refresh.ts` - Token refresh logic with keychain persistence
 - `src/lib/auth/client-credentials.ts` - Non-interactive client-credentials grant (`login --grant client-credentials`)
+- `src/lib/auth/id-jag.ts` - Enterprise-managed authorization (SEP-990, ID-JAG) runtime: token exchange at the IdP, ID token refresh, SDK provider (bridge-safe, no interactive code)
+- `src/lib/auth/id-jag-login.ts` - Interactive IdP SSO login for the id_jag grant (`login --grant id-jag`)
 - `src/lib/auth/auth-page.ts` - HTML for the OAuth callback result page (escaped)
 
 **Session-to-Profile Relationship:**

--- a/README.md
+++ b/README.md
@@ -860,6 +860,23 @@ extension) for non-interactive, machine-to-machine use such as CI/CD and daemons
 (or a private-key JWT assertion via `--client-key`, RFC 7523). Access tokens are fetched and
 refreshed automatically; pin a non-discoverable token endpoint with `--token-endpoint <url>`.
 
+It also covers **enterprise-managed authorization** (the
+[`io.modelcontextprotocol/enterprise-managed-authorization`](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization)
+extension, SEP-990) for organizations that control MCP server access centrally through their
+identity provider (e.g. Okta). You sign in once with corporate SSO, and mcpc then obtains MCP
+server tokens via identity assertion grants (ID-JAG) — no per-server consent screens:
+
+```bash
+mcpc login mcp.example.com --grant id-jag \
+  --idp https://acme.okta.com --idp-client-id <idp-client> \
+  --client-id <mcp-as-client> --client-secret <secret>
+```
+
+Both clients are pre-registered by your IT team: `--idp-client-id` at the enterprise IdP
+(add `--idp-client-secret` for confidential clients), `--client-id`/`--client-secret` at the
+MCP server's authorization server. The SSO session is kept alive with the IdP's refresh token;
+when it expires, affected sessions turn `unauthorized` with a re-login hint.
+
 #### Server instructions
 
 MCP servers can provide instructions describing their capabilities and usage. These are displayed when you connect to a server or show its session overview:

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -183,6 +183,11 @@ mcpc @s tools-list
 
 # Machine-to-machine (CI/CD, daemons) — client-credentials grant, no browser needed
 mcpc login mcp.example.com --grant client-credentials --client-id my-svc --client-secret s3cr3t
+
+# Enterprise-managed authorization — SSO once at the corporate IdP (e.g. Okta),
+# then identity assertion grants (ID-JAG); clients are pre-registered by IT
+mcpc login mcp.example.com --grant id-jag --idp https://acme.okta.com \
+  --idp-client-id idp-client --client-id mcp-client --client-secret s3cr3t
 ```
 
 With no auth flags, mcpc uses the `default` profile if one exists, otherwise it

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -39,6 +39,11 @@ import type { OAuthClientProvider } from '@modelcontextprotocol/client';
 import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/auth/keychain.js';
 import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
 import { createClientCredentialsProvider } from '../lib/auth/client-credentials.js';
+import { createIdJagProvider } from '../lib/auth/id-jag.js';
+import {
+  storeKeychainIdJagCredentials,
+  readKeychainIdJagCredentials,
+} from '../lib/auth/keychain.js';
 import type { Tool, Resource, Prompt, Task } from '@modelcontextprotocol/client';
 import { ResourceSyncManager } from './resource-sync.js';
 import type { TaskUpdate } from '../lib/types.js';
@@ -99,6 +104,10 @@ class BridgeProcess {
   // True when authProvider is a client-credentials provider — drives the
   // `oauth-client-credentials` extension capability declaration on initialize.
   private usesClientCredentials = false;
+
+  // True when authProvider is an enterprise-managed-authorization (id_jag) provider —
+  // drives the `enterprise-managed-authorization` extension capability declaration.
+  private usesIdJag = false;
 
   // HTTP headers (received via IPC, stored in memory only)
   private headers: Record<string, string> | null = null;
@@ -176,10 +185,45 @@ class BridgeProcess {
     logger.debug(`  privateKey: ${credentials.privateKeyPem ? 'present' : 'absent'}`);
     logger.debug(`  headers: ${credentials.headers ? Object.keys(credentials.headers).length : 0}`);
     logger.debug(`  proxyBearerToken: ${credentials.proxyBearerToken ? 'present' : 'absent'}`);
+    logger.debug(`  idJag: ${credentials.idJag ? 'present' : 'absent'}`);
 
-    // Client-credentials grant: build the SDK provider that fetches + refreshes
-    // tokens itself. No token manager / no static header — the SDK transport drives it.
-    if (credentials.oauthGrant === 'client_credentials' && credentials.clientId) {
+    // Enterprise-managed authorization (id_jag): build the SDK cross-app-access
+    // provider. It exchanges the stored IdP ID token for an ID-JAG and the ID-JAG
+    // for an MCP access token — the SDK transport drives it, like client-credentials.
+    if (credentials.oauthGrant === 'id_jag' && credentials.idJag) {
+      const idJag = credentials.idJag;
+      logger.debug(`  idToken: ${idJag.idToken ? 'present' : 'MISSING'}`);
+      logger.debug(`  idpRefreshToken: ${idJag.idpRefreshToken ? 'present' : 'absent'}`);
+      this.authProvider = createIdJagProvider(idJag, {
+        serverUrl: credentials.serverUrl,
+        profileName: credentials.profileName,
+        callbacks: {
+          // Reload the material before each exchange (another process may have
+          // rotated the IdP refresh token). Keychain reads/writes here are the
+          // sanctioned OAuth token refresh path (see #55) — the initial material
+          // was still loaded CLI-side pre-spawn and delivered via IPC.
+          reloadCredentials: async () => {
+            logger.debug('Reloading id-jag material from keychain before exchange...');
+            return readKeychainIdJagCredentials(credentials.serverUrl, credentials.profileName);
+          },
+          // Persist rotated IdP tokens after an ID token refresh.
+          onIdTokenRefresh: async (updated) => {
+            logger.debug('IdP ID token refreshed, persisting to keychain');
+            await storeKeychainIdJagCredentials(
+              credentials.serverUrl,
+              credentials.profileName,
+              updated
+            );
+            await updateAuthProfileRefreshedAt(credentials.serverUrl, credentials.profileName);
+            logger.debug('Profile refreshedAt timestamp updated');
+          },
+        },
+      });
+      this.usesIdJag = true;
+      logger.debug('Enterprise-managed authorization (id-jag) provider created for SDK transport');
+      // Client-credentials grant: build the SDK provider that fetches + refreshes
+      // tokens itself. No token manager / no static header — the SDK transport drives it.
+    } else if (credentials.oauthGrant === 'client_credentials' && credentials.clientId) {
       this.authProvider = createClientCredentialsProvider({
         clientId: credentials.clientId,
         ...(credentials.clientSecret ? { clientSecret: credentials.clientSecret } : {}),
@@ -618,7 +662,10 @@ class BridgeProcess {
     const clientConfig: CreateMcpClientOptions = {
       clientInfo: { name: 'mcpc', version: mcpcVersion },
       serverConfig,
-      capabilities: buildClientCapabilities({ clientCredentials: this.usesClientCredentials }),
+      capabilities: buildClientCapabilities({
+        clientCredentials: this.usesClientCredentials,
+        enterpriseManagedAuth: this.usesIdJag,
+      }),
       // Pass auth provider for automatic token refresh (HTTP transport only)
       ...(this.authProvider && { authProvider: this.authProvider }),
       // Pass session ID for resumption (HTTP transport only)

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -36,6 +36,10 @@ export async function login(
     clientKeyAlg?: string;
     tokenEndpoint?: string;
     clientMetadataUrl?: string | false;
+    idp?: string;
+    idpClientId?: string;
+    idpClientSecret?: string;
+    idpScope?: string;
     callbackPort?: number;
     callbackHost?: string;
   }
@@ -49,14 +53,29 @@ export async function login(
     // Resolve the grant type (default: the interactive authorization-code flow).
     // Accept both hyphen and underscore spellings (e.g. "client_credentials").
     const grant = (options.grant ?? 'authorization-code').toLowerCase().replace(/_/g, '-');
-    if (grant !== 'authorization-code' && grant !== 'client-credentials') {
+    if (grant !== 'authorization-code' && grant !== 'client-credentials' && grant !== 'id-jag') {
       throw new ClientError(
-        `Invalid --grant "${grant}". Supported values: authorization-code (default), client-credentials.`
+        `Invalid --grant "${grant}". Supported values: authorization-code (default), ` +
+          `client-credentials, id-jag.`
       );
+    }
+
+    // The --idp-* flags only apply to the enterprise-managed authorization grant.
+    if (grant !== 'id-jag') {
+      if (options.idp || options.idpClientId || options.idpClientSecret || options.idpScope) {
+        throw new ClientError(
+          '--idp/--idp-client-id/--idp-client-secret/--idp-scope require --grant id-jag'
+        );
+      }
     }
 
     if (grant === 'client-credentials') {
       await loginWithClientCredentials(normalizedUrl, profileName, options);
+      return;
+    }
+
+    if (grant === 'id-jag') {
+      await loginWithIdJag(normalizedUrl, profileName, options);
       return;
     }
 
@@ -276,6 +295,104 @@ async function loginWithClientCredentials(
           profile: profileName,
           serverUrl: normalizedUrl,
           grant: 'client_credentials',
+          scopes: result.scopes,
+        },
+        'json'
+      )
+    );
+  }
+}
+
+/**
+ * Login with enterprise-managed authorization (SEP-990, ID-JAG): interactive SSO
+ * at the enterprise IdP, then identity-assertion grants for the MCP server.
+ * Throws on invalid flag combinations (ClientError, exit 1); the caller maps
+ * errors to their exit codes.
+ */
+async function loginWithIdJag(
+  normalizedUrl: string,
+  profileName: string,
+  options: {
+    outputMode: OutputMode;
+    scope?: string;
+    clientId?: string;
+    clientSecret?: string;
+    clientKey?: string;
+    clientKeyAlg?: string;
+    tokenEndpoint?: string;
+    clientMetadataUrl?: string | false;
+    idp?: string;
+    idpClientId?: string;
+    idpClientSecret?: string;
+    idpScope?: string;
+    callbackPort?: number;
+    callbackHost?: string;
+  }
+): Promise<void> {
+  if (!options.idp || !options.idpClientId) {
+    throw new ClientError(
+      '--grant id-jag requires --idp <issuer-url> and --idp-client-id ' +
+        '(the client your organization pre-registered at the enterprise IdP)'
+    );
+  }
+  if (!options.clientId || !options.clientSecret) {
+    throw new ClientError(
+      '--grant id-jag requires --client-id and --client-secret ' +
+        "(a confidential client registered at the MCP server's authorization server)"
+    );
+  }
+
+  // Flags of the other grants have no meaning here.
+  if (options.clientKey || options.clientKeyAlg) {
+    throw new ClientError('--client-key/--client-key-alg require --grant client-credentials');
+  }
+  if (options.tokenEndpoint) {
+    throw new ClientError('--token-endpoint is only supported with --grant client-credentials');
+  }
+  if (typeof options.clientMetadataUrl === 'string') {
+    throw new ClientError('--client-metadata-url cannot be used with --grant id-jag');
+  }
+
+  if (options.outputMode === 'human') {
+    console.log(formatInfo(`Starting enterprise-managed authorization (SSO via ${options.idp})`));
+    console.log(formatInfo(`Server: ${normalizedUrl}`));
+    console.log(formatInfo(`Profile: ${theme.magenta(profileName)}`));
+  }
+
+  const { loginIdJag } = await import('../../lib/auth/id-jag-login.js');
+  const result = await loginIdJag(normalizedUrl, profileName, {
+    idpIssuer: options.idp,
+    idpClientId: options.idpClientId,
+    mcpClientId: options.clientId,
+    mcpClientSecret: options.clientSecret,
+    ...(options.idpClientSecret ? { idpClientSecret: options.idpClientSecret } : {}),
+    ...(options.idpScope ? { idpScope: options.idpScope } : {}),
+    ...(options.scope ? { scope: options.scope } : {}),
+    ...(options.callbackPort !== undefined ? { callbackPort: options.callbackPort } : {}),
+    ...(options.callbackHost ? { callbackHost: options.callbackHost } : {}),
+  });
+
+  if (options.outputMode === 'human') {
+    console.log(formatSuccess('Authentication successful!'));
+    console.log(formatInfo(`Profile ${theme.magenta(profileName)} saved`));
+    if (result.profile.userEmail || result.profile.userName) {
+      console.log(
+        formatInfo(
+          `User: ${result.profile.userName || ''}${result.profile.userEmail ? ` <${result.profile.userEmail}>` : ''}`.trim()
+        )
+      );
+    }
+    if (result.scopes && result.scopes.length > 0) {
+      console.log(formatInfo(`Scopes: ${result.scopes.join(', ')}`));
+    }
+  } else {
+    console.log(
+      formatOutput(
+        {
+          profile: profileName,
+          serverUrl: normalizedUrl,
+          grant: 'id_jag',
+          idpIssuer: result.profile.idpIssuer,
           scopes: result.scopes,
         },
         'json'

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -204,10 +204,15 @@ export async function listSessionsAndAuthProfiles(options: {
         const hostStr = getServerHost(profile.serverUrl);
         const nameStr = theme.magenta(profile.name);
         // Client-credentials profiles have no user identity; label the grant instead.
-        const annotation =
+        // Enterprise (id_jag) profiles carry the user identity from the IdP SSO —
+        // append "enterprise" so they are distinguishable from plain OAuth logins.
+        let annotation =
           profile.userEmail ||
           profile.userName ||
           (profile.oauthGrant === 'client_credentials' ? 'client credentials' : '');
+        if (profile.oauthGrant === 'id_jag') {
+          annotation = annotation ? `${annotation}, enterprise` : 'enterprise';
+        }
         // Show refreshedAt if available, otherwise createdAt
         const timeAgo = formatTimeAgo(profile.refreshedAt || profile.createdAt);
         const timeLabel = profile.refreshedAt ? 'refreshed' : 'created';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -641,7 +641,8 @@ ${jsonHelp(
     .option('--scope <scopes>', 'OAuth scopes to request (e.g. --scope "read write")')
     .option(
       '--grant <type>',
-      'OAuth grant: authorization-code (default, interactive) or client-credentials (machine-to-machine)'
+      'OAuth grant: authorization-code (default, interactive), client-credentials ' +
+        '(machine-to-machine), or id-jag (enterprise-managed authorization via your IdP)'
     )
     .option('--client-id <id>', 'Pre-registered OAuth client ID (skips CIMD and DCR)')
     .option('--client-secret <secret>', 'Pre-registered OAuth client secret (requires --client-id)')
@@ -653,6 +654,16 @@ ${jsonHelp(
     .option(
       '--token-endpoint <url>',
       'OAuth token endpoint (client-credentials only; auto-discovered if omitted)'
+    )
+    .option('--idp <url>', 'Enterprise IdP issuer URL (id-jag only)')
+    .option('--idp-client-id <id>', 'Client ID pre-registered at the enterprise IdP (id-jag only)')
+    .option(
+      '--idp-client-secret <secret>',
+      'Client secret for the enterprise IdP; omit for public IdP clients (id-jag only)'
+    )
+    .option(
+      '--idp-scope <scopes>',
+      'OIDC scopes for the IdP SSO (id-jag only; default: "openid profile email offline_access")'
     )
     .option(
       '--client-metadata-url <url>',
@@ -704,6 +715,24 @@ ${chalk.bold('Machine-to-machine authentication (for CI/CD and daemons):')}
   --token-endpoint <url> for servers without discoverable metadata.
 
   See https://modelcontextprotocol.io/extensions/auth/oauth-client-credentials
+
+${chalk.bold("Enterprise-managed authorization (SSO via your organization's IdP):")}
+  Pass --grant id-jag when your organization controls MCP server access
+  centrally through its identity provider (e.g. Okta). You sign in once with
+  your corporate SSO; mcpc then obtains MCP tokens via identity assertion
+  grants (ID-JAG) without any per-server consent screens:
+
+  mcpc login mcp.example.com --grant id-jag \\
+    --idp https://acme.okta.com --idp-client-id <idp-client> \\
+    --client-id <mcp-as-client> --client-secret <secret>
+
+  Both clients are pre-registered by your IT team: --idp-client-id at the
+  enterprise IdP (add --idp-client-secret if it is a confidential client),
+  --client-id/--client-secret at the MCP server's authorization server.
+  --scope requests MCP-server scopes; --idp-scope overrides the OIDC scopes
+  used for the SSO itself.
+
+  See https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization
 ${jsonHelp('Interactive prompts go to stderr; stdout is a clean JSON object', '`{ profile, serverUrl, scopes }`')}`
     )
     .action(async (server, opts, command) => {
@@ -746,6 +775,10 @@ ${jsonHelp('Interactive prompts go to stderr; stdout is a clean JSON object', '`
         clientKeyAlg: opts.clientKeyAlg,
         tokenEndpoint: opts.tokenEndpoint,
         clientMetadataUrl: opts.clientMetadataUrl,
+        idp: opts.idp,
+        idpClientId: opts.idpClientId,
+        idpClientSecret: opts.idpClientSecret,
+        idpScope: opts.idpScope,
         ...(callbackPort !== undefined ? { callbackPort } : {}),
         ...(callbackHost ? { callbackHost } : {}),
         ...getOptionsFromCommand(command),

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -10,6 +10,13 @@ import type { ClientCapabilities } from '@modelcontextprotocol/client';
  */
 export const CLIENT_CREDENTIALS_EXTENSION_KEY = 'io.modelcontextprotocol/oauth-client-credentials';
 
+/**
+ * Capability key advertising enterprise-managed authorization support (SEP-990,
+ * ID-JAG), per the MCP extension `io.modelcontextprotocol/enterprise-managed-authorization`.
+ */
+export const ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY =
+  'io.modelcontextprotocol/enterprise-managed-authorization';
+
 /** Options influencing the advertised client capabilities for a given connection. */
 export interface BuildClientCapabilitiesOptions {
   /**
@@ -18,6 +25,11 @@ export interface BuildClientCapabilitiesOptions {
    * don't claim machine-to-machine auth on connections that don't use it.
    */
   clientCredentials?: boolean;
+  /**
+   * Declare the `io.modelcontextprotocol/enterprise-managed-authorization` extension.
+   * Set only for connections that authenticate with the id_jag grant.
+   */
+  enterpriseManagedAuth?: boolean;
 }
 
 /**
@@ -38,13 +50,15 @@ export interface BuildClientCapabilitiesOptions {
 export function buildClientCapabilities(
   options: BuildClientCapabilitiesOptions = {}
 ): ClientCapabilities {
+  const extensions: NonNullable<ClientCapabilities['extensions']> = {
+    ...(options.clientCredentials ? { [CLIENT_CREDENTIALS_EXTENSION_KEY]: {} } : {}),
+    ...(options.enterpriseManagedAuth ? { [ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY]: {} } : {}),
+  };
   return {
     tasks: {
       list: {},
       cancel: {},
     },
-    ...(options.clientCredentials
-      ? { extensions: { [CLIENT_CREDENTIALS_EXTENSION_KEY]: {} } }
-      : {}),
+    ...(Object.keys(extensions).length > 0 ? { extensions } : {}),
   };
 }

--- a/src/lib/auth/id-jag-login.ts
+++ b/src/lib/auth/id-jag-login.ts
@@ -1,0 +1,319 @@
+/**
+ * Interactive login for enterprise-managed authorization (`--grant id-jag`).
+ *
+ * Orchestrates the one-time setup of the id_jag grant:
+ *   1. discover the MCP server's authorization server and check it accepts ID-JAGs
+ *   2. discover the enterprise IdP's OIDC endpoints
+ *   3. run browser SSO at the IdP (authorization code + PKCE) to obtain an OIDC
+ *      ID token (and, with offline access, an IdP refresh token)
+ *   4. validate the full chain by performing a real ID-JAG + jwt-bearer exchange
+ *   5. persist the material in the OS keychain and write the auth profile
+ *
+ * Kept separate from `id-jag.ts` so the bridge never imports the interactive
+ * browser/callback-server code.
+ */
+
+import { randomBytes, createHash } from 'crypto';
+import {
+  auth as sdkAuth,
+  discoverOAuthProtectedResourceMetadata,
+  type FetchLike,
+} from '@modelcontextprotocol/client';
+import type { AuthProfile, IdJagCredentials } from '../types.js';
+import { AuthError } from '../errors.js';
+import { proxyFetch } from '../proxy.js';
+import { normalizeServerUrl } from '../utils.js';
+import { createLogger } from '../logger.js';
+import { describeAuthError } from './client-credentials.js';
+import {
+  createIdJagProvider,
+  decodeJwtPayload,
+  getJwtExpirySecs,
+  ID_JAG_GRANT_PROFILE,
+} from './id-jag.js';
+import { storeKeychainIdJagCredentials } from './keychain.js';
+import { getAuthProfile, saveAuthProfile } from './profiles.js';
+import { discoverAuthServerMetadata, getOAuthServerUrl } from './oauth-utils.js';
+import { runInteractiveAuthorization, findCallbackPort } from './oauth-flow.js';
+
+const logger = createLogger('id-jag-login');
+
+/**
+ * Default OIDC scopes requested at the enterprise IdP: identity claims for the
+ * profile display plus offline access so the IdP issues a refresh token and the
+ * SSO session survives ID token expiry.
+ */
+export const DEFAULT_IDP_SCOPE = 'openid profile email offline_access';
+
+/** Options for {@link loginIdJag}, mapped from the `mcpc login` CLI flags. */
+export interface IdJagLoginOptions {
+  /** Enterprise IdP issuer URL (`--idp`). */
+  idpIssuer: string;
+  /** Client pre-registered at the IdP (`--idp-client-id`). */
+  idpClientId: string;
+  /** IdP client secret (`--idp-client-secret`; absent for public IdP clients). */
+  idpClientSecret?: string;
+  /** Client registered at the MCP authorization server (`--client-id`). */
+  mcpClientId: string;
+  /** Secret for the MCP authorization server client (`--client-secret`). */
+  mcpClientSecret: string;
+  /** Space-separated scopes requested for the MCP server (`--scope`). */
+  scope?: string;
+  /** OIDC scopes for the IdP SSO (`--idp-scope`; default: {@link DEFAULT_IDP_SCOPE}). */
+  idpScope?: string;
+  callbackPort?: number;
+  callbackHost?: string;
+}
+
+/** Result of an id-jag login. */
+export interface IdJagLoginResult {
+  profile: AuthProfile;
+  scopes?: string[];
+}
+
+/** Identity claims read (unverified, display-only) from the IdP's ID token. */
+interface IdTokenClaims {
+  sub?: string;
+  email?: string;
+  name?: string;
+  preferred_username?: string;
+  nonce?: string;
+}
+
+/**
+ * Check the MCP server's authorization server metadata for ID-JAG support.
+ * Forgiving on missing metadata (the validation exchange in step 4 is the real
+ * test); hard error only when the server explicitly lists supported grant
+ * profiles and ID-JAG is not among them.
+ */
+async function checkServerSupportsIdJag(serverUrl: string): Promise<void> {
+  let grantProfiles: unknown;
+  try {
+    const prm = await discoverOAuthProtectedResourceMetadata(
+      serverUrl,
+      {},
+      proxyFetch as FetchLike
+    );
+    const authServerUrl = prm.authorization_servers?.[0] ?? serverUrl;
+    const metadata = await discoverAuthServerMetadata(authServerUrl);
+    grantProfiles = metadata?.['authorization_grant_profiles_supported'];
+  } catch (error) {
+    logger.debug(
+      `Could not discover authorization server metadata for ${serverUrl}: ` +
+        `${(error as Error).message} — continuing, the validation token request will verify support`
+    );
+    return;
+  }
+
+  if (Array.isArray(grantProfiles) && !grantProfiles.includes(ID_JAG_GRANT_PROFILE)) {
+    throw new AuthError(
+      `${serverUrl} does not advertise support for identity assertion grants ` +
+        `(${ID_JAG_GRANT_PROFILE} is not in its authorization_grant_profiles_supported). ` +
+        `Enterprise-managed authorization is not available for this server — ` +
+        `try the standard interactive login instead: mcpc login ${serverUrl}`
+    );
+  }
+}
+
+/**
+ * Run OIDC authorization-code + PKCE SSO at the enterprise IdP and exchange the
+ * code for tokens. Returns the ID token and, when granted, the IdP refresh token.
+ */
+async function performIdpSso(
+  opts: IdJagLoginOptions,
+  profileName: string
+): Promise<{ idToken: string; idpRefreshToken?: string; idpTokenEndpoint: string }> {
+  const idpMetadata = await discoverAuthServerMetadata(opts.idpIssuer);
+  const authorizationEndpoint = idpMetadata?.['authorization_endpoint'];
+  const tokenEndpoint = idpMetadata?.token_endpoint;
+  if (typeof authorizationEndpoint !== 'string' || !tokenEndpoint) {
+    throw new AuthError(
+      `Could not discover OAuth endpoints for the enterprise IdP at ${opts.idpIssuer}. ` +
+        `Check that --idp points at the IdP issuer URL (it must serve ` +
+        `/.well-known/openid-configuration or /.well-known/oauth-authorization-server).`
+    );
+  }
+
+  // PKCE (S256) + `state` for CSRF protection + `nonce` echoed into the ID token.
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+  const state = randomBytes(16).toString('hex');
+  const nonce = randomBytes(16).toString('hex');
+
+  const port = await findCallbackPort(opts.callbackPort);
+  const redirectUri = `http://${opts.callbackHost || '127.0.0.1'}:${port}/callback`;
+
+  const authorizationUrl = new URL(authorizationEndpoint);
+  authorizationUrl.searchParams.set('response_type', 'code');
+  authorizationUrl.searchParams.set('client_id', opts.idpClientId);
+  authorizationUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizationUrl.searchParams.set('scope', opts.idpScope || DEFAULT_IDP_SCOPE);
+  authorizationUrl.searchParams.set('state', state);
+  authorizationUrl.searchParams.set('nonce', nonce);
+  authorizationUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizationUrl.searchParams.set('code_challenge_method', 'S256');
+
+  const callback = await runInteractiveAuthorization(authorizationUrl, port, {
+    serverUrl: opts.idpIssuer,
+    profileName,
+  });
+  if (callback.state !== state) {
+    throw new AuthError(
+      'Enterprise IdP returned a mismatched state parameter — possible CSRF, aborting login'
+    );
+  }
+
+  // Exchange the authorization code at the IdP token endpoint.
+  logger.debug('Exchanging IdP authorization code for tokens...');
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code: callback.code,
+    redirect_uri: redirectUri,
+    client_id: opts.idpClientId,
+    code_verifier: codeVerifier,
+  });
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+  if (opts.idpClientSecret) {
+    const basic = Buffer.from(`${opts.idpClientId}:${opts.idpClientSecret}`).toString('base64');
+    headers['Authorization'] = `Basic ${basic}`;
+  }
+  const response = await proxyFetch(tokenEndpoint, {
+    method: 'POST',
+    headers,
+    body: params.toString(),
+  });
+  if (!response.ok) {
+    const errorText = (await response.text()).slice(0, 400);
+    throw new AuthError(
+      `Enterprise IdP rejected the authorization code exchange ` +
+        `(${response.status}): ${errorText}`
+    );
+  }
+  const tokens = (await response.json()) as { id_token?: string; refresh_token?: string };
+  if (!tokens.id_token) {
+    throw new AuthError(
+      `Enterprise IdP did not return an ID token. Make sure the IdP client is an ` +
+        `OpenID Connect client and the requested scope includes "openid" ` +
+        `(requested: "${opts.idpScope || DEFAULT_IDP_SCOPE}").`
+    );
+  }
+  const claims = decodeJwtPayload<IdTokenClaims>(tokens.id_token);
+  if (claims?.nonce && claims.nonce !== nonce) {
+    throw new AuthError('Enterprise IdP returned an ID token with a mismatched nonce — aborting');
+  }
+
+  const result: { idToken: string; idpRefreshToken?: string; idpTokenEndpoint: string } = {
+    idToken: tokens.id_token,
+    idpTokenEndpoint: tokenEndpoint,
+  };
+  if (tokens.refresh_token) {
+    result.idpRefreshToken = tokens.refresh_token;
+  } else {
+    logger.warn(
+      'Enterprise IdP issued no refresh token — sessions will require a new login ' +
+        'once the ID token expires'
+    );
+  }
+  return result;
+}
+
+/**
+ * Log in with the enterprise-managed authorization grant: SSO at the IdP,
+ * validate the full ID-JAG chain against the MCP server, persist material in
+ * the OS keychain, and write the auth profile.
+ */
+export async function loginIdJag(
+  serverUrl: string,
+  profileName: string,
+  opts: IdJagLoginOptions
+): Promise<IdJagLoginResult> {
+  const normalizedServerUrl = normalizeServerUrl(serverUrl);
+  const oauthServerUrl = getOAuthServerUrl(normalizedServerUrl);
+  const idpIssuer = normalizeServerUrl(opts.idpIssuer);
+
+  // 1. Fail fast when the server explicitly rules out ID-JAGs.
+  await checkServerSupportsIdJag(oauthServerUrl);
+
+  // 2 + 3. IdP endpoint discovery and browser SSO.
+  const sso = await performIdpSso({ ...opts, idpIssuer }, profileName);
+
+  const info: IdJagCredentials = {
+    idpIssuer,
+    idpTokenEndpoint: sso.idpTokenEndpoint,
+    idpClientId: opts.idpClientId,
+    idToken: sso.idToken,
+    mcpClientId: opts.mcpClientId,
+    mcpClientSecret: opts.mcpClientSecret,
+  };
+  if (opts.idpClientSecret) info.idpClientSecret = opts.idpClientSecret;
+  if (sso.idpRefreshToken) info.idpRefreshToken = sso.idpRefreshToken;
+  if (opts.scope) info.scope = opts.scope;
+  const idTokenExpiresAt = getJwtExpirySecs(sso.idToken);
+  if (idTokenExpiresAt !== undefined) info.idTokenExpiresAt = idTokenExpiresAt;
+
+  // 4. Validate the full chain with the same provider the bridge uses at runtime:
+  // RFC 9728 discovery, RFC 8693 token exchange at the IdP, and the jwt-bearer
+  // exchange at the MCP authorization server. A successful login therefore
+  // guarantees the session will connect.
+  logger.debug('Validating the ID-JAG chain with a real token request...');
+  const provider = createIdJagProvider(info, {
+    serverUrl: normalizedServerUrl,
+    profileName,
+  });
+  let grantedScope: string | undefined;
+  try {
+    const result = await sdkAuth(provider, {
+      serverUrl: oauthServerUrl,
+      ...(opts.scope ? { scope: opts.scope } : {}),
+      fetchFn: proxyFetch as FetchLike,
+    });
+    if (result !== 'AUTHORIZED') {
+      // CrossAppAccessProvider never redirects; anything else is unexpected.
+      throw new AuthError(`Unexpected authorization result: ${result}`);
+    }
+    grantedScope = (await provider.tokens())?.scope;
+    logger.debug('ID-JAG validation token request succeeded');
+  } catch (error) {
+    if (error instanceof AuthError) throw error;
+    throw new AuthError(`Enterprise-managed authentication failed: ${describeAuthError(error)}`);
+  }
+
+  // 5. Persist the material in the OS keychain.
+  await storeKeychainIdJagCredentials(normalizedServerUrl, profileName, info);
+
+  // Prefer scopes the server actually granted; fall back to what was requested.
+  const grantedScopes = grantedScope ? grantedScope.split(' ') : undefined;
+  const requestedScopes = opts.scope ? opts.scope.split(' ') : undefined;
+  const effectiveScopes =
+    grantedScopes && grantedScopes.length > 0 ? grantedScopes : requestedScopes;
+
+  // Write/refresh the profile metadata (preserve original createdAt on re-login).
+  const claims = decodeJwtPayload<IdTokenClaims>(sso.idToken);
+  const now = new Date().toISOString();
+  const existing = await getAuthProfile(normalizedServerUrl, profileName);
+  const profile: AuthProfile = {
+    name: profileName,
+    serverUrl: normalizedServerUrl,
+    authType: 'oauth',
+    oauthGrant: 'id_jag',
+    oauthIssuer: normalizedServerUrl,
+    idpIssuer,
+    createdAt: existing?.createdAt ?? now,
+    authenticatedAt: now,
+    ...(effectiveScopes && effectiveScopes.length > 0 ? { scopes: effectiveScopes } : {}),
+  };
+  if (claims?.email) profile.userEmail = claims.email;
+  if (claims?.name) profile.userName = claims.name;
+  else if (claims?.preferred_username) profile.userName = claims.preferred_username;
+  if (claims?.sub) profile.userSubject = claims.sub;
+
+  await saveAuthProfile(profile);
+  logger.debug(`Saved id-jag profile ${profileName} for ${normalizedServerUrl}`);
+
+  const result: IdJagLoginResult = { profile };
+  if (effectiveScopes && effectiveScopes.length > 0) result.scopes = effectiveScopes;
+  return result;
+}

--- a/src/lib/auth/id-jag.ts
+++ b/src/lib/auth/id-jag.ts
@@ -1,0 +1,244 @@
+/**
+ * Enterprise-managed authorization (SEP-990, ID-JAG).
+ *
+ * Implements the MCP extension `io.modelcontextprotocol/enterprise-managed-authorization`:
+ * the user signs in once at the enterprise IdP (OIDC SSO, handled by `id-jag-login.ts`),
+ * and mcpc then obtains MCP-server access tokens without any further user interaction by
+ * exchanging the stored OIDC ID token at the IdP for an Identity Assertion JWT
+ * Authorization Grant (ID-JAG, RFC 8693 token exchange), and the ID-JAG at the MCP
+ * authorization server for an access token (RFC 7523 jwt-bearer grant).
+ *
+ * The SDK's `CrossAppAccessProvider` drives the jwt-bearer exchange and token caching;
+ * this module supplies its assertion callback (the IdP side) and keeps the stored ID
+ * token fresh via the IdP refresh token. Kept free of any interactive/browser code so
+ * the bridge can import it.
+ */
+
+import {
+  CrossAppAccessProvider,
+  requestJwtAuthorizationGrant,
+  type OAuthClientProvider,
+} from '@modelcontextprotocol/client';
+import type { IdJagCredentials } from '../types.js';
+import { AuthError } from '../errors.js';
+import { proxyFetch } from '../proxy.js';
+import { createLogger } from '../logger.js';
+import { describeAuthError } from './client-credentials.js';
+import type { OAuthTokenResponse } from './oauth-utils.js';
+
+const logger = createLogger('id-jag');
+
+/** Client name advertised in token request metadata. */
+const CLIENT_NAME = 'mcpc';
+
+/**
+ * OAuth grant profile identifier advertised by authorization servers that accept
+ * ID-JAGs, in the `authorization_grant_profiles_supported` metadata field.
+ */
+export const ID_JAG_GRANT_PROFILE = 'urn:ietf:params:oauth:grant-profile:id-jag';
+
+/** Refresh the ID token when it expires within this window (matches OAuthTokenManager). */
+const ID_TOKEN_EXPIRY_BUFFER_SECS = 60;
+
+/**
+ * Decode a JWT payload without verifying the signature (for expiry checks and
+ * display-only identity claims). Returns undefined when not a decodable JWT.
+ */
+export function decodeJwtPayload<T = Record<string, unknown>>(jwt: string): T | undefined {
+  try {
+    const parts = jwt.split('.');
+    if (parts.length !== 3) return undefined;
+    return JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf-8')) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Decode the `exp` claim (unix seconds) from a JWT without verifying it.
+ * Returns undefined when the token is not a decodable JWT.
+ */
+export function getJwtExpirySecs(jwt: string): number | undefined {
+  const exp = decodeJwtPayload<{ exp?: number }>(jwt)?.exp;
+  return typeof exp === 'number' ? exp : undefined;
+}
+
+/**
+ * Renew the OIDC ID token at the enterprise IdP using the stored refresh token
+ * (plain `grant_type=refresh_token`; client secret sent via HTTP Basic when present).
+ * Returns the updated credentials — callers persist them.
+ */
+export async function refreshIdpIdToken(info: IdJagCredentials): Promise<IdJagCredentials> {
+  if (!info.idpRefreshToken) {
+    throw new AuthError('No IdP refresh token available to renew the enterprise SSO ID token');
+  }
+  logger.debug(`Refreshing IdP ID token at: ${info.idpTokenEndpoint}`);
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: info.idpRefreshToken,
+    client_id: info.idpClientId,
+  });
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+    Accept: 'application/json',
+  };
+  if (info.idpClientSecret) {
+    const basic = Buffer.from(`${info.idpClientId}:${info.idpClientSecret}`).toString('base64');
+    headers['Authorization'] = `Basic ${basic}`;
+  }
+
+  const response = await proxyFetch(info.idpTokenEndpoint, {
+    method: 'POST',
+    headers,
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    // Log only a bounded snippet — the response could echo attacker-influenced content.
+    const errorText = (await response.text()).slice(0, 400);
+    logger.error(`IdP ID token refresh failed: ${response.status} ${errorText}`);
+    if (response.status === 400 || response.status === 401) {
+      throw new AuthError(
+        'Enterprise IdP refresh token is invalid or expired. Please re-authenticate.'
+      );
+    }
+    throw new AuthError(
+      `Failed to refresh enterprise SSO ID token: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const tokens = (await response.json()) as OAuthTokenResponse & { id_token?: string };
+  if (!tokens.id_token) {
+    throw new AuthError(
+      'Enterprise IdP did not return an ID token on refresh. Please re-authenticate.'
+    );
+  }
+
+  const updated: IdJagCredentials = { ...info, idToken: tokens.id_token };
+  const expiresAt = getJwtExpirySecs(tokens.id_token);
+  if (expiresAt !== undefined) {
+    updated.idTokenExpiresAt = expiresAt;
+  } else {
+    delete updated.idTokenExpiresAt;
+  }
+  if (tokens.refresh_token) {
+    updated.idpRefreshToken = tokens.refresh_token; // rotated by the IdP
+  }
+  logger.debug('IdP ID token refreshed');
+  return updated;
+}
+
+/** Callbacks for keeping stored id-jag material in sync across processes. */
+export interface IdJagProviderCallbacks {
+  /**
+   * Re-read the latest stored material before each use (another process may have
+   * rotated the IdP refresh token). Return undefined to keep the current material.
+   */
+  reloadCredentials?: () => Promise<IdJagCredentials | undefined>;
+  /** Persist rotated IdP tokens after a successful ID token refresh. */
+  onIdTokenRefresh?: (updated: IdJagCredentials) => Promise<void>;
+}
+
+/** Options for {@link createIdJagProvider}. */
+export interface CreateIdJagProviderOptions {
+  /** Normalized MCP server URL (used in re-authentication hints). */
+  serverUrl: string;
+  /** Auth profile name (used in re-authentication hints). */
+  profileName: string;
+  callbacks?: IdJagProviderCallbacks;
+}
+
+/** Build the `mcpc login` hint for a dead enterprise SSO session. */
+function buildReloginHint(serverUrl: string, profileName: string): string {
+  const profileFlag = profileName === 'default' ? '' : ` --profile ${profileName}`;
+  return (
+    `Please re-authenticate with: mcpc login ${serverUrl} --grant id-jag${profileFlag} ` +
+    `(plus the --idp/--client flags used originally; see: mcpc help login)`
+  );
+}
+
+/**
+ * Build the SDK OAuthClientProvider for the enterprise-managed authorization
+ * (id_jag) grant. The SDK transport drives discovery, the jwt-bearer exchange,
+ * and access token caching through this provider automatically; the assertion
+ * callback below supplies the ID-JAG from the enterprise IdP, refreshing the
+ * stored ID token first when it has expired.
+ */
+export function createIdJagProvider(
+  info: IdJagCredentials,
+  options: CreateIdJagProviderOptions
+): OAuthClientProvider {
+  const { serverUrl, profileName, callbacks } = options;
+  let current = info;
+
+  const getValidIdToken = async (): Promise<string> => {
+    const expiresAt = current.idTokenExpiresAt ?? getJwtExpirySecs(current.idToken);
+    const nowSecs = Math.floor(Date.now() / 1000);
+    if (expiresAt === undefined || expiresAt - nowSecs > ID_TOKEN_EXPIRY_BUFFER_SECS) {
+      return current.idToken;
+    }
+
+    logger.debug('Enterprise SSO ID token expired or expiring soon');
+    if (!current.idpRefreshToken) {
+      throw new AuthError(
+        `Enterprise SSO session has expired and the IdP issued no refresh token. ` +
+          buildReloginHint(serverUrl, profileName)
+      );
+    }
+    try {
+      current = await refreshIdpIdToken(current);
+    } catch (error) {
+      throw new AuthError(
+        `Could not renew the enterprise SSO session: ${describeAuthError(error)}. ` +
+          buildReloginHint(serverUrl, profileName)
+      );
+    }
+    await callbacks?.onIdTokenRefresh?.(current);
+    return current.idToken;
+  };
+
+  return new CrossAppAccessProvider({
+    assertion: async (ctx) => {
+      if (callbacks?.reloadCredentials) {
+        const reloaded = await callbacks.reloadCredentials();
+        if (reloaded) current = reloaded;
+      }
+      const idToken = await getValidIdToken();
+      const scope = ctx.scope ?? current.scope;
+      logger.debug(
+        `Requesting ID-JAG from IdP (audience: ${ctx.authorizationServerUrl}, ` +
+          `resource: ${ctx.resourceUrl})`
+      );
+      try {
+        const result = await requestJwtAuthorizationGrant({
+          tokenEndpoint: current.idpTokenEndpoint,
+          audience: ctx.authorizationServerUrl,
+          resource: ctx.resourceUrl,
+          idToken,
+          clientId: current.idpClientId,
+          ...(current.idpClientSecret ? { clientSecret: current.idpClientSecret } : {}),
+          ...(scope ? { scope } : {}),
+          fetchFn: ctx.fetchFn,
+        });
+        logger.debug('ID-JAG obtained from IdP');
+        return result.jwtAuthGrant;
+      } catch (error) {
+        if (error instanceof AuthError) throw error;
+        // The IdP refused the exchange: policy denies access, the ID token is no
+        // longer accepted, or the IdP client may not use the token-exchange grant.
+        throw new AuthError(
+          `Enterprise IdP refused to issue an identity assertion grant (ID-JAG): ` +
+            `${describeAuthError(error)}. ` +
+            `Check that your organization allows this MCP server and that the IdP client ` +
+            `is permitted the token-exchange grant. ` +
+            buildReloginHint(serverUrl, profileName)
+        );
+      }
+    },
+    clientId: info.mcpClientId,
+    clientSecret: info.mcpClientSecret,
+    clientName: CLIENT_NAME,
+    fetchFn: proxyFetch,
+  });
+}

--- a/src/lib/auth/keychain.ts
+++ b/src/lib/auth/keychain.ts
@@ -17,6 +17,7 @@ import chalk from 'chalk';
 import { createLogger, getJsonMode } from '../logger.js';
 import { getServerHost, getMcpcHome, fileExists } from '../utils.js';
 import { withFileLock } from '../file-lock.js';
+import type { IdJagCredentials } from '../types.js';
 
 const logger = createLogger('keychain');
 const SERVICE_NAME = 'mcpc';
@@ -227,6 +228,9 @@ const oauthTokensAccount = (serverUrl: string, profileName: string): string =>
 const oauthClientCredentialsAccount = (serverUrl: string, profileName: string): string =>
   `auth-profile:${getServerHost(serverUrl)}:${profileName}:client-credentials`;
 
+const oauthIdJagAccount = (serverUrl: string, profileName: string): string =>
+  `auth-profile:${getServerHost(serverUrl)}:${profileName}:id-jag`;
+
 const sessionHeadersAccount = (sessionName: string): string => `session:${sessionName}:headers`;
 
 const proxyBearerTokenAccount = (sessionName: string): string =>
@@ -355,6 +359,37 @@ export async function removeKeychainClientCredentials(
 ): Promise<boolean> {
   logger.debug(`Deleting client-credentials material for ${profileName} @ ${serverUrl}`);
   return keychainDelete(oauthClientCredentialsAccount(serverUrl, profileName));
+}
+
+/** Store enterprise-managed authorization (id_jag) material for an auth profile. */
+export async function storeKeychainIdJagCredentials(
+  serverUrl: string,
+  profileName: string,
+  info: IdJagCredentials
+): Promise<void> {
+  logger.debug(`Storing id-jag material for ${profileName} @ ${serverUrl}`);
+  await keychainSet(oauthIdJagAccount(serverUrl, profileName), JSON.stringify(info));
+}
+
+/** Read enterprise-managed authorization (id_jag) material for an auth profile. */
+export async function readKeychainIdJagCredentials(
+  serverUrl: string,
+  profileName: string
+): Promise<IdJagCredentials | undefined> {
+  logger.debug(`Retrieving id-jag material for ${profileName} @ ${serverUrl}`);
+  return keychainGetParsed<IdJagCredentials>(
+    oauthIdJagAccount(serverUrl, profileName),
+    'id-jag material'
+  );
+}
+
+/** Delete enterprise-managed authorization (id_jag) material for an auth profile. */
+export async function removeKeychainIdJagCredentials(
+  serverUrl: string,
+  profileName: string
+): Promise<boolean> {
+  logger.debug(`Deleting id-jag material for ${profileName} @ ${serverUrl}`);
+  return keychainDelete(oauthIdJagAccount(serverUrl, profileName));
 }
 
 /** Store custom HTTP headers for a session. */

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -31,7 +31,7 @@ const logger = createLogger('oauth-flow');
  * issuer identifier; when present the SDK validates it against the discovered
  * authorization server before redeeming the code (mix-up attack defense).
  */
-interface CallbackResult {
+export interface CallbackResult {
   code: string;
   state?: string;
   iss?: string;
@@ -529,6 +529,82 @@ function promptForCallbackUrl(): {
   });
 
   return { promise, cleanup };
+}
+
+/**
+ * Find an available loopback port for the OAuth callback server: the exact
+ * `--callback-port` when given, otherwise the first free port from mcpc's
+ * fixed callback port list.
+ */
+export async function findCallbackPort(callbackPort?: number): Promise<number> {
+  return findAvailablePort(callbackPort ? [callbackPort] : MCPC_OAUTH_CALLBACK_PORTS);
+}
+
+/**
+ * Drive one interactive authorization redirect: start the loopback callback
+ * server on `port`, show the authorization URL, ask for confirmation before
+ * opening the browser (with paste-the-callback-URL fallback when the browser
+ * cannot be opened, and Esc to cancel), and wait for the authorization code.
+ *
+ * Used by login flows that build their own authorization URL — e.g. the
+ * enterprise IdP SSO of the id-jag grant. `performOAuthFlow` below keeps its
+ * own copy of this choreography because it is interleaved with the SDK's
+ * `auth()` orchestration.
+ */
+export async function runInteractiveAuthorization(
+  authorizationUrl: URL,
+  port: number,
+  context: { serverUrl: string; profileName: string; scope?: string }
+): Promise<CallbackResult> {
+  const { server, codePromise, destroyConnections } = startCallbackServer(port, context);
+  let escapeHandler: ReturnType<typeof waitForEscapeKey> | null = null;
+  let pasteHandler: ReturnType<typeof promptForCallbackUrl> | null = null;
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(port, '127.0.0.1', () => {
+        logger.debug(`Callback server listening on port ${port}`);
+        resolve();
+      });
+    });
+
+    // Interactive chatter goes to stderr so stdout stays clean for --json output.
+    console.error(`\nAuthorization URL: ${authorizationUrl.toString()}`);
+    const confirmed = await waitForEnterKey(
+      'Press Enter to open browser (any other key to cancel): '
+    );
+    if (!confirmed) {
+      throw new ClientError('Authentication cancelled by user');
+    }
+
+    console.error('Opening browser...');
+    const opened = await tryOpenBrowser(authorizationUrl.toString());
+
+    const racers: Promise<CallbackResult>[] = [codePromise];
+    if (opened) {
+      console.error('If the browser does not open automatically, please visit the URL above.');
+      console.error('Press Esc to cancel.\n');
+      escapeHandler = waitForEscapeKey();
+      racers.push(escapeHandler.promise as Promise<CallbackResult>);
+    } else {
+      console.error(
+        '\nCould not open browser. Please open the authorization URL above in your browser.'
+      );
+      console.error(
+        'After authorizing, copy the full callback URL from the browser address bar and paste it here.'
+      );
+      pasteHandler = promptForCallbackUrl();
+      racers.push(pasteHandler.promise);
+    }
+
+    return await Promise.race(racers);
+  } finally {
+    escapeHandler?.cleanup();
+    pasteHandler?.cleanup();
+    destroyConnections();
+    server.close();
+  }
 }
 
 /**

--- a/src/lib/auth/profiles.ts
+++ b/src/lib/auth/profiles.ts
@@ -23,6 +23,7 @@ import {
   removeKeychainOAuthClientInfo,
   removeKeychainOAuthTokenInfo,
   removeKeychainClientCredentials,
+  removeKeychainIdJagCredentials,
 } from './keychain.js';
 
 const logger = createLogger('auth-profiles');
@@ -287,6 +288,7 @@ export async function deleteAuthProfiles(
           await removeKeychainOAuthClientInfo(profile.serverUrl, profile.name);
           await removeKeychainOAuthTokenInfo(profile.serverUrl, profile.name);
           await removeKeychainClientCredentials(profile.serverUrl, profile.name);
+          await removeKeychainIdJagCredentials(profile.serverUrl, profile.name);
           logger.debug(
             `Removed keychain entries for profile: ${profile.name} on ${getServerHost(profile.serverUrl)}`
           );

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -43,6 +43,7 @@ import {
   readKeychainOAuthTokenInfo,
   readKeychainOAuthClientInfo,
   readKeychainClientCredentials,
+  readKeychainIdJagCredentials,
   readKeychainSessionHeaders,
   readKeychainProxyBearerToken,
 } from './auth/keychain.js';
@@ -547,7 +548,21 @@ async function loadAuthCredentials(
     logger.debug(`Looking up auth profile ${profileName} for ${serverUrl}`);
 
     const profile = await getAuthProfile(serverUrl, profileName);
-    if (profile?.oauthGrant === 'client_credentials') {
+    if (profile?.oauthGrant === 'id_jag') {
+      // Enterprise-managed authorization: load the stored IdP + client material so
+      // the bridge can build the SDK cross-app-access provider.
+      const idJag = await readKeychainIdJagCredentials(profile.serverUrl, profileName);
+      if (idJag) {
+        credentials.serverUrl = profile.serverUrl;
+        credentials.oauthGrant = 'id_jag';
+        credentials.idJag = idJag;
+        logger.debug(`Found id-jag material for profile ${profileName}`);
+      } else {
+        logger.warn(
+          `Profile ${profileName} uses the id-jag grant but no material was found in the keychain`
+        );
+      }
+    } else if (profile?.oauthGrant === 'client_credentials') {
       // Client-credentials grant: load the stored secret/key so the bridge can
       // build the SDK provider that fetches and refreshes tokens itself.
       const cc = await readKeychainClientCredentials(profile.serverUrl, profileName);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -233,8 +233,11 @@ export interface SessionsStorage {
  * - authorization_code: interactive, browser-based flow (the default; assumed when absent)
  * - client_credentials: machine-to-machine flow (no user), per the MCP extension
  *   `io.modelcontextprotocol/oauth-client-credentials`
+ * - id_jag: enterprise-managed authorization (SEP-990): SSO at the enterprise IdP,
+ *   then identity-assertion JWT authorization grants (ID-JAG) for the MCP server,
+ *   per the MCP extension `io.modelcontextprotocol/enterprise-managed-authorization`
  */
-export type OAuthGrant = 'authorization_code' | 'client_credentials';
+export type OAuthGrant = 'authorization_code' | 'client_credentials' | 'id_jag';
 
 /**
  * Authentication profile data stored in ~/.mcpc/profiles.json
@@ -253,6 +256,8 @@ export interface AuthProfile {
   oauthGrant?: OAuthGrant;
   // OAuth metadata
   oauthIssuer: string;
+  /** Enterprise IdP issuer URL (id_jag grant only). */
+  idpIssuer?: string;
   scopes?: string[];
   // User info (from OIDC id_token, if available)
   userEmail?: string;
@@ -269,6 +274,36 @@ export interface AuthProfile {
  */
 export interface AuthProfilesStorage {
   profiles: Record<string, Record<string, AuthProfile>>; // serverUrl -> profileName -> AuthProfile
+}
+
+/**
+ * Enterprise-managed authorization (SEP-990) material for the `id_jag` grant.
+ * Stored as one keychain blob per profile and delivered to the bridge via IPC.
+ * The bridge exchanges `idToken` at the IdP for an ID-JAG (RFC 8693 token
+ * exchange) and the ID-JAG at the MCP authorization server for an access token
+ * (RFC 7523 jwt-bearer) — both handled by the MCP SDK.
+ */
+export interface IdJagCredentials {
+  /** Enterprise IdP issuer URL. */
+  idpIssuer: string;
+  /** IdP token endpoint, discovered and pinned at login so the bridge never re-discovers. */
+  idpTokenEndpoint: string;
+  /** Client pre-registered at the enterprise IdP. */
+  idpClientId: string;
+  /** IdP client secret (absent for public IdP clients). */
+  idpClientSecret?: string;
+  /** Current OIDC ID token from the IdP — the subject of the RFC 8693 exchange. */
+  idToken: string;
+  /** ID token expiry (`exp` claim, unix seconds). */
+  idTokenExpiresAt?: number;
+  /** IdP refresh token; renews the ID token when the IdP granted offline access. */
+  idpRefreshToken?: string;
+  /** Client registered at the MCP authorization server. */
+  mcpClientId: string;
+  /** Secret for the MCP authorization server client (required by the SDK provider). */
+  mcpClientSecret: string;
+  /** Space-separated scopes requested for the MCP server. */
+  scope?: string;
 }
 
 /**
@@ -301,6 +336,8 @@ export interface AuthCredentials {
   keyAlg?: string; // JWT signing algorithm for the private_key_jwt variant (e.g. RS256)
   scope?: string; // space-separated scopes requested by the client-credentials grant
   tokenEndpoint?: string; // explicit token endpoint (--token-endpoint); bypasses discovery
+  // Enterprise-managed authorization material (id_jag grant; sent via IPC, never CLI args)
+  idJag?: IdJagCredentials;
   // HTTP headers (from --header flags, stored in keychain)
   headers?: Record<string, string>;
   // Bearer token the bridge's proxy server requires (from --proxy-bearer-token).

--- a/test/unit/core/capabilities.test.ts
+++ b/test/unit/core/capabilities.test.ts
@@ -5,6 +5,7 @@
 import {
   buildClientCapabilities,
   CLIENT_CREDENTIALS_EXTENSION_KEY,
+  ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY,
 } from '../../../src/core/capabilities.js';
 
 describe('buildClientCapabilities', () => {
@@ -38,5 +39,25 @@ describe('buildClientCapabilities', () => {
     };
     expect(caps.extensions).toBeDefined();
     expect(caps.extensions).toHaveProperty(CLIENT_CREDENTIALS_EXTENSION_KEY);
+    expect(caps.extensions).not.toHaveProperty(ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY);
+  });
+
+  it('declares the enterprise-managed-authorization extension when requested', () => {
+    expect(ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY).toBe(
+      'io.modelcontextprotocol/enterprise-managed-authorization'
+    );
+    const caps = buildClientCapabilities({ enterpriseManagedAuth: true }) as {
+      extensions?: Record<string, unknown>;
+    };
+    expect(caps.extensions).toBeDefined();
+    expect(caps.extensions).toHaveProperty(ENTERPRISE_MANAGED_AUTH_EXTENSION_KEY);
+    expect(caps.extensions).not.toHaveProperty(CLIENT_CREDENTIALS_EXTENSION_KEY);
+  });
+
+  it('omits the enterprise-managed-authorization extension when false', () => {
+    const caps = buildClientCapabilities({ enterpriseManagedAuth: false }) as {
+      extensions?: Record<string, unknown>;
+    };
+    expect(caps.extensions).toBeUndefined();
   });
 });

--- a/test/unit/lib/auth/id-jag.test.ts
+++ b/test/unit/lib/auth/id-jag.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Unit tests for enterprise-managed authorization (SEP-990, ID-JAG) helpers
+ * (src/lib/auth/id-jag.ts).
+ *
+ * Covers the IdP-side pieces with a mocked fetch: the exact RFC 8693 token
+ * exchange wire format, ID token refresh/rotation, the expiry buffer, and the
+ * re-authentication error paths. The full login + browser SSO flow (network,
+ * interactive) is out of scope here.
+ */
+
+import type { MockInstance } from 'vitest';
+import {
+  createIdJagProvider,
+  decodeJwtPayload,
+  getJwtExpirySecs,
+  refreshIdpIdToken,
+  ID_JAG_GRANT_PROFILE,
+} from '../../../../src/lib/auth/id-jag.js';
+import type { IdJagCredentials } from '../../../../src/lib/types.js';
+import { AuthError } from '../../../../src/lib/errors.js';
+import * as proxyModule from '../../../../src/lib/proxy.js';
+
+/** Build an unsigned JWT with the given payload (signature is never verified). */
+function makeJwt(payload: Record<string, unknown>): string {
+  const enc = (obj: Record<string, unknown>): string =>
+    Buffer.from(JSON.stringify(obj)).toString('base64url');
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc(payload)}.sig`;
+}
+
+function mockResponse(body: object, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'mock',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+const NOW_SECS = Math.floor(Date.now() / 1000);
+
+function makeCredentials(overrides: Partial<IdJagCredentials> = {}): IdJagCredentials {
+  return {
+    idpIssuer: 'https://idp.example.com',
+    idpTokenEndpoint: 'https://idp.example.com/token',
+    idpClientId: 'idp-client',
+    idpClientSecret: 'idp-secret',
+    idToken: makeJwt({ sub: 'user-1', exp: NOW_SECS + 3600 }),
+    idTokenExpiresAt: NOW_SECS + 3600,
+    idpRefreshToken: 'idp-refresh-1',
+    mcpClientId: 'mcp-client',
+    mcpClientSecret: 'mcp-secret',
+    scope: 'read write',
+    ...overrides,
+  };
+}
+
+const ID_JAG_RESPONSE = {
+  issued_token_type: 'urn:ietf:params:oauth:token-type:id-jag',
+  access_token: 'the-id-jag',
+  token_type: 'N_A',
+};
+
+describe('decodeJwtPayload / getJwtExpirySecs', () => {
+  it('decodes a JWT payload', () => {
+    const jwt = makeJwt({ sub: 'u', exp: 1234, email: 'a@b.c' });
+    expect(decodeJwtPayload(jwt)).toEqual({ sub: 'u', exp: 1234, email: 'a@b.c' });
+    expect(getJwtExpirySecs(jwt)).toBe(1234);
+  });
+
+  it('returns undefined for non-JWT input', () => {
+    expect(decodeJwtPayload('not-a-jwt')).toBeUndefined();
+    expect(getJwtExpirySecs('a.b')).toBeUndefined();
+    expect(getJwtExpirySecs(makeJwt({ sub: 'no-exp' }))).toBeUndefined();
+  });
+});
+
+describe('refreshIdpIdToken', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(proxyModule, 'proxyFetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('posts a refresh_token grant with HTTP Basic client auth and rotates tokens', async () => {
+    const newIdToken = makeJwt({ sub: 'user-1', exp: NOW_SECS + 7200 });
+    fetchSpy.mockResolvedValue(
+      mockResponse({ id_token: newIdToken, refresh_token: 'idp-refresh-2', token_type: 'Bearer' })
+    );
+
+    const updated = await refreshIdpIdToken(makeCredentials());
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://idp.example.com/token');
+    const params = new URLSearchParams(init.body as string);
+    expect(params.get('grant_type')).toBe('refresh_token');
+    expect(params.get('refresh_token')).toBe('idp-refresh-1');
+    expect(params.get('client_id')).toBe('idp-client');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe(
+      `Basic ${Buffer.from('idp-client:idp-secret').toString('base64')}`
+    );
+
+    expect(updated.idToken).toBe(newIdToken);
+    expect(updated.idTokenExpiresAt).toBe(NOW_SECS + 7200);
+    expect(updated.idpRefreshToken).toBe('idp-refresh-2');
+  });
+
+  it('omits client auth for public IdP clients and keeps an unrotated refresh token', async () => {
+    const newIdToken = makeJwt({ sub: 'user-1', exp: NOW_SECS + 7200 });
+    fetchSpy.mockResolvedValue(mockResponse({ id_token: newIdToken, token_type: 'Bearer' }));
+
+    const info = makeCredentials();
+    delete info.idpClientSecret;
+    const updated = await refreshIdpIdToken(info);
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined();
+    expect(updated.idpRefreshToken).toBe('idp-refresh-1');
+  });
+
+  it('throws a re-auth AuthError when the IdP rejects the refresh token', async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ error: 'invalid_grant' }, 400));
+    await expect(refreshIdpIdToken(makeCredentials())).rejects.toThrow(AuthError);
+    await expect(refreshIdpIdToken(makeCredentials())).rejects.toThrow(/re-authenticate/i);
+  });
+
+  it('throws when the IdP returns no ID token', async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ access_token: 'x', token_type: 'Bearer' }));
+    await expect(refreshIdpIdToken(makeCredentials())).rejects.toThrow(
+      /did not return an ID token/
+    );
+  });
+
+  it('throws when no refresh token is stored', async () => {
+    const info = makeCredentials();
+    delete info.idpRefreshToken;
+    await expect(refreshIdpIdToken(info)).rejects.toThrow(/no idp refresh token/i);
+  });
+});
+
+describe('createIdJagProvider', () => {
+  let fetchSpy: MockInstance;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(proxyModule, 'proxyFetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const PROVIDER_OPTIONS = { serverUrl: 'https://mcp.example.com', profileName: 'default' };
+
+  /**
+   * Drive the provider the way the SDK's auth() does: seed the discovered
+   * URLs, then ask it to prepare the token request (which invokes the
+   * assertion callback — the RFC 8693 exchange at the IdP).
+   */
+  async function prepareTokenRequest(
+    provider: ReturnType<typeof createIdJagProvider>
+  ): Promise<URLSearchParams> {
+    (
+      provider as unknown as { saveAuthorizationServerUrl(url: string): void }
+    ).saveAuthorizationServerUrl('https://auth.mcp.example.com');
+    (provider as unknown as { saveResourceUrl(url: string): void }).saveResourceUrl(
+      'https://mcp.example.com'
+    );
+    return (
+      provider as unknown as { prepareTokenRequest(scope?: string): Promise<URLSearchParams> }
+    ).prepareTokenRequest();
+  }
+
+  it('exchanges a fresh ID token for an ID-JAG with the exact RFC 8693 wire format', async () => {
+    fetchSpy.mockResolvedValue(mockResponse(ID_JAG_RESPONSE));
+
+    const provider = createIdJagProvider(makeCredentials(), PROVIDER_OPTIONS);
+    const tokenRequest = await prepareTokenRequest(provider);
+
+    // One fetch: the token exchange at the IdP (no refresh needed).
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [URL | string, RequestInit];
+    expect(String(url)).toBe('https://idp.example.com/token');
+    const params = new URLSearchParams(init.body as string);
+    expect(params.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:token-exchange');
+    expect(params.get('requested_token_type')).toBe('urn:ietf:params:oauth:token-type:id-jag');
+    expect(params.get('subject_token_type')).toBe('urn:ietf:params:oauth:token-type:id_token');
+    expect(params.get('subject_token')).toBe(makeCredentials().idToken);
+    expect(params.get('audience')).toBe('https://auth.mcp.example.com');
+    expect(params.get('resource')).toBe('https://mcp.example.com');
+    expect(params.get('client_id')).toBe('idp-client');
+    expect(params.get('client_secret')).toBe('idp-secret');
+    expect(params.get('scope')).toBe('read write');
+
+    // The provider then presents the ID-JAG as a jwt-bearer assertion.
+    expect(tokenRequest.get('grant_type')).toBe('urn:ietf:params:oauth:grant-type:jwt-bearer');
+    expect(tokenRequest.get('assertion')).toBe('the-id-jag');
+  });
+
+  it('refreshes an expired ID token first and persists the rotated material', async () => {
+    const expiredJwt = makeJwt({ sub: 'user-1', exp: NOW_SECS - 10 });
+    const freshJwt = makeJwt({ sub: 'user-1', exp: NOW_SECS + 7200 });
+    fetchSpy
+      .mockResolvedValueOnce(
+        mockResponse({ id_token: freshJwt, refresh_token: 'idp-refresh-2', token_type: 'Bearer' })
+      )
+      .mockResolvedValueOnce(mockResponse(ID_JAG_RESPONSE));
+
+    const onIdTokenRefresh = vi.fn().mockResolvedValue(undefined);
+    const provider = createIdJagProvider(
+      makeCredentials({ idToken: expiredJwt, idTokenExpiresAt: NOW_SECS - 10 }),
+      { ...PROVIDER_OPTIONS, callbacks: { onIdTokenRefresh } }
+    );
+    await prepareTokenRequest(provider);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    const refreshParams = new URLSearchParams(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
+    expect(refreshParams.get('grant_type')).toBe('refresh_token');
+    const exchangeParams = new URLSearchParams(
+      (fetchSpy.mock.calls[1] as [string, RequestInit])[1].body as string
+    );
+    expect(exchangeParams.get('subject_token')).toBe(freshJwt);
+
+    expect(onIdTokenRefresh).toHaveBeenCalledTimes(1);
+    const updated = onIdTokenRefresh.mock.calls[0]![0] as IdJagCredentials;
+    expect(updated.idToken).toBe(freshJwt);
+    expect(updated.idpRefreshToken).toBe('idp-refresh-2');
+  });
+
+  it('throws a re-auth AuthError when the ID token expired and no refresh token exists', async () => {
+    const expiredJwt = makeJwt({ sub: 'user-1', exp: NOW_SECS - 10 });
+    const info = makeCredentials({ idToken: expiredJwt, idTokenExpiresAt: NOW_SECS - 10 });
+    delete info.idpRefreshToken;
+
+    const provider = createIdJagProvider(info, PROVIDER_OPTIONS);
+    await expect(prepareTokenRequest(provider)).rejects.toThrow(AuthError);
+    fetchSpy.mockClear();
+    await expect(prepareTokenRequest(provider)).rejects.toThrow(
+      /re-authenticate with: mcpc login https:\/\/mcp\.example\.com --grant id-jag/
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('prefers reloaded credentials from the keychain over the initial material', async () => {
+    const rotatedJwt = makeJwt({ sub: 'user-1', exp: NOW_SECS + 9000 });
+    fetchSpy.mockResolvedValue(mockResponse(ID_JAG_RESPONSE));
+
+    const reloadCredentials = vi
+      .fn()
+      .mockResolvedValue(
+        makeCredentials({ idToken: rotatedJwt, idTokenExpiresAt: NOW_SECS + 9000 })
+      );
+    const provider = createIdJagProvider(makeCredentials(), {
+      ...PROVIDER_OPTIONS,
+      callbacks: { reloadCredentials },
+    });
+    await prepareTokenRequest(provider);
+
+    expect(reloadCredentials).toHaveBeenCalledTimes(1);
+    const params = new URLSearchParams(
+      (fetchSpy.mock.calls[0] as [string, RequestInit])[1].body as string
+    );
+    expect(params.get('subject_token')).toBe(rotatedJwt);
+  });
+
+  it('wraps IdP token-exchange rejections in an actionable AuthError', async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ error: 'invalid_grant', error_description: 'policy denies access' }, 400)
+    );
+
+    const provider = createIdJagProvider(makeCredentials(), PROVIDER_OPTIONS);
+    await expect(prepareTokenRequest(provider)).rejects.toThrow(AuthError);
+    await expect(prepareTokenRequest(provider)).rejects.toThrow(
+      /refused to issue an identity assertion grant.*policy denies access/s
+    );
+  });
+
+  it('exports the ID-JAG grant profile identifier', () => {
+    expect(ID_JAG_GRANT_PROFILE).toBe('urn:ietf:params:oauth:grant-profile:id-jag');
+  });
+});


### PR DESCRIPTION
Adds MCP's [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension (SEP-990): sign in once with corporate SSO at the enterprise IdP, and mcpc then obtains MCP server tokens via identity assertion grants (ID-JAG, RFC 8693 token exchange + RFC 7523 jwt-bearer) with no per-server consent screens. The SDK v2's `CrossAppAccessProvider` drives the exchanges; mcpc supplies the IdP SSO and grant plumbing, mirroring the existing client-credentials grant.

- New `mcpc login <server> --grant id-jag --idp <issuer> --idp-client-id <id> [--idp-client-secret <s>] --client-id <id> --client-secret <s>`, with full-chain validation at login (fail fast)
- ID token kept fresh via the IdP refresh token; rotated tokens persisted from the bridge on the sanctioned OAuth-refresh keychain path; dead SSO sessions land in `unauthorized` with a re-login hint
- Material stored as one OS keychain blob per profile, delivered to the bridge via IPC (never argv); profile listing labels these profiles "enterprise"
- Advertises the extension in client capabilities on id-jag connections only
- 19 new unit tests (RFC 8693 wire format, refresh/rotation, error paths); smoke-tested end-to-end against a mock IdP + mock MCP authorization server

Follow-ups deferred: public/CIMD clients at the MCP AS (SDK beta.5 requires `clientSecret`), SAML assertions, e2e mock-IdP suite.

https://claude.ai/code/session_01KFAG6CNK4kftV6RvHe2Jqi