### PR TITLE
Persist server capabilities and instructions for session resumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Sessions resumed after a bridge restart (e.g. crash recovery) no longer lose their negotiated protocol version: session details showed `Protocol: unknown` and, worse, requests were sent without the required `MCP-Protocol-Version` header. The stored version is now restored on resumption, and the server name is shown again in session details.
+- Resumed sessions also keep their server capabilities and instructions, which previously vanished after a bridge restart: `mcpc @session` showed no capabilities, `grep` no longer found the server instructions, and `resources-subscribe` wrongly refused with "server does not support resource subscriptions".
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - New `mcpc login <server> --grant id-jag` for MCP's [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension: sign in once with your corporate SSO (`--idp <issuer>`), and mcpc obtains MCP server tokens via identity assertion grants (ID-JAG) without per-server consent screens.
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
+- `mcpc --json` now reports each session's server `capabilities`, plus `hasInstructions` to tell whether the server provided instructions (read them with `mcpc --json @<session>`).
 - New `--protocol-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--protocol-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as a `protocolVersion` field in mcp.json config entries.
 
 ### Changed

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -21,6 +21,7 @@ import type {
 import {
   KEEPALIVE_INTERVAL_MILLIS,
   MAX_PERSISTED_INSTRUCTIONS_CHARS,
+  TRIMMED_INSTRUCTIONS_NOTICE,
   X402_SCHEME_PREFERENCES,
 } from '../lib/types.js';
 import { createLogger, setVerbose, initFileLogger, closeFileLogger } from '../lib/index.js';
@@ -32,6 +33,7 @@ import {
   ensureSecureTempDir,
   cleanupOrphanedLogFiles,
   isSessionExpiredError,
+  truncate,
   StderrTail,
 } from '../lib/index.js';
 import {
@@ -844,13 +846,13 @@ class BridgeProcess {
       const instructions = serverDetails.instructions;
       if (instructions && instructions.length > MAX_PERSISTED_INSTRUCTIONS_CHARS) {
         logger.debug(
-          `Not persisting server instructions (${instructions.length} chars, ` +
-            `limit ${MAX_PERSISTED_INSTRUCTIONS_CHARS}); they will be missing after a resumption`
+          `Trimming server instructions before persisting them (${instructions.length} chars, ` +
+            `limit ${MAX_PERSISTED_INSTRUCTIONS_CHARS})`
         );
-        sessionUpdate.instructions = undefined;
-      } else {
-        sessionUpdate.instructions = instructions;
       }
+      sessionUpdate.instructions = instructions
+        ? truncate(instructions, MAX_PERSISTED_INSTRUCTIONS_CHARS, TRIMMED_INSTRUCTIONS_NOTICE)
+        : instructions;
     }
     if (newMcpSessionId) {
       sessionUpdate.mcpSessionId = newMcpSessionId;

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -11,8 +11,18 @@ import { unlink } from 'fs/promises';
 import { dirname } from 'path';
 import { createMcpClient, CreateMcpClientOptions, buildClientCapabilities } from '../core/index.js';
 import type { McpClient } from '../core/index.js';
-import type { ServerConfig, IpcMessage, LoggingLevel, X402SchemePreference } from '../lib/index.js';
-import { KEEPALIVE_INTERVAL_MILLIS, X402_SCHEME_PREFERENCES } from '../lib/types.js';
+import type {
+  ServerConfig,
+  IpcMessage,
+  LoggingLevel,
+  X402SchemePreference,
+  ServerDetails,
+} from '../lib/index.js';
+import {
+  KEEPALIVE_INTERVAL_MILLIS,
+  MAX_PERSISTED_INSTRUCTIONS_CHARS,
+  X402_SCHEME_PREFERENCES,
+} from '../lib/types.js';
 import { createLogger, setVerbose, initFileLogger, closeFileLogger } from '../lib/index.js';
 import {
   fileExists,
@@ -129,6 +139,14 @@ class BridgeProcess {
 
   // Resource→file sync for resources-subscribe (created once the MCP client connects)
   private resourceSync: ResourceSyncManager | null = null;
+
+  // Handshake results persisted at the original connect, used only when this bridge
+  // resumed a server-side session: resumption skips `initialize`, so the SDK client
+  // reports no serverInfo/capabilities/instructions of its own (see #325).
+  private resumedHandshakeDetails: Pick<
+    ServerDetails,
+    'serverInfo' | 'capabilities' | 'instructions'
+  > | null = null;
 
   // Promise to track when auth credentials are received (for startup sequencing)
   private authCredentialsReceived: Promise<void> | null = null;
@@ -761,8 +779,19 @@ class BridgeProcess {
         this.resourceSync?.handleUpdated(notification.params.uri);
       });
 
+    // Resuming a server-side session skips the initialize handshake, so remember the
+    // values persisted by the connect that did perform it — they are the only source
+    // of server capabilities and instructions for the rest of this bridge's life.
+    if (this.options.mcpSessionId && sessionData) {
+      this.resumedHandshakeDetails = {
+        ...(sessionData.serverInfo && { serverInfo: sessionData.serverInfo }),
+        ...(sessionData.capabilities && { capabilities: sessionData.capabilities }),
+        ...(sessionData.instructions && { instructions: sessionData.instructions }),
+      };
+    }
+
     // Update session with protocol version, MCP session ID, and lastSeenAt
-    const serverDetails = await this.client.getServerDetails();
+    const serverDetails = await this.getServerDetails();
     const newMcpSessionId = this.client.getMcpSessionId();
 
     // Detect session ID mismatch: we tried to resume but server did not return the
@@ -807,6 +836,22 @@ class BridgeProcess {
     if (serverDetails.serverInfo) {
       sessionUpdate.serverInfo = serverDetails.serverInfo;
     }
+    // Capabilities and instructions come from the handshake only, so persist them for
+    // future resumptions. They travel together: writing instructions unconditionally
+    // here also clears stale text when a reconnect finds the server no longer sends any.
+    if (serverDetails.capabilities) {
+      sessionUpdate.capabilities = serverDetails.capabilities;
+      const instructions = serverDetails.instructions;
+      if (instructions && instructions.length > MAX_PERSISTED_INSTRUCTIONS_CHARS) {
+        logger.debug(
+          `Not persisting server instructions (${instructions.length} chars, ` +
+            `limit ${MAX_PERSISTED_INSTRUCTIONS_CHARS}); they will be missing after a resumption`
+        );
+        sessionUpdate.instructions = undefined;
+      } else {
+        sessionUpdate.instructions = instructions;
+      }
+    }
     if (newMcpSessionId) {
       sessionUpdate.mcpSessionId = newMcpSessionId;
       logger.info(`MCP-Session-Id saved for resumption: ${newMcpSessionId}`);
@@ -828,6 +873,32 @@ class BridgeProcess {
         logger.warn('Failed to pre-populate tools cache:', err);
       });
     }
+  }
+
+  /**
+   * Server details for this connection, with the handshake-only fields restored from
+   * sessions.json when the bridge resumed an existing server-side session. Resumption
+   * reuses the session and skips `initialize`, so the SDK client would otherwise report
+   * no server name, no capabilities and no instructions at all (see #325).
+   *
+   * Always use this instead of `client.getServerDetails()` inside the bridge.
+   */
+  private async getServerDetails(): Promise<ServerDetails> {
+    if (!this.client) {
+      throw new NetworkError('MCP client not connected');
+    }
+    const details = await this.client.getServerDetails();
+    const persisted = this.resumedHandshakeDetails;
+    if (!persisted) return details;
+
+    if (!details.serverInfo && persisted.serverInfo) details.serverInfo = persisted.serverInfo;
+    if (!details.capabilities && persisted.capabilities) {
+      details.capabilities = persisted.capabilities;
+    }
+    if (!details.instructions && persisted.instructions) {
+      details.instructions = persisted.instructions;
+    }
+    return details;
   }
 
   /**
@@ -880,7 +951,7 @@ class BridgeProcess {
     }
 
     // Get upstream server instructions to pass to proxy clients
-    const serverDetails = await this.client.getServerDetails();
+    const serverDetails = await this.getServerDetails();
     const instructions = serverDetails.instructions;
 
     const proxyOptions: ConstructorParameters<typeof ProxyServer>[0] = {
@@ -1426,7 +1497,7 @@ class BridgeProcess {
           // subscriptions/listen acknowledgment instead, so let the subscribe attempt
           // decide there — it fails loudly when the server does not honor the URI.
           if (this.client.getProtocolEra() !== 'modern') {
-            const details = await this.client.getServerDetails();
+            const details = await this.getServerDetails();
             if (!details.capabilities?.resources?.subscribe) {
               throw new ClientError(
                 `Server does not support resource subscriptions (no resources.subscribe capability).\n` +
@@ -1485,19 +1556,9 @@ class BridgeProcess {
           break;
         }
 
-        case 'getServerDetails': {
-          const details = await this.client.getServerDetails();
-          // A resumed HTTP session skips the initialize handshake, so the SDK client
-          // has no serverInfo; fall back to the value persisted at original connect.
-          if (!details.serverInfo) {
-            const session = await getSession(this.options.sessionName);
-            if (session?.serverInfo) {
-              details.serverInfo = session.serverInfo;
-            }
-          }
-          result = details;
+        case 'getServerDetails':
+          result = await this.getServerDetails();
           break;
-        }
 
         case 'listTasks': {
           const cursor = message.params as string | undefined;

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -139,11 +139,14 @@ export async function listSessionsAndAuthProfiles(options: {
     // sessions.json) is mapped to the public `stateless` field here so the list output
     // matches `mcpc @<session>` and `mcpc connect` (null until the mode is known).
     // Server instructions are persisted for session resumption but kept out of the list —
-    // they can be kilobytes per session. Read them with `mcpc --json @<session>`.
-    const sessionsWithStatus = sessions.map(({ connectionMode, instructions: _, ...session }) => ({
+    // they can be kilobytes per session. Only their presence is reported, as
+    // `hasInstructions` (they are not part of the advertised capabilities); read the text
+    // itself with `mcpc --json @<session>`.
+    const sessionsWithStatus = sessions.map(({ connectionMode, instructions, ...session }) => ({
       ...session,
       status: getBridgeStatus(session),
       ...statelessField(connectionMode),
+      hasInstructions: !!instructions,
     }));
     console.log(
       formatOutput(

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -138,7 +138,9 @@ export async function listSessionsAndAuthProfiles(options: {
     // Add bridge status to JSON output. The persisted `connectionMode` enum (stored in
     // sessions.json) is mapped to the public `stateless` field here so the list output
     // matches `mcpc @<session>` and `mcpc connect` (null until the mode is known).
-    const sessionsWithStatus = sessions.map(({ connectionMode, ...session }) => ({
+    // Server instructions are persisted for session resumption but kept out of the list —
+    // they can be kilobytes per session. Read them with `mcpc --json @<session>`.
+    const sessionsWithStatus = sessions.map(({ connectionMode, instructions: _, ...session }) => ({
       ...session,
       status: getBridgeStatus(session),
       ...statelessField(connectionMode),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -80,6 +80,14 @@ export const KEEPALIVE_INTERVAL_MILLIS = 30_000;
 /** Threshold for considering a session disconnected (bridge alive but server unreachable) */
 export const DISCONNECTED_THRESHOLD_MILLIS = 2 * KEEPALIVE_INTERVAL_MILLIS + 5000; // ~2 missed pings + 5s buffer
 
+/**
+ * Upper bound on server instructions persisted in sessions.json (see `SessionData.instructions`).
+ * The file is read by every mcpc command, so an oversized blob is dropped rather than
+ * slowing down the whole CLI; the session still works, it just cannot show the
+ * instructions after a resumption.
+ */
+export const MAX_PERSISTED_INSTRUCTIONS_CHARS = 32_768;
+
 /** Valid x402 scheme preferences. Canonical source for CLI validation and type-narrowing. */
 export const X402_SCHEME_PREFERENCES = ['auto', 'upto', 'exact'] as const;
 export type X402SchemePreference = (typeof X402_SCHEME_PREFERENCES)[number];
@@ -170,6 +178,18 @@ export interface SessionData {
     name: string;
     version: string;
   };
+  /**
+   * Server capabilities reported by the initialize handshake. Persisted because a
+   * resumed session reuses the server-side session and therefore skips the handshake,
+   * leaving the client with no capabilities of its own.
+   */
+  capabilities?: ServerCapabilities;
+  /**
+   * Server instructions reported by the initialize handshake, persisted alongside
+   * `capabilities`. Omitted when the server sends none, or when they are larger than
+   * {@link MAX_PERSISTED_INSTRUCTIONS_CHARS} (sessions.json is read on every command).
+   */
+  instructions?: string | undefined;
   status?: SessionStatus; // Session health status (default: active)
   proxy?: ProxyConfig; // Proxy server configuration (if enabled)
   notifications?: SessionNotifications; // Last list change notification timestamps

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -82,11 +82,13 @@ export const DISCONNECTED_THRESHOLD_MILLIS = 2 * KEEPALIVE_INTERVAL_MILLIS + 500
 
 /**
  * Upper bound on server instructions persisted in sessions.json (see `SessionData.instructions`).
- * The file is read by every mcpc command, so an oversized blob is dropped rather than
- * slowing down the whole CLI; the session still works, it just cannot show the
- * instructions after a resumption.
+ * The file is read by every mcpc command, so oversized instructions are trimmed rather than
+ * slowing down the whole CLI.
  */
 export const MAX_PERSISTED_INSTRUCTIONS_CHARS = 32_768;
+
+/** Marks the end of server instructions trimmed to MAX_PERSISTED_INSTRUCTIONS_CHARS. */
+export const TRIMMED_INSTRUCTIONS_NOTICE = '\n\n[... trimmed excessive length]';
 
 /** Valid x402 scheme preferences. Canonical source for CLI validation and type-narrowing. */
 export const X402_SCHEME_PREFERENCES = ['auto', 'upto', 'exact'] as const;
@@ -186,8 +188,8 @@ export interface SessionData {
   capabilities?: ServerCapabilities;
   /**
    * Server instructions reported by the initialize handshake, persisted alongside
-   * `capabilities`. Omitted when the server sends none, or when they are larger than
-   * {@link MAX_PERSISTED_INSTRUCTIONS_CHARS} (sessions.json is read on every command).
+   * `capabilities`. Trimmed to {@link MAX_PERSISTED_INSTRUCTIONS_CHARS} (sessions.json is
+   * read on every command), and omitted when the server sends none.
    */
   instructions?: string | undefined;
   status?: SessionStatus; // Session health status (default: active)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -515,13 +515,15 @@ export function stringifyJson(obj: unknown, pretty = false): string {
 }
 
 /**
- * Truncate a string to a maximum length
+ * Truncate a string to a maximum length, ending it with `suffix` so readers can tell
+ * the text is incomplete. The result never exceeds `maxLength`, unless `suffix` alone
+ * is longer than that.
  */
-export function truncate(str: string, maxLength: number): string {
+export function truncate(str: string, maxLength: number, suffix = '...'): string {
   if (str.length <= maxLength) {
     return str;
   }
-  return str.slice(0, maxLength - 3) + '...';
+  return str.slice(0, Math.max(0, maxLength - suffix.length)) + suffix;
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -516,14 +516,17 @@ export function stringifyJson(obj: unknown, pretty = false): string {
 
 /**
  * Truncate a string to a maximum length, ending it with `suffix` so readers can tell
- * the text is incomplete. The result never exceeds `maxLength`, unless `suffix` alone
- * is longer than that.
+ * the text is incomplete. The suffix counts towards `maxLength`, so the result never
+ * exceeds it; when the suffix leaves no room for any of the original text, the string
+ * is cut to `maxLength` without one.
  */
 export function truncate(str: string, maxLength: number, suffix = '...'): string {
-  if (str.length <= maxLength) {
+  const limit = Math.max(0, maxLength);
+  if (str.length <= limit) {
     return str;
   }
-  return str.slice(0, Math.max(0, maxLength - suffix.length)) + suffix;
+  const kept = limit - suffix.length;
+  return kept > 0 ? str.slice(0, kept) + suffix : str.slice(0, limit);
 }
 
 /**

--- a/test/e2e/suites/sessions/resume.test.sh
+++ b/test/e2e/suites/sessions/resume.test.sh
@@ -39,8 +39,10 @@ test_pass
 test_case "capabilities and instructions persisted after connect"
 capabilities=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .capabilities | tostring")
 assert_contains "$capabilities" "tools" "capabilities should be stored after connect"
-# Instructions are deliberately omitted from the session list (they can be kilobytes),
-# so read them straight from sessions.json
+# The session list reports only whether instructions exist (they can be kilobytes),
+# so read the text itself straight from sessions.json
+has_instructions=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .hasInstructions")
+assert_eq "$has_instructions" "true" "session list should report hasInstructions"
 stored_instructions=$(jq -r ".sessions[\"$SESSION\"].instructions" "$MCPC_HOME_DIR/sessions.json")
 assert_contains "$stored_instructions" "E2E test server" "instructions should be stored after connect"
 test_pass

--- a/test/e2e/suites/sessions/resume.test.sh
+++ b/test/e2e/suites/sessions/resume.test.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# Test: session resumption after a bridge crash preserves the negotiated protocol version
+# Test: session resumption after a bridge crash preserves the negotiated protocol
+# version, the server capabilities and the server instructions
 #
 # Regression guard: the SDK skips the initialize handshake when resuming with a
-# preserved MCP-Session-Id, so the client never re-learns the protocol version.
-# mcpc must seed the reconnected transport with the version persisted in
-# sessions.json — otherwise session details show "Protocol: unknown" and requests
-# go out without the required MCP-Protocol-Version header.
+# preserved MCP-Session-Id, so the client never re-learns any of it. mcpc must
+# restore the values persisted in sessions.json — otherwise session details show
+# "Protocol: unknown" with no capabilities and no instructions, and requests go
+# out without the required MCP-Protocol-Version header.
 
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/resume"
@@ -32,6 +33,16 @@ bridge_pid=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .pid")
 assert_not_empty "$protocol_version" "protocolVersion should be stored after connect"
 assert_not_empty "$mcp_session_id" "mcpSessionId should be stored after connect"
 assert_not_empty "$bridge_pid" "bridge PID should be stored after connect"
+test_pass
+
+# Test: capabilities and instructions are persisted so a resumed bridge can restore them
+test_case "capabilities and instructions persisted after connect"
+capabilities=$(json_get ".sessions[] | select(.name == \"$SESSION\") | .capabilities | tostring")
+assert_contains "$capabilities" "tools" "capabilities should be stored after connect"
+# Instructions are deliberately omitted from the session list (they can be kilobytes),
+# so read them straight from sessions.json
+stored_instructions=$(jq -r ".sessions[\"$SESSION\"].instructions" "$MCPC_HOME_DIR/sessions.json")
+assert_contains "$stored_instructions" "E2E test server" "instructions should be stored after connect"
 test_pass
 
 # Test: crash the bridge without graceful shutdown (no HTTP DELETE, so the
@@ -80,6 +91,35 @@ json_protocol=$(json_get ".protocolVersion")
 json_server_name=$(json_get ".serverInfo.name")
 assert_eq "$json_protocol" "$protocol_version" "JSON protocolVersion should match original"
 assert_not_empty "$json_server_name" "JSON serverInfo.name should be present after resume"
+test_pass
+
+# Test: capabilities survive resumption — without them the session reports
+# "(none)" and the resources-subscribe pre-check below wrongly refuses
+test_case "capabilities preserved after resume"
+json_capabilities=$(json_get ".capabilities | tostring")
+assert_contains "$json_capabilities" "tools" "JSON capabilities should be present after resume"
+run_mcpc "$SESSION"
+assert_success
+assert_contains "$STDOUT" "tools (" "session details should still list the tools capability"
+test_pass
+
+# Test: instructions survive resumption (shown in session details, searched by `grep`)
+test_case "instructions preserved after resume"
+assert_contains "$STDOUT" "E2E test server" "session details should still show instructions"
+run_mcpc --json "$SESSION" grep "E2E test server" --instructions
+assert_success
+assert_json "$STDOUT" '.sessions[0].instructions | type == "string"' \
+  "grep should still match the server instructions after resume"
+test_pass
+
+# Test: the resources.subscribe capability check accepts a resumed session
+test_case "resources-subscribe works after resume"
+subscribe_uri="test://dynamic/counter"
+run_mcpc "$SESSION" resources-subscribe "$subscribe_uri" "$TEST_TMP/resume-sync.txt"
+assert_success
+assert_not_contains "$STDOUT" "does not support resource subscriptions"
+run_mcpc "$SESSION" resources-unsubscribe "$subscribe_uri"
+assert_success
 test_pass
 
 # Test: close session

--- a/test/unit/lib/utils.test.ts
+++ b/test/unit/lib/utils.test.ts
@@ -570,15 +570,19 @@ describe('truncate', () => {
 
   it('should handle edge cases', () => {
     expect(truncate('abc', 3)).toBe('abc');
-    expect(truncate('abcd', 3)).toBe('...');
+    // No room for the suffix plus any text, so cut without one rather than overflow
+    expect(truncate('abcd', 3)).toBe('abc');
+    expect(truncate('abcd', 0)).toBe('');
   });
 
-  it('should end with a custom suffix without exceeding maxLength', () => {
+  it('should count the suffix towards maxLength', () => {
     expect(truncate('hello world', 11, ' [trimmed]')).toBe('hello world');
-    const result = truncate('hello world', 10, ' [trimmed]');
-    expect(result).toBe(' [trimmed]');
-    expect(result.length).toBe(10);
     expect(truncate('hello world, this is long', 20, ' [trimmed]')).toBe('hello worl [trimmed]');
+
+    // A suffix that leaves no room for text is dropped, keeping the result within maxLength
+    const result = truncate('hello world', 10, ' [trimmed]');
+    expect(result).toBe('hello worl');
+    expect(result.length).toBe(10);
   });
 });
 

--- a/test/unit/lib/utils.test.ts
+++ b/test/unit/lib/utils.test.ts
@@ -572,6 +572,14 @@ describe('truncate', () => {
     expect(truncate('abc', 3)).toBe('abc');
     expect(truncate('abcd', 3)).toBe('...');
   });
+
+  it('should end with a custom suffix without exceeding maxLength', () => {
+    expect(truncate('hello world', 11, ' [trimmed]')).toBe('hello world');
+    const result = truncate('hello world', 10, ' [trimmed]');
+    expect(result).toBe(' [trimmed]');
+    expect(result.length).toBe(10);
+    expect(truncate('hello world, this is long', 20, ' [trimmed]')).toBe('hello worl [trimmed]');
+  });
 });
 
 describe('isProcessAlive', () => {


### PR DESCRIPTION
Resuming a stateful HTTP session reuses the server-side session and so skips the `initialize` handshake, leaving the SDK client with no capabilities and no instructions. After a crash-recovery restart the session showed no capabilities, `grep` no longer found the server instructions, and `resources-subscribe` wrongly refused with "server does not support resource subscriptions".

- Persist capabilities and instructions in `sessions.json` at the connect that performs the handshake, and restore them for the lifetime of a resumed bridge
- Route every bridge-side read through one helper, so the subscribe pre-check, the tools-cache warmup and the `--proxy` server all see the restored values
- Skip instructions larger than 32 KB, and keep them out of the `mcpc --json` session list (they can be kilobytes per session)
- Extend the resume e2e test with capabilities, instructions and a `resources-subscribe` round trip (verified to fail without the fix)

Fixes #325. Refs #324.

https://claude.ai/code/session_01YRqAADGF3hWDQ83t4FvtHJ