### PR TITLE
Add --mcp-version flag to pin MCP protocol version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
+- New `--mcp-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--mcp-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as an `mcpVersion` field in mcp.json config entries.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,7 @@ mcpc/
 
 - Thin, runtime-agnostic wrapper around the official TypeScript SDK v2 client (`@modelcontextprotocol/client`, works with Node.js ≥22.12 and Bun ≥1)
 - Protocol version negotiation is automatic: the client probes servers with `server/discover` and speaks `2026-07-28` (stateless era) when supported, falling back to the legacy `initialize` handshake on the same connection (which negotiates `2025-11-25` down to `2024-10-07`)
+- `mcpc connect --mcp-version <version>` (or an `mcpVersion` field in a config entry) pins one exact protocol version instead — strict, no fallback; the supported list lives in `src/core/protocol.ts` (kept dependency-free so the CLI never loads the SDK at startup; a unit test guards drift against the SDK's list)
 - Transport abstraction: Streamable HTTP and stdio (both created via the SDK's transports)
 - Captures negotiated protocol version and MCP session ID after connect
 - Streamable HTTP connection management with reconnection delegated to the SDK (exponential backoff: 1s → 30s max, up to 10 retries)

--- a/README.md
+++ b/README.md
@@ -343,6 +343,12 @@ with `grep`, server keepalive and status checks by [periodic probing](#ping), ch
 notifications, resource-to-file syncs, and automatic OAuth token refresh. It is also more
 efficient than forcing every MCP command to rediscover the server and reauthenticate.
 
+The protocol version is negotiated automatically (`mcpc @session` shows the result). To pin
+one exact version instead, pass `--mcp-version` to `connect` (e.g.
+`mcpc connect mcp.apify.com --mcp-version 2025-11-25`) — the connection then fails if the
+server does not support that version. Config file entries can set the same via an
+`mcpVersion` field.
+
 Sessions are given names prefixed with `@` (e.g. `@apify`),
 which then serve as unique references in commands.
 

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -58,6 +58,9 @@ mcpc connect                             # discover standard configs + connect e
   (`mcp.apify.com` → `@apify`). A matching session (same server + auth) is reused.
 - **Stdio (command-based) entries launch a local process on connect** — only connect
   to configs you trust. Bulk connects skip stdio entries unless you pass `--stdio`.
+- The MCP protocol version is negotiated automatically. Pass
+  `--mcp-version <version>` (e.g. `--mcp-version 2025-11-25`) to pin one exact
+  version — the connection fails if the server does not support it.
 - `login` / `logout` only accept an MCP server URL (a bare host or full
   `http(s)://` URL) — not config files or auto-discovery.
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -35,6 +35,8 @@ import {
   theme,
 } from '../output.js';
 import { withMcpClient, resolveTarget, resolveAuthProfile } from '../helpers.js';
+// Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
+import { isSupportedMcpVersion, SUPPORTED_MCP_VERSIONS } from '../../core/protocol.js';
 import {
   deleteSession,
   saveSession,
@@ -132,6 +134,7 @@ type ConnectSessionOptions = {
   noProfile?: boolean;
   proxy?: string;
   proxyBearerToken?: string;
+  mcpVersion?: string;
   x402?: X402SchemePreference;
   insecure?: boolean;
   skipDetails?: boolean;
@@ -256,6 +259,14 @@ export async function connectSession(
   // Validate proxy-bearer-token is only used with --proxy
   if (options.proxyBearerToken && !options.proxy) {
     throw new ClientError('--proxy-bearer-token requires --proxy to be specified');
+  }
+
+  // Validate --mcp-version (if provided)
+  if (options.mcpVersion && !isSupportedMcpVersion(options.mcpVersion)) {
+    throw new ClientError(
+      `Unsupported MCP protocol version: ${options.mcpVersion}\n` +
+        `Supported versions: ${SUPPORTED_MCP_VERSIONS.join(', ')}`
+    );
   }
 
   // Check if session already exists
@@ -460,9 +471,14 @@ export async function connectSession(
       };
       console.log(formatOutput([failed], 'json'));
     } else {
+      const pinHint = serverConfig.mcpVersion
+        ? `  The session is pinned to MCP ${serverConfig.mcpVersion}. If the server does not\n` +
+          `  support that version, reconnect without --mcp-version to auto-negotiate.\n`
+        : '';
       console.log(
         formatWarning(
           `Session ${name} created but server is not responding: ${errorMsg}\n` +
+            pinHint +
             `  The session will auto-recover when the server becomes available.\n` +
             `  Check status with: mcpc ${name}`
         )
@@ -602,6 +618,7 @@ type BulkConnectOptions = {
   proxy?: string;
   proxyBearerToken?: string;
   stdio?: boolean;
+  mcpVersion?: string;
   x402?: X402SchemePreference;
   insecure?: boolean;
 };

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -294,7 +294,15 @@ export async function showServerDetails(
     const resourceSubscriptions = Object.values(sessionData?.resourceSubscriptions ?? {});
 
     if (options.outputMode === 'human') {
-      console.log(formatServerDetails(serverDetails, target, tools, resourceSubscriptions));
+      console.log(
+        formatServerDetails(
+          serverDetails,
+          target,
+          tools,
+          resourceSubscriptions,
+          context.serverConfig?.mcpVersion
+        )
+      );
     } else {
       // JSON output MUST match MCP InitializeResult structure!
       // See https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -80,6 +80,7 @@ export async function resolveTarget(
     timeoutSecs?: number;
     verbose?: boolean;
     profile?: string;
+    mcpVersion?: string;
   } = {}
 ): Promise<ServerConfig> {
   if (options.verbose) {
@@ -106,6 +107,7 @@ export async function resolveTarget(
       ...serverConfig,
       ...(Object.keys(mergedHeaders).length > 0 && { headers: mergedHeaders }),
       ...(options.timeoutSecs && { timeout: options.timeoutSecs }),
+      ...(options.mcpVersion && { mcpVersion: options.mcpVersion }),
     };
   }
 
@@ -129,6 +131,7 @@ export async function resolveTarget(
     url,
     ...(Object.keys(headers).length > 0 && { headers }),
     ...(options.timeoutSecs && { timeout: options.timeoutSecs }),
+    ...(options.mcpVersion && { mcpVersion: options.mcpVersion }),
   };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,8 @@ import { clean } from './commands/clean.js';
 import { MCPC_OAUTH_CALLBACK_HOSTS, MCPC_OAUTH_CALLBACK_PORTS } from '../lib/auth/oauth-utils.js';
 import type { OutputMode, X402SchemePreference } from '../lib/index.js';
 import { X402_SCHEME_PREFERENCES } from '../lib/index.js';
+// Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
+import { SUPPORTED_MCP_VERSIONS } from '../core/protocol.js';
 import {
   extractOptions,
   preProcessX402Argv,
@@ -474,6 +476,10 @@ Full docs: ${docsUrl}`
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--stdio', 'Launch all local stdio servers from selected config files')
     .option(
+      '--mcp-version <version>',
+      'Pin the MCP protocol version, e.g. 2025-11-25 (default: auto-negotiate)'
+    )
+    .option(
       '--x402 [scheme]',
       'Enable x402 auto-payment using the configured wallet; optional scheme: auto (default, prefer upto), upto, or exact.'
     )
@@ -504,6 +510,9 @@ ${chalk.bold('Stdio servers (command-based, run locally):')}
 ${chalk.bold('Protocol version:')}
   mcpc negotiates MCP 2026-07-28 with servers that support it and falls
   back to older versions (2025-11-25 down to 2024-10-07) automatically.
+  Pass --mcp-version to pin one exact version instead — the connection
+  fails if the server does not support it. Supported values:
+  ${SUPPORTED_MCP_VERSIONS.join(', ')}.
   Run mcpc @session to see the negotiated version.
 ${jsonHelp(
   'Array of `InitializeResult` objects (one per session), extended with `toolNames` and `_mcpc` metadata',
@@ -535,6 +544,7 @@ ${jsonHelp(
           ...(opts.proxy && { proxy: opts.proxy as string }),
           ...(opts.proxyBearerToken && { proxyBearerToken: opts.proxyBearerToken as string }),
           ...(opts.stdio && { stdio: true }),
+          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -566,6 +576,7 @@ ${jsonHelp(
           ...(opts.proxy && { proxy: opts.proxy as string }),
           ...(opts.proxyBearerToken && { proxyBearerToken: opts.proxyBearerToken as string }),
           ...(opts.stdio && { stdio: true }),
+          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -590,6 +601,7 @@ ${jsonHelp(
           config: parsed.file,
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
+          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -599,6 +611,7 @@ ${jsonHelp(
           ...(headers && { headers }),
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
+          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1600,7 +1600,8 @@ export function formatServerDetails(
   details: ServerDetails,
   target: string,
   tools?: Tool[],
-  resourceSubscriptions?: ResourceSubscriptionEntry[]
+  resourceSubscriptions?: ResourceSubscriptionEntry[],
+  pinnedMcpVersion?: string
 ): string {
   const lines: string[] = [];
   const bullet = chalk.dim('*');
@@ -1620,7 +1621,11 @@ export function formatServerDetails(
   // any request may hit any server instance; stateful = stdio process or HTTP session id)
   const hasMode = connectionMode !== undefined && connectionMode !== 'unknown';
   if (protocolVersion || hasMode) {
-    const mode = hasMode ? ` (${connectionMode})` : '';
+    const modeParts = [
+      ...(hasMode ? [connectionMode] : []),
+      ...(pinnedMcpVersion ? ['pinned'] : []),
+    ];
+    const mode = modeParts.length > 0 ? ` (${modeParts.join(', ')})` : '';
     lines.push(chalk.bold('Protocol:') + ` ${protocolVersion ?? 'unknown'}${mode}`);
     lines.push('');
   }

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -133,6 +133,8 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     // Cap the version-negotiation probe timeout on stdio (local servers answer fast;
     // some legacy ones never answer pre-initialize requests at all)
     ...(options.serverConfig.command && { stdioTransport: true }),
+    // Pin the MCP protocol version when requested (strict, no fallback)
+    ...(options.serverConfig.mcpVersion && { mcpVersion: options.serverConfig.mcpVersion }),
   };
 
   // Tolerate tool schemas stamped with pre-2020-12 dialects (draft-07 etc.), which the

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -14,3 +14,6 @@ export * from './factory.js';
 
 // Export client capabilities builder
 export * from './capabilities.js';
+
+// Export protocol version constants and helpers
+export * from './protocol.js';

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -33,8 +33,9 @@ import {
   CancelTaskResultSchema,
 } from '@modelcontextprotocol/core';
 import { createNoOpLogger, type Logger } from '../lib/logger.js';
-import { ServerError, NetworkError, isShutdownError } from '../lib/errors.js';
+import { ClientError, ServerError, NetworkError, isShutdownError } from '../lib/errors.js';
 import { fetchAllPages } from '../lib/utils.js';
+import { isModernMcpVersion, isSupportedMcpVersion, SUPPORTED_MCP_VERSIONS } from './protocol.js';
 
 /**
  * Traverse the .cause chain to find the deepest (most specific) error message
@@ -101,6 +102,13 @@ export interface McpClientOptions extends ClientOptions {
    * version-negotiation probe timeout (see STDIO_PROBE_TIMEOUT_MILLIS).
    */
   stdioTransport?: boolean;
+
+  /**
+   * Pin the MCP protocol version instead of auto-negotiating (strict: the
+   * connection fails unless the server agrees to exactly this version).
+   * Must be one of SUPPORTED_MCP_VERSIONS.
+   */
+  mcpVersion?: string;
 }
 
 /**
@@ -138,6 +146,41 @@ const RELISTEN_MAX_DELAY_MILLIS = 30_000;
 const STDIO_PROBE_TIMEOUT_MILLIS = 5_000;
 
 /**
+ * Compute the SDK version-negotiation options for an optional `--mcp-version` pin.
+ *
+ * - No pin: probe with `server/discover` and talk 2026-07-28 when the server supports
+ *   it, falling back to the legacy `initialize` handshake on the same connection.
+ * - Modern pin (2026-07-28+): the SDK's `{ pin }` mode — the server must offer exactly
+ *   that revision, no fallback.
+ * - Legacy pin: plain `initialize` handshake (no probe) offering only the pinned
+ *   version; the SDK rejects the connection if the server counter-offers anything else.
+ *
+ * Exported for unit tests.
+ */
+export function resolveVersionOptions(
+  mcpVersion: string | undefined,
+  stdioTransport: boolean | undefined
+): Pick<ClientOptions, 'versionNegotiation' | 'supportedProtocolVersions'> {
+  const probe = stdioTransport ? { probe: { timeoutMs: STDIO_PROBE_TIMEOUT_MILLIS } } : {};
+  if (mcpVersion === undefined) {
+    return { versionNegotiation: { mode: 'auto', ...probe } };
+  }
+  if (!isSupportedMcpVersion(mcpVersion)) {
+    throw new ClientError(
+      `Unsupported MCP protocol version: ${mcpVersion}\n` +
+        `Supported versions: ${SUPPORTED_MCP_VERSIONS.join(', ')}`
+    );
+  }
+  if (isModernMcpVersion(mcpVersion)) {
+    return { versionNegotiation: { mode: { pin: mcpVersion }, ...probe } };
+  }
+  return {
+    versionNegotiation: { mode: 'legacy' },
+    supportedProtocolVersions: [mcpVersion],
+  };
+}
+
+/**
  * MCP Client wrapper class
  * Provides a convenient interface to the MCP SDK Client with error handling and logging
  * Implements IMcpClient interface for compatibility with SessionClient
@@ -169,13 +212,10 @@ export class McpClient implements IMcpClient {
 
     this.client = new SDKClient(clientInfo, {
       capabilities: options.capabilities || {},
-      // Probe servers with `server/discover` and talk 2026-07-28 when they support it,
-      // falling back to the 2025-11-25 `initialize` handshake on the same connection.
-      versionNegotiation: {
-        mode: 'auto',
-        ...(options.stdioTransport ? { probe: { timeoutMs: STDIO_PROBE_TIMEOUT_MILLIS } } : {}),
-      },
       ...options,
+      // Placed after the spread so a caller-supplied versionNegotiation never
+      // overrides the mcpVersion pin (or the default auto negotiation).
+      ...resolveVersionOptions(options.mcpVersion, options.stdioTransport),
     });
 
     // Set up error handling

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -1,0 +1,38 @@
+/**
+ * MCP protocol version constants and helpers.
+ *
+ * Deliberately dependency-free: the CLI imports this module on every invocation
+ * (for `--mcp-version` validation and help text), so it must not pull in the MCP
+ * SDK. The legacy list mirrors the SDK's `SUPPORTED_PROTOCOL_VERSIONS` (the
+ * versions its `initialize` handshake can offer/accept) and the modern list
+ * mirrors its internal `SUPPORTED_MODERN_PROTOCOL_VERSIONS`; a unit test guards
+ * against drift on SDK upgrades.
+ */
+
+/** Modern-era protocol revisions (2026-07-28 and later), newest first. */
+export const MODERN_MCP_VERSIONS: readonly string[] = ['2026-07-28'];
+
+/** Legacy-era protocol revisions negotiated via the `initialize` handshake, newest first. */
+export const LEGACY_MCP_VERSIONS: readonly string[] = [
+  '2025-11-25',
+  '2025-06-18',
+  '2025-03-26',
+  '2024-11-05',
+  '2024-10-07',
+];
+
+/** All protocol revisions mcpc can pin via `--mcp-version`, newest first. */
+export const SUPPORTED_MCP_VERSIONS: readonly string[] = [
+  ...MODERN_MCP_VERSIONS,
+  ...LEGACY_MCP_VERSIONS,
+];
+
+/** Whether a protocol revision belongs to the modern (2026-07-28+) era. */
+export function isModernMcpVersion(version: string): boolean {
+  return MODERN_MCP_VERSIONS.includes(version);
+}
+
+/** Whether a protocol revision can be pinned via `--mcp-version`. */
+export function isSupportedMcpVersion(version: string): boolean {
+  return SUPPORTED_MCP_VERSIONS.includes(version);
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,6 +95,7 @@ export interface ServerConfig {
   args?: string[]; // For stdio transport
   env?: Record<string, string>; // Environment variables for stdio transport
   timeout?: number; // Request timeout in SECONDS (field name kept as `timeout` for mcp.json / sessions.json compatibility)
+  mcpVersion?: string; // Pin the MCP protocol version (strict, no fallback; absent = auto-negotiate)
 }
 
 /**

--- a/test/e2e/suites/basic/mcp-version.test.sh
+++ b/test/e2e/suites/basic/mcp-version.test.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Test: --mcp-version pins the MCP protocol version on connect
+#
+# Runs in both eras of the protocol matrix: the pin matching the active test
+# server succeeds and is displayed; the mismatched pin fails the handshake.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "basic/mcp-version" --isolated
+
+# Start test server
+start_test_server
+
+# Which pin matches the active test server, and which one cannot
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  MATCH_VERSION="2026-07-28"
+  MISMATCH_VERSION="2025-11-25"
+else
+  MATCH_VERSION="2025-11-25"
+  MISMATCH_VERSION="2026-07-28"
+fi
+
+# =============================================================================
+# Test: unsupported version is rejected before connecting
+# =============================================================================
+
+test_case "connect rejects an unsupported --mcp-version"
+run_mcpc connect "$TEST_SERVER_URL" "$(session_name "inv")" --header "X-Test: true" --mcp-version 1999-01-01
+assert_failure
+assert_contains "$STDERR" "Unsupported MCP protocol version: 1999-01-01"
+assert_contains "$STDERR" "Supported versions:"
+test_pass
+
+# =============================================================================
+# Test: pin matching the server's protocol version
+# =============================================================================
+
+SESSION=$(session_name "pin")
+
+test_case "connect with a matching --mcp-version succeeds"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true" --mcp-version "$MATCH_VERSION"
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
+test_pass
+
+test_case "session info shows the negotiated version as pinned"
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
+assert_contains "$STDOUT" "pinned"
+test_pass
+
+test_case "JSON session info includes the mcpVersion pin"
+run_mcpc --json "$SESSION"
+assert_success
+assert_json_valid "$STDOUT"
+assert_json_eq "$STDOUT" '._mcpc.server.mcpVersion' "$MATCH_VERSION"
+assert_json_eq "$STDOUT" '.protocolVersion' "$MATCH_VERSION"
+test_pass
+
+test_case "the pin survives a session restart"
+run_mcpc "$SESSION" restart
+assert_success
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
+assert_contains "$STDOUT" "pinned"
+test_pass
+
+test_case "tools work on a pinned session"
+run_mcpc "$SESSION" tools-call echo message:="pinned hello"
+assert_success
+assert_contains "$STDOUT" "pinned hello"
+test_pass
+
+run_mcpc "$SESSION" close 2>/dev/null || true
+
+# =============================================================================
+# Test: pin the server cannot satisfy fails the handshake
+# =============================================================================
+
+test_case "connect with a mismatched --mcp-version does not connect"
+MISMATCH_SESSION=$(session_name "mis")
+run_mcpc connect "$TEST_SERVER_URL" "$MISMATCH_SESSION" --header "X-Test: true" --mcp-version "$MISMATCH_VERSION"
+_SESSIONS_CREATED+=("$MISMATCH_SESSION")
+# The session record is created but the handshake must fail — the CLI reports the
+# failure (with the pin hint) instead of a connected server.
+assert_contains "$STDOUT$STDERR" "pinned to MCP $MISMATCH_VERSION"
+assert_not_contains "$STDOUT" "Protocol: $MISMATCH_VERSION"
+test_pass
+
+run_mcpc "$MISMATCH_SESSION" close 2>/dev/null || true
+
+test_done

--- a/test/unit/core/protocol.test.ts
+++ b/test/unit/core/protocol.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for MCP protocol version constants and the --mcp-version pin mapping
+ */
+
+import { SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/client';
+import {
+  MODERN_MCP_VERSIONS,
+  LEGACY_MCP_VERSIONS,
+  SUPPORTED_MCP_VERSIONS,
+  isModernMcpVersion,
+  isSupportedMcpVersion,
+} from '../../../src/core/protocol.js';
+import { resolveVersionOptions } from '../../../src/core/mcp-client.js';
+import { ClientError } from '../../../src/lib/errors.js';
+
+describe('protocol version constants', () => {
+  it('legacy list stays in sync with the SDK (drift guard)', () => {
+    // protocol.ts hardcodes the list so the CLI never loads the SDK at startup;
+    // this test catches drift when the SDK is upgraded.
+    expect(LEGACY_MCP_VERSIONS).toEqual(SUPPORTED_PROTOCOL_VERSIONS);
+  });
+
+  it('supported list is modern versions followed by legacy versions', () => {
+    expect(SUPPORTED_MCP_VERSIONS).toEqual([...MODERN_MCP_VERSIONS, ...LEGACY_MCP_VERSIONS]);
+  });
+
+  it('classifies modern and legacy versions', () => {
+    expect(isModernMcpVersion('2026-07-28')).toBe(true);
+    expect(isModernMcpVersion('2025-11-25')).toBe(false);
+    expect(isSupportedMcpVersion('2026-07-28')).toBe(true);
+    expect(isSupportedMcpVersion('2025-11-25')).toBe(true);
+    expect(isSupportedMcpVersion('2024-10-07')).toBe(true);
+    expect(isSupportedMcpVersion('1999-01-01')).toBe(false);
+    expect(isSupportedMcpVersion('')).toBe(false);
+  });
+});
+
+describe('resolveVersionOptions', () => {
+  it('defaults to auto negotiation without a pin', () => {
+    expect(resolveVersionOptions(undefined, undefined)).toEqual({
+      versionNegotiation: { mode: 'auto' },
+    });
+  });
+
+  it('caps the probe timeout on stdio without a pin', () => {
+    const options = resolveVersionOptions(undefined, true);
+    expect(options.versionNegotiation?.mode).toBe('auto');
+    expect(options.versionNegotiation?.probe?.timeoutMs).toBeGreaterThan(0);
+  });
+
+  it('maps a modern pin to the SDK pin mode', () => {
+    expect(resolveVersionOptions('2026-07-28', undefined)).toEqual({
+      versionNegotiation: { mode: { pin: '2026-07-28' } },
+    });
+  });
+
+  it('maps a legacy pin to legacy mode with a single supported version', () => {
+    expect(resolveVersionOptions('2025-11-25', undefined)).toEqual({
+      versionNegotiation: { mode: 'legacy' },
+      supportedProtocolVersions: ['2025-11-25'],
+    });
+    expect(resolveVersionOptions('2024-10-07', true)).toEqual({
+      versionNegotiation: { mode: 'legacy' },
+      supportedProtocolVersions: ['2024-10-07'],
+    });
+  });
+
+  it('rejects unsupported versions with the supported list', () => {
+    expect(() => resolveVersionOptions('1999-01-01', undefined)).toThrow(ClientError);
+    expect(() => resolveVersionOptions('1999-01-01', undefined)).toThrow(
+      /Supported versions: 2026-07-28, 2025-11-25/
+    );
+  });
+});


### PR DESCRIPTION
Adds `--mcp-version <version>` to `mcpc connect` (and an `mcpVersion` field in mcp.json entries) to pin the MCP protocol version instead of auto-negotiating. The pin is strict: the connection fails with an actionable error unless the server agrees to exactly the requested version.

- Modern pin (2026-07-28) maps to the SDK's `{ pin }` mode; legacy pins run the plain `initialize` handshake offering only the pinned version
- Pin persists in sessions.json (survives `restart`) and shows as `(pinned)` in `mcpc @session`
- Supported versions live in a dependency-free `src/core/protocol.ts` (CLI startup never loads the SDK); a unit test guards drift against the SDK's list
- New e2e suite runs in both eras of the protocol matrix; docs/help/skill updated

Refs #314

https://claude.ai/code/session_01DCJziR1mQfJk9XynQCwsFx