### PR TITLE
Preserve protocol version on session resumption after crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
 - Updated the MCP TypeScript SDK v2 to `2.0.0-beta.5`, which fixes interoperability with 2026-07-28 servers built on the latest SDK betas (they require the new `Mcp-Method` request header that older clients did not send).
 
+### Fixed
+
+- Sessions resumed after a bridge restart (e.g. crash recovery) no longer lose their negotiated protocol version: session details showed `Protocol: unknown` and, worse, requests were sent without the required `MCP-Protocol-Version` header. The stored version is now restored on resumption, and the server name is shown again in session details.
+
 ### Deprecated
 
 - The `logging-set-level` command is deprecated and will be removed in a future release: MCP 2026-07-28 removed the underlying `logging/setLevel` request. It keeps working on 2025-11-25 servers during the deprecation window.

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -75,6 +75,7 @@ interface BridgeOptions {
   profileName?: string; // Auth profile name for token refresh
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
+  protocolVersion?: string; // Protocol version negotiated by the resumed session (only set with mcpSessionId)
   /** x402 scheme preference; presence enables x402 auto-payment, absence disables. */
   x402?: X402SchemePreference;
   insecure?: boolean; // Skip TLS certificate verification
@@ -670,6 +671,11 @@ class BridgeProcess {
       ...(this.authProvider && { authProvider: this.authProvider }),
       // Pass session ID for resumption (HTTP transport only)
       ...(this.options.mcpSessionId && { mcpSessionId: this.options.mcpSessionId }),
+      // Restore the previously negotiated protocol version on resumption: the SDK skips
+      // the handshake when a session ID is supplied, so without this the reconnected
+      // transport would not know which MCP-Protocol-Version header to send
+      ...(this.options.mcpSessionId &&
+        this.options.protocolVersion && { protocolVersion: this.options.protocolVersion }),
       // Pass x402 fetch middleware (HTTP transport only)
       ...(customFetch && { customFetch }),
       // Route stdio server stderr into the bridge log + tail buffer
@@ -1479,9 +1485,19 @@ class BridgeProcess {
           break;
         }
 
-        case 'getServerDetails':
-          result = await this.client.getServerDetails();
+        case 'getServerDetails': {
+          const details = await this.client.getServerDetails();
+          // A resumed HTTP session skips the initialize handshake, so the SDK client
+          // has no serverInfo; fall back to the value persisted at original connect.
+          if (!details.serverInfo) {
+            const session = await getSession(this.options.sessionName);
+            if (session?.serverInfo) {
+              details.serverInfo = session.serverInfo;
+            }
+          }
+          result = details;
           break;
+        }
 
         case 'listTasks': {
           const cursor = message.params as string | undefined;
@@ -1771,7 +1787,7 @@ async function main(): Promise<void> {
 
   if (args.length < 2) {
     console.error(
-      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>] [--x402 <auto|upto|exact>] [--insecure]'
+      'Usage: mcpc-bridge <sessionName> <transportConfigJson> [--verbose] [--profile <name>] [--proxy-host <host>] [--proxy-port <port>] [--mcp-session-id <id>] [--protocol-version <version>] [--x402 <auto|upto|exact>] [--insecure]'
     );
     process.exit(1);
   }
@@ -1804,6 +1820,13 @@ async function main(): Promise<void> {
   const mcpSessionIdIndex = args.indexOf('--mcp-session-id');
   if (mcpSessionIdIndex !== -1 && args[mcpSessionIdIndex + 1]) {
     mcpSessionId = args[mcpSessionIdIndex + 1];
+  }
+
+  // Parse --protocol-version argument (protocol version negotiated by the resumed session)
+  let protocolVersion: string | undefined;
+  const protocolVersionIndex = args.indexOf('--protocol-version');
+  if (protocolVersionIndex !== -1 && args[protocolVersionIndex + 1]) {
+    protocolVersion = args[protocolVersionIndex + 1];
   }
 
   // Parse `--x402 <scheme>` (CLI always spawns the bridge with an explicit value).
@@ -1841,6 +1864,9 @@ async function main(): Promise<void> {
     }
     if (mcpSessionId) {
       bridgeOptions.mcpSessionId = mcpSessionId;
+    }
+    if (protocolVersion) {
+      bridgeOptions.protocolVersion = protocolVersion;
     }
     if (x402) {
       bridgeOptions.x402 = x402;

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -56,6 +56,14 @@ export interface CreateMcpClientOptions {
   mcpSessionId?: string;
 
   /**
+   * Protocol version negotiated by the session being resumed (HTTP transport only,
+   * pass together with mcpSessionId). The SDK skips the handshake when resuming, so
+   * the transport needs the original version to keep sending the required
+   * MCP-Protocol-Version header.
+   */
+  protocolVersion?: string;
+
+  /**
    * Custom fetch function for the transport (HTTP transport only)
    * Used by x402 payment middleware
    */
@@ -155,6 +163,7 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     const transportOptions: {
       authProvider?: OAuthClientProvider;
       mcpSessionId?: string;
+      protocolVersion?: string;
       customFetch?: FetchLike;
       onStderrLine?: (line: string) => void;
     } = {};
@@ -163,6 +172,9 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     }
     if (options.mcpSessionId) {
       transportOptions.mcpSessionId = options.mcpSessionId;
+      if (options.protocolVersion) {
+        transportOptions.protocolVersion = options.protocolVersion;
+      }
     }
     if (options.customFetch) {
       transportOptions.customFetch = options.customFetch;

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -400,9 +400,16 @@ export class McpClient implements IMcpClient {
   /**
    * Protocol era of the connection: 'modern' for 2026-07-28+ (negotiated via
    * server/discover), 'legacy' for the 2025-era initialize handshake.
+   * A resumed HTTP session skips the handshake, so the SDK client never learns
+   * the era; derive it from the restored protocol version instead.
    */
   getProtocolEra(): ProtocolEra | undefined {
-    return this.client.getProtocolEra();
+    const sdkEra = this.client.getProtocolEra();
+    if (sdkEra) return sdkEra;
+    if (this.negotiatedProtocolVersion) {
+      return isModernMcpVersion(this.negotiatedProtocolVersion) ? 'modern' : 'legacy';
+    }
+    return undefined;
   }
 
   /**

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -166,6 +166,14 @@ export interface CreateTransportOptions {
   mcpSessionId?: string;
 
   /**
+   * Protocol version negotiated by the session being resumed (HTTP transport only).
+   * The SDK skips the initialize handshake when mcpSessionId is provided, so the
+   * transport must be seeded with the original version to keep sending the
+   * required MCP-Protocol-Version header on all requests.
+   */
+  protocolVersion?: string;
+
+  /**
    * Custom fetch function (HTTP transport only)
    * Used by x402 middleware to intercept and modify requests
    */
@@ -220,10 +228,16 @@ export function createTransportFromConfig(
       logger.debug('No authProvider provided for HTTP transport');
     }
 
-    // Set session ID for resuming a previous MCP session
+    // Set session ID for resuming a previous MCP session, restoring the protocol
+    // version negotiated by the original handshake (the SDK skips the handshake on
+    // resumption, so the version cannot be re-negotiated)
     if (options.mcpSessionId) {
       transportOptions.sessionId = options.mcpSessionId;
       logger.debug(`Setting mcpSessionId for session resumption: ${options.mcpSessionId}`);
+      if (options.protocolVersion) {
+        transportOptions.protocolVersion = options.protocolVersion;
+        logger.debug(`Restoring negotiated protocol version: ${options.protocolVersion}`);
+      }
     }
 
     if (config.headers !== undefined) {

--- a/src/lib/bridge-manager.ts
+++ b/src/lib/bridge-manager.ts
@@ -117,6 +117,7 @@ export interface StartBridgeOptions {
   headers?: Record<string, string>; // Headers to send via IPC (caller stores in keychain)
   proxyConfig?: ProxyConfig; // Proxy server configuration
   mcpSessionId?: string; // MCP session ID for resumption (Streamable HTTP only)
+  protocolVersion?: string; // Protocol version negotiated by the resumed session (only pass with mcpSessionId)
   /** x402 scheme preference; presence enables x402 auto-payment, absence disables. */
   x402?: X402SchemePreference;
   insecure?: boolean; // Skip TLS certificate verification
@@ -150,6 +151,7 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     headers,
     proxyConfig,
     mcpSessionId,
+    protocolVersion,
     x402,
     insecure,
   } = options;
@@ -209,10 +211,17 @@ export async function startBridge(options: StartBridgeOptions): Promise<StartBri
     args.push('--proxy-port', String(proxyConfig.port));
   }
 
-  // Pass MCP session ID for resumption (if available)
+  // Pass MCP session ID for resumption (if available), along with the protocol version
+  // negotiated by the original session — the SDK skips the handshake on resumption, so
+  // the bridge must seed the transport with the version to keep the required
+  // MCP-Protocol-Version header on all requests
   if (mcpSessionId) {
     args.push('--mcp-session-id', mcpSessionId);
     logger.debug(`Passing MCP session ID for resumption: ${mcpSessionId}`);
+    if (protocolVersion) {
+      args.push('--protocol-version', protocolVersion);
+      logger.debug(`Passing negotiated protocol version for resumption: ${protocolVersion}`);
+    }
   }
 
   // Pass x402 scheme preference (presence enables x402).
@@ -504,6 +513,10 @@ export async function restartBridge(sessionName: string): Promise<StartBridgeRes
   if (session.mcpSessionId) {
     bridgeOptions.mcpSessionId = session.mcpSessionId;
     logger.debug(`Using saved MCP session ID for resumption: ${session.mcpSessionId}`);
+    if (session.protocolVersion) {
+      bridgeOptions.protocolVersion = session.protocolVersion;
+      logger.debug(`Using saved protocol version for resumption: ${session.protocolVersion}`);
+    }
   }
   if (session.x402) {
     bridgeOptions.x402 = session.x402;

--- a/test/e2e/suites/sessions/resume.test.sh
+++ b/test/e2e/suites/sessions/resume.test.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Test: session resumption after a bridge crash preserves the negotiated protocol version
+#
+# Regression guard: the SDK skips the initialize handshake when resuming with a
+# preserved MCP-Session-Id, so the client never re-learns the protocol version.
+# mcpc must seed the reconnected transport with the version persisted in
+# sessions.json — otherwise session details show "Protocol: unknown" and requests
+# go out without the required MCP-Protocol-Version header.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "sessions/resume"
+
+# MCP session IDs (and thus resumption) exist only in the 2025-era protocol;
+# 2026-07-28 connections are stateless.
+require_server_protocol legacy
+
+# Start test server
+start_test_server
+
+SESSION=$(session_name "resume")
+
+# Test: create session and capture negotiated protocol state
+test_case "create session and capture protocol state"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION"
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+
+run_mcpc --json
+protocol_version=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .protocolVersion")
+mcp_session_id=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .mcpSessionId")
+bridge_pid=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .pid")
+assert_not_empty "$protocol_version" "protocolVersion should be stored after connect"
+assert_not_empty "$mcp_session_id" "mcpSessionId should be stored after connect"
+assert_not_empty "$bridge_pid" "bridge PID should be stored after connect"
+test_pass
+
+# Test: crash the bridge without graceful shutdown (no HTTP DELETE, so the
+# server keeps the MCP session alive and the restarted bridge can resume it)
+test_case "crash bridge (no graceful shutdown)"
+if is_windows; then
+  _kill_tree "$bridge_pid"
+  sleep 1
+else
+  kill -9 "$bridge_pid" 2>/dev/null || true
+  if ! wait_for "! kill -0 $bridge_pid 2>/dev/null" 10; then
+    test_fail "bridge should not be running after SIGKILL"
+    exit 1
+  fi
+fi
+test_pass
+
+# Test: next command auto-restarts the bridge and resumes the MCP session
+test_case "command works after crash (auto-restart resumes session)"
+run_mcpc "$SESSION" ping
+assert_success
+test_pass
+
+# Test: the session was resumed, not re-initialized
+test_case "same MCP session ID after resume"
+run_mcpc --json
+resumed_session_id=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .mcpSessionId")
+assert_eq "$resumed_session_id" "$mcp_session_id" "mcpSessionId should be unchanged after resume"
+test_pass
+
+# Test: protocol version survives resumption (SDK skips the handshake, so mcpc
+# must restore the persisted version)
+test_case "protocol version preserved after resume"
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "Protocol: $protocol_version"
+assert_not_contains "$STDOUT" "Protocol: unknown"
+test_pass
+
+# Test: server info is still shown in session details after resume
+test_case "server info preserved after resume"
+assert_contains "$STDOUT" "Server:"
+run_mcpc --json "$SESSION"
+assert_success
+json_protocol=$(json_get ".protocolVersion")
+json_server_name=$(json_get ".serverInfo.name")
+assert_eq "$json_protocol" "$protocol_version" "JSON protocolVersion should match original"
+assert_not_empty "$json_server_name" "JSON serverInfo.name should be present after resume"
+test_pass
+
+# Test: close session
+test_case "close session"
+run_mcpc "$SESSION" close
+assert_success
+_SESSIONS_CREATED=("${_SESSIONS_CREATED[@]/$SESSION}")
+test_pass
+
+test_done

--- a/test/e2e/suites/stdio/filesystem.test.sh
+++ b/test/e2e/suites/stdio/filesystem.test.sh
@@ -30,6 +30,29 @@ command=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .serverConfig.
 assert_not_empty "$command" "command should be present for stdio transport"
 test_pass
 
+# Test: negotiated protocol version is detected for stdio sessions.
+# Regression guard: MCP SDK v1's stdio client transport never exposed the
+# negotiated protocolVersion (typescript-sdk#1468), so mcpc <= 0.5.0 showed
+# "Protocol: unknown" for every stdio server. The v2 client reports it via
+# getNegotiatedProtocolVersion() regardless of transport.
+test_case "protocol version is detected for stdio session"
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "Protocol: 20"
+assert_not_contains "$STDOUT" "Protocol: unknown"
+test_pass
+
+# Test: protocol version is present in --json session details
+test_case "protocol version in --json session details"
+run_mcpc --json "$SESSION"
+assert_success
+protocol_version=$(json_get ".protocolVersion")
+case "$protocol_version" in
+  20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]) ;;
+  *) test_fail "protocolVersion should be a date-formatted MCP version, got: $protocol_version" ;;
+esac
+test_pass
+
 # Test: list tools via stdio session
 test_case "tools-list works via stdio session"
 run_xmcpc "$SESSION" tools-list


### PR DESCRIPTION
Sessions resumed after a bridge crash lost their negotiated protocol version: session details showed `Protocol: unknown (stateful)` without the server name, and all requests on the resumed connection were sent without the required `MCP-Protocol-Version` header. The SDK skips the initialize handshake when reconnecting with a preserved `MCP-Session-Id`, so mcpc now seeds the reconstructed transport with the version persisted in sessions.json.

- Thread the stored `protocolVersion` through the resume path (bridge manager → bridge → transport), using the SDK transport option intended for exactly this case
- Derive the protocol era from the restored version so era-dependent routing keeps working on resumed connections
- Fall back to persisted `serverInfo` in session details after resumption
- New e2e test crashes the bridge and asserts the resumed session keeps its protocol version, server info, and session ID (verified to fail without the fix)
- Also adds an e2e guard asserting stdio sessions report a real protocol version (the mcpc ≤ 0.5.0 symptom from modelcontextprotocol/typescript-sdk#1468)

Fixes #324. Refs #325 (follow-up: capabilities/instructions after resumption).

https://claude.ai/code/session_011pqNs7aoZWzXjgBUxAsias