### PR TITLE
Rename --mcp-version to --protocol-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `mcpc login <server> --grant id-jag` for MCP's [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension: sign in once with your corporate SSO (`--idp <issuer>`), and mcpc obtains MCP server tokens via identity assertion grants (ID-JAG) without per-server consent screens.
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
-- New `--mcp-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--mcp-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as an `mcpVersion` field in mcp.json config entries.
+- New `--protocol-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--protocol-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as a `protocolVersion` field in mcp.json config entries.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ mcpc/
 
 - Thin, runtime-agnostic wrapper around the official TypeScript SDK v2 client (`@modelcontextprotocol/client`, works with Node.js ≥22.12 and Bun ≥1)
 - Protocol version negotiation is automatic: the client probes servers with `server/discover` and speaks `2026-07-28` (stateless era) when supported, falling back to the legacy `initialize` handshake on the same connection (which negotiates `2025-11-25` down to `2024-10-07`)
-- `mcpc connect --mcp-version <version>` (or an `mcpVersion` field in a config entry) pins one exact protocol version instead — strict, no fallback; the supported list lives in `src/core/protocol.ts` (kept dependency-free so the CLI never loads the SDK at startup; a unit test guards drift against the SDK's list)
+- `mcpc connect --protocol-version <version>` (or a `protocolVersion` field in a config entry) pins one exact protocol version instead — strict, no fallback; the supported list lives in `src/core/protocol.ts` (kept dependency-free so the CLI never loads the SDK at startup; a unit test guards drift against the SDK's list)
 - Transport abstraction: Streamable HTTP and stdio (both created via the SDK's transports)
 - Captures negotiated protocol version and MCP session ID after connect
 - Streamable HTTP connection management with reconnection delegated to the SDK (exponential backoff: 1s → 30s max, up to 10 retries)

--- a/README.md
+++ b/README.md
@@ -344,10 +344,10 @@ notifications, resource-to-file syncs, and automatic OAuth token refresh. It is 
 efficient than forcing every MCP command to rediscover the server and reauthenticate.
 
 The protocol version is negotiated automatically (`mcpc @session` shows the result). To pin
-one exact version instead, pass `--mcp-version` to `connect` (e.g.
-`mcpc connect mcp.apify.com --mcp-version 2025-11-25`) — the connection then fails if the
-server does not support that version. Config file entries can set the same via an
-`mcpVersion` field.
+one exact version instead, pass `--protocol-version` to `connect` (e.g.
+`mcpc connect mcp.apify.com --protocol-version 2025-11-25`) — the connection then fails if the
+server does not support that version. Config file entries can set the same via a
+`protocolVersion` field.
 
 Sessions are given names prefixed with `@` (e.g. `@apify`),
 which then serve as unique references in commands.

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -59,8 +59,8 @@ mcpc connect                             # discover standard configs + connect e
 - **Stdio (command-based) entries launch a local process on connect** — only connect
   to configs you trust. Bulk connects skip stdio entries unless you pass `--stdio`.
 - The MCP protocol version is negotiated automatically. Pass
-  `--mcp-version <version>` (e.g. `--mcp-version 2025-11-25`) to pin one exact
-  version — the connection fails if the server does not support it.
+  `--protocol-version <version>` (e.g. `--protocol-version 2025-11-25`) to pin
+  one exact version — the connection fails if the server does not support it.
 - `login` / `logout` only accept an MCP server URL (a bare host or full
   `http(s)://` URL) — not config files or auto-discovery.
 

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -36,7 +36,7 @@ import {
 } from '../output.js';
 import { withMcpClient, resolveTarget, resolveAuthProfile } from '../helpers.js';
 // Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
-import { isSupportedMcpVersion, SUPPORTED_MCP_VERSIONS } from '../../core/protocol.js';
+import { isSupportedProtocolVersion, SUPPORTED_PROTOCOL_VERSIONS } from '../../core/protocol.js';
 import {
   deleteSession,
   saveSession,
@@ -134,7 +134,7 @@ type ConnectSessionOptions = {
   noProfile?: boolean;
   proxy?: string;
   proxyBearerToken?: string;
-  mcpVersion?: string;
+  protocolVersion?: string;
   x402?: X402SchemePreference;
   insecure?: boolean;
   skipDetails?: boolean;
@@ -261,11 +261,11 @@ export async function connectSession(
     throw new ClientError('--proxy-bearer-token requires --proxy to be specified');
   }
 
-  // Validate --mcp-version (if provided)
-  if (options.mcpVersion && !isSupportedMcpVersion(options.mcpVersion)) {
+  // Validate --protocol-version (if provided)
+  if (options.protocolVersion && !isSupportedProtocolVersion(options.protocolVersion)) {
     throw new ClientError(
-      `Unsupported MCP protocol version: ${options.mcpVersion}\n` +
-        `Supported versions: ${SUPPORTED_MCP_VERSIONS.join(', ')}`
+      `Unsupported MCP protocol version: ${options.protocolVersion}\n` +
+        `Supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')}`
     );
   }
 
@@ -471,9 +471,9 @@ export async function connectSession(
       };
       console.log(formatOutput([failed], 'json'));
     } else {
-      const pinHint = serverConfig.mcpVersion
-        ? `  The session is pinned to MCP ${serverConfig.mcpVersion}. If the server does not\n` +
-          `  support that version, reconnect without --mcp-version to auto-negotiate.\n`
+      const pinHint = serverConfig.protocolVersion
+        ? `  The session is pinned to MCP ${serverConfig.protocolVersion}. If the server does not\n` +
+          `  support that version, reconnect without --protocol-version to auto-negotiate.\n`
         : '';
       console.log(
         formatWarning(
@@ -618,7 +618,7 @@ type BulkConnectOptions = {
   proxy?: string;
   proxyBearerToken?: string;
   stdio?: boolean;
-  mcpVersion?: string;
+  protocolVersion?: string;
   x402?: X402SchemePreference;
   insecure?: boolean;
 };

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -305,7 +305,7 @@ export async function showServerDetails(
           target,
           tools,
           resourceSubscriptions,
-          context.serverConfig?.mcpVersion
+          context.serverConfig?.protocolVersion
         )
       );
     } else {

--- a/src/cli/helpers.ts
+++ b/src/cli/helpers.ts
@@ -80,7 +80,7 @@ export async function resolveTarget(
     timeoutSecs?: number;
     verbose?: boolean;
     profile?: string;
-    mcpVersion?: string;
+    protocolVersion?: string;
   } = {}
 ): Promise<ServerConfig> {
   if (options.verbose) {
@@ -107,7 +107,7 @@ export async function resolveTarget(
       ...serverConfig,
       ...(Object.keys(mergedHeaders).length > 0 && { headers: mergedHeaders }),
       ...(options.timeoutSecs && { timeout: options.timeoutSecs }),
-      ...(options.mcpVersion && { mcpVersion: options.mcpVersion }),
+      ...(options.protocolVersion && { protocolVersion: options.protocolVersion }),
     };
   }
 
@@ -131,7 +131,7 @@ export async function resolveTarget(
     url,
     ...(Object.keys(headers).length > 0 && { headers }),
     ...(options.timeoutSecs && { timeout: options.timeoutSecs }),
-    ...(options.mcpVersion && { mcpVersion: options.mcpVersion }),
+    ...(options.protocolVersion && { protocolVersion: options.protocolVersion }),
   };
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,7 +29,7 @@ import { MCPC_OAUTH_CALLBACK_HOSTS, MCPC_OAUTH_CALLBACK_PORTS } from '../lib/aut
 import type { OutputMode, X402SchemePreference } from '../lib/index.js';
 import { X402_SCHEME_PREFERENCES } from '../lib/index.js';
 // Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
-import { SUPPORTED_MCP_VERSIONS } from '../core/protocol.js';
+import { SUPPORTED_PROTOCOL_VERSIONS } from '../core/protocol.js';
 import {
   extractOptions,
   preProcessX402Argv,
@@ -476,7 +476,7 @@ Full docs: ${docsUrl}`
     .option('--proxy-bearer-token <token>', 'Require authentication for access to proxy server')
     .option('--stdio', 'Launch all local stdio servers from selected config files')
     .option(
-      '--mcp-version <version>',
+      '--protocol-version <version>',
       'Pin the MCP protocol version, e.g. 2025-11-25 (default: auto-negotiate)'
     )
     .option(
@@ -510,9 +510,9 @@ ${chalk.bold('Stdio servers (command-based, run locally):')}
 ${chalk.bold('Protocol version:')}
   mcpc negotiates MCP 2026-07-28 with servers that support it and falls
   back to older versions (2025-11-25 down to 2024-10-07) automatically.
-  Pass --mcp-version to pin one exact version instead — the connection
+  Pass --protocol-version to pin one exact version instead — the connection
   fails if the server does not support it. Supported values:
-  ${SUPPORTED_MCP_VERSIONS.join(', ')}.
+  ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')}.
   Run mcpc @session to see the negotiated version.
 ${jsonHelp(
   'Array of `InitializeResult` objects (one per session), extended with `toolNames` and `_mcpc` metadata',
@@ -544,7 +544,7 @@ ${jsonHelp(
           ...(opts.proxy && { proxy: opts.proxy as string }),
           ...(opts.proxyBearerToken && { proxyBearerToken: opts.proxyBearerToken as string }),
           ...(opts.stdio && { stdio: true }),
-          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
+          ...(opts.protocolVersion && { protocolVersion: opts.protocolVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -576,7 +576,7 @@ ${jsonHelp(
           ...(opts.proxy && { proxy: opts.proxy as string }),
           ...(opts.proxyBearerToken && { proxyBearerToken: opts.proxyBearerToken as string }),
           ...(opts.stdio && { stdio: true }),
-          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
+          ...(opts.protocolVersion && { protocolVersion: opts.protocolVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -601,7 +601,7 @@ ${jsonHelp(
           config: parsed.file,
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
-          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
+          ...(opts.protocolVersion && { protocolVersion: opts.protocolVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });
@@ -611,7 +611,7 @@ ${jsonHelp(
           ...(headers && { headers }),
           proxy: opts.proxy,
           proxyBearerToken: opts.proxyBearerToken,
-          ...(opts.mcpVersion && { mcpVersion: opts.mcpVersion as string }),
+          ...(opts.protocolVersion && { protocolVersion: opts.protocolVersion as string }),
           ...(globalOpts.x402 && { x402: globalOpts.x402 }),
           ...(globalOpts.insecure && { insecure: true }),
         });

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1601,7 +1601,7 @@ export function formatServerDetails(
   target: string,
   tools?: Tool[],
   resourceSubscriptions?: ResourceSubscriptionEntry[],
-  pinnedMcpVersion?: string
+  pinnedProtocolVersion?: string
 ): string {
   const lines: string[] = [];
   const bullet = chalk.dim('*');
@@ -1623,7 +1623,7 @@ export function formatServerDetails(
   if (protocolVersion || hasMode) {
     const modeParts = [
       ...(hasMode ? [connectionMode] : []),
-      ...(pinnedMcpVersion ? ['pinned'] : []),
+      ...(pinnedProtocolVersion ? ['pinned'] : []),
     ];
     const mode = modeParts.length > 0 ? ` (${modeParts.join(', ')})` : '';
     lines.push(chalk.bold('Protocol:') + ` ${protocolVersion ?? 'unknown'}${mode}`);

--- a/src/core/factory.ts
+++ b/src/core/factory.ts
@@ -142,7 +142,9 @@ export async function createMcpClient(options: CreateMcpClientOptions): Promise<
     // some legacy ones never answer pre-initialize requests at all)
     ...(options.serverConfig.command && { stdioTransport: true }),
     // Pin the MCP protocol version when requested (strict, no fallback)
-    ...(options.serverConfig.mcpVersion && { mcpVersion: options.serverConfig.mcpVersion }),
+    ...(options.serverConfig.protocolVersion && {
+      protocolVersion: options.serverConfig.protocolVersion,
+    }),
   };
 
   // Tolerate tool schemas stamped with pre-2020-12 dialects (draft-07 etc.), which the

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -35,7 +35,11 @@ import {
 import { createNoOpLogger, type Logger } from '../lib/logger.js';
 import { ClientError, ServerError, NetworkError, isShutdownError } from '../lib/errors.js';
 import { fetchAllPages } from '../lib/utils.js';
-import { isModernMcpVersion, isSupportedMcpVersion, SUPPORTED_MCP_VERSIONS } from './protocol.js';
+import {
+  isModernProtocolVersion,
+  isSupportedProtocolVersion,
+  SUPPORTED_PROTOCOL_VERSIONS,
+} from './protocol.js';
 
 /**
  * Traverse the .cause chain to find the deepest (most specific) error message
@@ -106,9 +110,9 @@ export interface McpClientOptions extends ClientOptions {
   /**
    * Pin the MCP protocol version instead of auto-negotiating (strict: the
    * connection fails unless the server agrees to exactly this version).
-   * Must be one of SUPPORTED_MCP_VERSIONS.
+   * Must be one of SUPPORTED_PROTOCOL_VERSIONS.
    */
-  mcpVersion?: string;
+  protocolVersion?: string;
 }
 
 /**
@@ -146,7 +150,7 @@ const RELISTEN_MAX_DELAY_MILLIS = 30_000;
 const STDIO_PROBE_TIMEOUT_MILLIS = 5_000;
 
 /**
- * Compute the SDK version-negotiation options for an optional `--mcp-version` pin.
+ * Compute the SDK version-negotiation options for an optional `--protocol-version` pin.
  *
  * - No pin: probe with `server/discover` and talk 2026-07-28 when the server supports
  *   it, falling back to the legacy `initialize` handshake on the same connection.
@@ -158,25 +162,25 @@ const STDIO_PROBE_TIMEOUT_MILLIS = 5_000;
  * Exported for unit tests.
  */
 export function resolveVersionOptions(
-  mcpVersion: string | undefined,
+  protocolVersion: string | undefined,
   stdioTransport: boolean | undefined
 ): Pick<ClientOptions, 'versionNegotiation' | 'supportedProtocolVersions'> {
   const probe = stdioTransport ? { probe: { timeoutMs: STDIO_PROBE_TIMEOUT_MILLIS } } : {};
-  if (mcpVersion === undefined) {
+  if (protocolVersion === undefined) {
     return { versionNegotiation: { mode: 'auto', ...probe } };
   }
-  if (!isSupportedMcpVersion(mcpVersion)) {
+  if (!isSupportedProtocolVersion(protocolVersion)) {
     throw new ClientError(
-      `Unsupported MCP protocol version: ${mcpVersion}\n` +
-        `Supported versions: ${SUPPORTED_MCP_VERSIONS.join(', ')}`
+      `Unsupported MCP protocol version: ${protocolVersion}\n` +
+        `Supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')}`
     );
   }
-  if (isModernMcpVersion(mcpVersion)) {
-    return { versionNegotiation: { mode: { pin: mcpVersion }, ...probe } };
+  if (isModernProtocolVersion(protocolVersion)) {
+    return { versionNegotiation: { mode: { pin: protocolVersion }, ...probe } };
   }
   return {
     versionNegotiation: { mode: 'legacy' },
-    supportedProtocolVersions: [mcpVersion],
+    supportedProtocolVersions: [protocolVersion],
   };
 }
 
@@ -214,8 +218,8 @@ export class McpClient implements IMcpClient {
       capabilities: options.capabilities || {},
       ...options,
       // Placed after the spread so a caller-supplied versionNegotiation never
-      // overrides the mcpVersion pin (or the default auto negotiation).
-      ...resolveVersionOptions(options.mcpVersion, options.stdioTransport),
+      // overrides the protocolVersion pin (or the default auto negotiation).
+      ...resolveVersionOptions(options.protocolVersion, options.stdioTransport),
     });
 
     // Set up error handling
@@ -407,7 +411,7 @@ export class McpClient implements IMcpClient {
     const sdkEra = this.client.getProtocolEra();
     if (sdkEra) return sdkEra;
     if (this.negotiatedProtocolVersion) {
-      return isModernMcpVersion(this.negotiatedProtocolVersion) ? 'modern' : 'legacy';
+      return isModernProtocolVersion(this.negotiatedProtocolVersion) ? 'modern' : 'legacy';
     }
     return undefined;
   }

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -2,7 +2,7 @@
  * MCP protocol version constants and helpers.
  *
  * Deliberately dependency-free: the CLI imports this module on every invocation
- * (for `--mcp-version` validation and help text), so it must not pull in the MCP
+ * (for `--protocol-version` validation and help text), so it must not pull in the MCP
  * SDK. The legacy list mirrors the SDK's `SUPPORTED_PROTOCOL_VERSIONS` (the
  * versions its `initialize` handshake can offer/accept) and the modern list
  * mirrors its internal `SUPPORTED_MODERN_PROTOCOL_VERSIONS`; a unit test guards
@@ -10,10 +10,10 @@
  */
 
 /** Modern-era protocol revisions (2026-07-28 and later), newest first. */
-export const MODERN_MCP_VERSIONS: readonly string[] = ['2026-07-28'];
+export const MODERN_PROTOCOL_VERSIONS: readonly string[] = ['2026-07-28'];
 
 /** Legacy-era protocol revisions negotiated via the `initialize` handshake, newest first. */
-export const LEGACY_MCP_VERSIONS: readonly string[] = [
+export const LEGACY_PROTOCOL_VERSIONS: readonly string[] = [
   '2025-11-25',
   '2025-06-18',
   '2025-03-26',
@@ -21,18 +21,18 @@ export const LEGACY_MCP_VERSIONS: readonly string[] = [
   '2024-10-07',
 ];
 
-/** All protocol revisions mcpc can pin via `--mcp-version`, newest first. */
-export const SUPPORTED_MCP_VERSIONS: readonly string[] = [
-  ...MODERN_MCP_VERSIONS,
-  ...LEGACY_MCP_VERSIONS,
+/** All protocol revisions mcpc can pin via `--protocol-version`, newest first. */
+export const SUPPORTED_PROTOCOL_VERSIONS: readonly string[] = [
+  ...MODERN_PROTOCOL_VERSIONS,
+  ...LEGACY_PROTOCOL_VERSIONS,
 ];
 
 /** Whether a protocol revision belongs to the modern (2026-07-28+) era. */
-export function isModernMcpVersion(version: string): boolean {
-  return MODERN_MCP_VERSIONS.includes(version);
+export function isModernProtocolVersion(version: string): boolean {
+  return MODERN_PROTOCOL_VERSIONS.includes(version);
 }
 
-/** Whether a protocol revision can be pinned via `--mcp-version`. */
-export function isSupportedMcpVersion(version: string): boolean {
-  return SUPPORTED_MCP_VERSIONS.includes(version);
+/** Whether a protocol revision can be pinned via `--protocol-version`. */
+export function isSupportedProtocolVersion(version: string): boolean {
+  return SUPPORTED_PROTOCOL_VERSIONS.includes(version);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -95,7 +95,7 @@ export interface ServerConfig {
   args?: string[]; // For stdio transport
   env?: Record<string, string>; // Environment variables for stdio transport
   timeout?: number; // Request timeout in SECONDS (field name kept as `timeout` for mcp.json / sessions.json compatibility)
-  mcpVersion?: string; // Pin the MCP protocol version (strict, no fallback; absent = auto-negotiate)
+  protocolVersion?: string; // Pin the MCP protocol version (strict, no fallback; absent = auto-negotiate)
 }
 
 /**

--- a/test/e2e/suites/basic/protocol-version.test.sh
+++ b/test/e2e/suites/basic/protocol-version.test.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Test: --mcp-version pins the MCP protocol version on connect
+# Test: --protocol-version pins the MCP protocol version on connect
 #
 # Runs in both eras of the protocol matrix: the pin matching the active test
 # server succeeds and is displayed; the mismatched pin fails the handshake.
 
 source "$(dirname "$0")/../../lib/framework.sh"
-test_init "basic/mcp-version" --isolated
+test_init "basic/protocol-version" --isolated
 
 # Start test server
 start_test_server
@@ -23,8 +23,8 @@ fi
 # Test: unsupported version is rejected before connecting
 # =============================================================================
 
-test_case "connect rejects an unsupported --mcp-version"
-run_mcpc connect "$TEST_SERVER_URL" "$(session_name "inv")" --header "X-Test: true" --mcp-version 1999-01-01
+test_case "connect rejects an unsupported --protocol-version"
+run_mcpc connect "$TEST_SERVER_URL" "$(session_name "inv")" --header "X-Test: true" --protocol-version 1999-01-01
 assert_failure
 assert_contains "$STDERR" "Unsupported MCP protocol version: 1999-01-01"
 assert_contains "$STDERR" "Supported versions:"
@@ -36,8 +36,8 @@ test_pass
 
 SESSION=$(session_name "pin")
 
-test_case "connect with a matching --mcp-version succeeds"
-run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true" --mcp-version "$MATCH_VERSION"
+test_case "connect with a matching --protocol-version succeeds"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true" --protocol-version "$MATCH_VERSION"
 assert_success
 _SESSIONS_CREATED+=("$SESSION")
 assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
@@ -50,11 +50,11 @@ assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
 assert_contains "$STDOUT" "pinned"
 test_pass
 
-test_case "JSON session info includes the mcpVersion pin"
+test_case "JSON session info includes the protocolVersion pin"
 run_mcpc --json "$SESSION"
 assert_success
 assert_json_valid "$STDOUT"
-assert_json_eq "$STDOUT" '._mcpc.server.mcpVersion' "$MATCH_VERSION"
+assert_json_eq "$STDOUT" '._mcpc.server.protocolVersion' "$MATCH_VERSION"
 assert_json_eq "$STDOUT" '.protocolVersion' "$MATCH_VERSION"
 test_pass
 
@@ -79,9 +79,9 @@ run_mcpc "$SESSION" close 2>/dev/null || true
 # Test: pin the server cannot satisfy fails the handshake
 # =============================================================================
 
-test_case "connect with a mismatched --mcp-version does not connect"
+test_case "connect with a mismatched --protocol-version does not connect"
 MISMATCH_SESSION=$(session_name "mis")
-run_mcpc connect "$TEST_SERVER_URL" "$MISMATCH_SESSION" --header "X-Test: true" --mcp-version "$MISMATCH_VERSION"
+run_mcpc connect "$TEST_SERVER_URL" "$MISMATCH_SESSION" --header "X-Test: true" --protocol-version "$MISMATCH_VERSION"
 _SESSIONS_CREATED+=("$MISMATCH_SESSION")
 # The session record is created but the handshake must fail — the CLI reports the
 # failure (with the pin hint) instead of a connected server.

--- a/test/unit/core/protocol.test.ts
+++ b/test/unit/core/protocol.test.ts
@@ -1,14 +1,14 @@
 /**
- * Unit tests for MCP protocol version constants and the --mcp-version pin mapping
+ * Unit tests for MCP protocol version constants and the --protocol-version pin mapping
  */
 
-import { SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/client';
+import { SUPPORTED_PROTOCOL_VERSIONS as SDK_SUPPORTED_PROTOCOL_VERSIONS } from '@modelcontextprotocol/client';
 import {
-  MODERN_MCP_VERSIONS,
-  LEGACY_MCP_VERSIONS,
-  SUPPORTED_MCP_VERSIONS,
-  isModernMcpVersion,
-  isSupportedMcpVersion,
+  MODERN_PROTOCOL_VERSIONS,
+  LEGACY_PROTOCOL_VERSIONS,
+  SUPPORTED_PROTOCOL_VERSIONS,
+  isModernProtocolVersion,
+  isSupportedProtocolVersion,
 } from '../../../src/core/protocol.js';
 import { resolveVersionOptions } from '../../../src/core/mcp-client.js';
 import { ClientError } from '../../../src/lib/errors.js';
@@ -17,21 +17,24 @@ describe('protocol version constants', () => {
   it('legacy list stays in sync with the SDK (drift guard)', () => {
     // protocol.ts hardcodes the list so the CLI never loads the SDK at startup;
     // this test catches drift when the SDK is upgraded.
-    expect(LEGACY_MCP_VERSIONS).toEqual(SUPPORTED_PROTOCOL_VERSIONS);
+    expect(LEGACY_PROTOCOL_VERSIONS).toEqual(SDK_SUPPORTED_PROTOCOL_VERSIONS);
   });
 
   it('supported list is modern versions followed by legacy versions', () => {
-    expect(SUPPORTED_MCP_VERSIONS).toEqual([...MODERN_MCP_VERSIONS, ...LEGACY_MCP_VERSIONS]);
+    expect(SUPPORTED_PROTOCOL_VERSIONS).toEqual([
+      ...MODERN_PROTOCOL_VERSIONS,
+      ...LEGACY_PROTOCOL_VERSIONS,
+    ]);
   });
 
   it('classifies modern and legacy versions', () => {
-    expect(isModernMcpVersion('2026-07-28')).toBe(true);
-    expect(isModernMcpVersion('2025-11-25')).toBe(false);
-    expect(isSupportedMcpVersion('2026-07-28')).toBe(true);
-    expect(isSupportedMcpVersion('2025-11-25')).toBe(true);
-    expect(isSupportedMcpVersion('2024-10-07')).toBe(true);
-    expect(isSupportedMcpVersion('1999-01-01')).toBe(false);
-    expect(isSupportedMcpVersion('')).toBe(false);
+    expect(isModernProtocolVersion('2026-07-28')).toBe(true);
+    expect(isModernProtocolVersion('2025-11-25')).toBe(false);
+    expect(isSupportedProtocolVersion('2026-07-28')).toBe(true);
+    expect(isSupportedProtocolVersion('2025-11-25')).toBe(true);
+    expect(isSupportedProtocolVersion('2024-10-07')).toBe(true);
+    expect(isSupportedProtocolVersion('1999-01-01')).toBe(false);
+    expect(isSupportedProtocolVersion('')).toBe(false);
   });
 });
 


### PR DESCRIPTION
The MCP spec and TypeScript SDK use `protocolVersion` as the canonical term, so this renames the `mcpc connect --mcp-version` flag to `--protocol-version` and the mcp.json config field `mcpVersion` to `protocolVersion`. No deprecation alias — the flag was added in unreleased #320, so nothing shipped under the old name.

- Internal option fields, `protocol.ts` constants/helpers, docs (README, SKILL.md, CLAUDE.md), and the changelog entry renamed to match
- E2E suite renamed to `protocol-version.test.sh`; the JSON pin now appears as `_mcpc.server.protocolVersion`

Refs #320

https://claude.ai/code/session_01TpJ2kbEL9zSS4baM3CGU5E