### PR TITLE
Fail loudly for task commands on 2026-07-28 servers, add McpClient unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
+- `tools-call --task/--detach` against a server that does not support task-augmented tool calls now fails instead of printing a warning and running the tool synchronously. The flags change the shape of the output, so the fallback left `--detach` callers parsing a `taskId` that was never there, with exit code 0.
 - Updated the MCP TypeScript SDK v2 to `2.0.0-beta.5`, which fixes interoperability with 2026-07-28 servers built on the latest SDK betas (they require the new `Mcp-Method` request header that older clients did not send).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1152,9 +1152,12 @@ completes.
 `tools-list` and `tools-get` show task support annotations per tool:
 `[task:optional]`, `[task:required]`, or `[task:forbidden]`.
 
-Task commands require a server using protocol `2025-11-25`. In `2026-07-28` tasks moved to
-the `io.modelcontextprotocol/tasks` extension, which `mcpc` does not support yet — task
-commands on such servers return an error explaining this.
+Task commands require a server that advertises the tasks capability and uses protocol
+`2025-11-25`. In `2026-07-28` tasks moved to the `io.modelcontextprotocol/tasks` extension,
+which `mcpc` does not support yet. When either is missing, `--task`/`--detach` and the
+`tasks-*` commands fail with an error explaining which of the two it is — they never fall
+back to a plain synchronous call, because the flags change the shape of the output and
+`--detach` callers would be left parsing a task ID that is not there.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -857,7 +857,7 @@ Where `mcpc` stands on each part of the MCP specification:
 | 📁 **Roots**                                         | ❌ Not planned (deprecated by MCP)                                |
 | ❓ **Elicitation**                                   | 🚧 Planned                                                       |
 | 🔤 **Completion**                                    | 🚧 Planned                                                       |
-| 🤖 **Sampling**                                      | ❌ Not planned (deprecated by MCP)                                |
+| 🤖 **Sampling**                                      | ❌ Not applicable (no LLM access)                                 |
 
 Beyond the interactive browser login, the **Authorization** row above also covers the OAuth
 **client-credentials** grant (the [`io.modelcontextprotocol/oauth-client-credentials`](https://modelcontextprotocol.io/extensions/auth/oauth-client-credentials)

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -168,8 +168,12 @@ mcpc @apify tasks-result <taskId>               # block until the final result i
 mcpc @apify tasks-cancel <taskId>
 ```
 
-Task commands need a server on MCP protocol 2025-11-25; on 2026-07-28 servers
-they return an error (the new tasks extension is not supported yet).
+Task commands need a server on MCP protocol 2025-11-25 that advertises the tasks
+capability (`tools-list` flags it per tool as `[task:optional|required|forbidden]`).
+Otherwise `--task`/`--detach` and the `tasks-*` commands fail with an error — they
+never silently fall back to a synchronous call, so `--detach` output always has a
+`taskId` or a non-zero exit code. On 2026-07-28 servers tasks are an extension mcpc
+does not support yet.
 
 ## Authentication
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -9,7 +9,12 @@ import { initProxy, proxyFetch } from '../lib/proxy.js';
 import { createServer, type Server as NetServer, type Socket } from 'net';
 import { unlink } from 'fs/promises';
 import { dirname } from 'path';
-import { createMcpClient, CreateMcpClientOptions, buildClientCapabilities } from '../core/index.js';
+import {
+  createMcpClient,
+  CreateMcpClientOptions,
+  buildClientCapabilities,
+  tasksUnsupportedByServerMessage,
+} from '../core/index.js';
 import type { McpClient } from '../core/index.js';
 import type {
   ServerConfig,
@@ -1389,18 +1394,20 @@ class BridgeProcess {
           // Capture client ref — guaranteed non-null by check at top of handleMcpRequest
           const client = this.client;
 
-          // Reject --task/--detach on connections where tasks do not exist at all
-          // (2026-07-28 moved them to an extension mcpc does not support yet). Falling
-          // through to a plain tools/call would run the tool synchronously and hand
-          // --detach callers a tool result where they expect a task ID. A 2025-era
-          // server that simply lacks the tasks capability still falls back silently,
-          // which is the long-standing behavior for those servers.
+          // Refuse --task/--detach unless this connection can really run tasks. The CLI
+          // checks first and reports the same reason; this is the backstop for direct
+          // callers and for a capability that changed since that check. Falling through
+          // to a plain tools/call would run the tool synchronously and hand --detach
+          // callers a tool result where they expect a task ID.
           if (params.useTask) {
             client.assertTasksAvailable();
+            if (!client.supportsTasksForToolCall()) {
+              throw new ClientError(tasksUnsupportedByServerMessage());
+            }
           }
 
           const executeToolCall = async (): Promise<unknown> => {
-            if (params.useTask && client.supportsTasksForToolCall()) {
+            if (params.useTask) {
               if (params.detach) {
                 // Detached execution: start task and return task ID immediately
                 const taskUpdate = await client.callToolDetached(

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -48,14 +48,15 @@ import type { AuthCredentials, X402WalletCredentials } from '../lib/types.js';
 import { OAuthTokenManager } from '../lib/auth/oauth-token-manager.js';
 import { OAuthProvider } from '../lib/auth/oauth-provider.js';
 import type { OAuthClientProvider } from '@modelcontextprotocol/client';
-import { storeKeychainOAuthTokenInfo, readKeychainOAuthTokenInfo } from '../lib/auth/keychain.js';
-import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
-import { createClientCredentialsProvider } from '../lib/auth/client-credentials.js';
-import { createIdJagProvider } from '../lib/auth/id-jag.js';
 import {
+  storeKeychainOAuthTokenInfo,
+  readKeychainOAuthTokenInfo,
   storeKeychainIdJagCredentials,
   readKeychainIdJagCredentials,
 } from '../lib/auth/keychain.js';
+import { updateAuthProfileRefreshedAt } from '../lib/auth/profiles.js';
+import { createClientCredentialsProvider } from '../lib/auth/client-credentials.js';
+import { createIdJagProvider } from '../lib/auth/id-jag.js';
 import type { Tool, Resource, Prompt, Task } from '@modelcontextprotocol/client';
 import { ResourceSyncManager } from './resource-sync.js';
 import type { TaskUpdate } from '../lib/types.js';
@@ -242,9 +243,9 @@ class BridgeProcess {
       });
       this.usesIdJag = true;
       logger.debug('Enterprise-managed authorization (id-jag) provider created for SDK transport');
+    } else if (credentials.oauthGrant === 'client_credentials' && credentials.clientId) {
       // Client-credentials grant: build the SDK provider that fetches + refreshes
       // tokens itself. No token manager / no static header — the SDK transport drives it.
-    } else if (credentials.oauthGrant === 'client_credentials' && credentials.clientId) {
       this.authProvider = createClientCredentialsProvider({
         clientId: credentials.clientId,
         ...(credentials.clientSecret ? { clientSecret: credentials.clientSecret } : {}),
@@ -1387,6 +1388,17 @@ class BridgeProcess {
           // Helper to execute the tool call (used for initial attempt and 402 retry)
           // Capture client ref — guaranteed non-null by check at top of handleMcpRequest
           const client = this.client;
+
+          // Reject --task/--detach on connections where tasks do not exist at all
+          // (2026-07-28 moved them to an extension mcpc does not support yet). Falling
+          // through to a plain tools/call would run the tool synchronously and hand
+          // --detach callers a tool result where they expect a task ID. A 2025-era
+          // server that simply lacks the tasks capability still falls back silently,
+          // which is the long-standing behavior for those servers.
+          if (params.useTask) {
+            client.assertTasksAvailable();
+          }
+
           const executeToolCall = async (): Promise<unknown> => {
             if (params.useTask && client.supportsTasksForToolCall()) {
               if (params.detach) {

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -22,7 +22,11 @@ import { ClientError, ServerError } from '../../lib/errors.js';
 import type { CallToolResult, CommandOptions, TaskUpdate } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
 // Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
-import { isModernProtocolVersion, tasksUnavailableMessage } from '../../core/protocol.js';
+import {
+  isModernProtocolVersion,
+  tasksUnavailableMessage,
+  tasksUnsupportedByServerMessage,
+} from '../../core/protocol.js';
 import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
 import {
   loadSchemaFromFile,
@@ -183,14 +187,15 @@ function formatElapsed(millis: number): string {
 }
 
 /**
- * Check if task-augmented execution should be used for a tool call.
- * Tasks are opt-in via --task or --detach flags.
+ * Decide whether task-augmented execution applies to a tool call, and fail when the
+ * caller asked for it but this connection cannot deliver it.
  *
- * Throws when the connection's protocol has no tasks at all (2026-07-28 moved them to
- * the io.modelcontextprotocol/tasks extension, which mcpc does not support yet).
- * Falling back to a plain synchronous call there would hand `--detach` callers a tool
- * result where they parse a taskId, with exit code 0. A 2025-era server that merely
- * lacks the tasks capability still falls back with a warning, as it always has.
+ * `--task`/`--detach` change the shape of the output — `--detach` returns
+ * `{ taskId, status }` instead of a `CallToolResult` — so quietly running the tool
+ * synchronously instead would leave callers parsing a `taskId` that is not there, with
+ * exit code 0. Either reason to fail gets its own message: the protocol has no tasks at
+ * all (2026-07-28 moved them to an extension mcpc does not support yet), or the server
+ * does not advertise the capability.
  */
 async function shouldUseTask(
   client: import('../../lib/types.js').IMcpClient,
@@ -201,7 +206,10 @@ async function shouldUseTask(
   if (details.protocolVersion && isModernProtocolVersion(details.protocolVersion)) {
     throw new ServerError(tasksUnavailableMessage(details.protocolVersion));
   }
-  return !!details.capabilities?.tasks?.requests?.tools?.call;
+  if (!details.capabilities?.tasks?.requests?.tools?.call) {
+    throw new ServerError(tasksUnsupportedByServerMessage());
+  }
+  return true;
 }
 
 /**
@@ -314,19 +322,9 @@ export async function callTool(
       }
     }
 
-    // --detach implies --task
-    const taskRequested = options.detach || options.task;
-    // Check if we should use task-augmented execution
-    const useTask = await shouldUseTask(client, taskRequested);
-
-    // Warn if --task/--detach was requested but server doesn't support tasks
-    if (taskRequested && !useTask) {
-      if (options.outputMode === 'human') {
-        console.log(
-          formatWarning('Server does not support tasks, falling back to synchronous execution')
-        );
-      }
-    }
+    // --detach implies --task. Throws when this connection cannot run tasks — the flags
+    // change the output shape, so falling back silently is never the right answer.
+    const useTask = await shouldUseTask(client, options.detach || options.task);
 
     let result;
 

--- a/src/cli/commands/tools.ts
+++ b/src/cli/commands/tools.ts
@@ -18,9 +18,11 @@ import {
   formatInfo,
   formatTaskCommandsHint,
 } from '../output.js';
-import { ClientError } from '../../lib/errors.js';
+import { ClientError, ServerError } from '../../lib/errors.js';
 import type { CallToolResult, CommandOptions, TaskUpdate } from '../../lib/types.js';
 import { withMcpClient } from '../helpers.js';
+// Imported directly (not via the core barrel) so the CLI doesn't eagerly load the MCP SDK
+import { isModernProtocolVersion, tasksUnavailableMessage } from '../../core/protocol.js';
 import { parseCommandArgs, hasStdinData, readStdinArgs } from '../parser.js';
 import {
   loadSchemaFromFile,
@@ -183,6 +185,12 @@ function formatElapsed(millis: number): string {
 /**
  * Check if task-augmented execution should be used for a tool call.
  * Tasks are opt-in via --task or --detach flags.
+ *
+ * Throws when the connection's protocol has no tasks at all (2026-07-28 moved them to
+ * the io.modelcontextprotocol/tasks extension, which mcpc does not support yet).
+ * Falling back to a plain synchronous call there would hand `--detach` callers a tool
+ * result where they parse a taskId, with exit code 0. A 2025-era server that merely
+ * lacks the tasks capability still falls back with a warning, as it always has.
  */
 async function shouldUseTask(
   client: import('../../lib/types.js').IMcpClient,
@@ -190,6 +198,9 @@ async function shouldUseTask(
 ): Promise<boolean> {
   if (!async_) return false;
   const details = await client.getServerDetails();
+  if (details.protocolVersion && isModernProtocolVersion(details.protocolVersion)) {
+    throw new ServerError(tasksUnavailableMessage(details.protocolVersion));
+  }
   return !!details.capabilities?.tasks?.requests?.tools?.call;
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1164,8 +1164,12 @@ ${chalk.bold('Async tasks (--task, --detach):')}
   If you press Ctrl+C, the task keeps running and a hint with the task ID
   is printed so you can fetch or cancel it later.
   --detach returns the task ID immediately without waiting.
-  Tasks require a server using MCP protocol 2025-11-25 (on 2026-07-28
-  servers tasks are an extension not yet supported by mcpc).
+  Both flags require a server that advertises the tasks capability and uses
+  MCP protocol 2025-11-25 (on 2026-07-28 servers tasks are an extension not
+  yet supported by mcpc). If it does not, the command fails instead of
+  running the tool synchronously — the flags change the output shape, so the
+  fallback would silently return a result where a task ID is expected.
+  Check per-tool support in tools-list: [task:optional|required|forbidden].
 
 ${chalk.bold('Schema validation:')}
   --schema <file>       Validate tool schema before calling (save with tools-get --json)

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -38,8 +38,11 @@ import { fetchAllPages } from '../lib/utils.js';
 import {
   isModernProtocolVersion,
   isSupportedProtocolVersion,
+  tasksUnavailableMessage,
   SUPPORTED_PROTOCOL_VERSIONS,
 } from './protocol.js';
+import type { IMcpClient, ServerDetails, ConnectionMode, TaskUpdate } from '../lib/types.js';
+import type { Task } from '@modelcontextprotocol/client';
 
 /**
  * Traverse the .cause chain to find the deepest (most specific) error message
@@ -51,8 +54,6 @@ function getRootCauseMessage(error: Error): string {
   }
   return current.message;
 }
-import type { IMcpClient, ServerDetails, ConnectionMode, TaskUpdate } from '../lib/types.js';
-import type { Task } from '@modelcontextprotocol/client';
 
 /**
  * Convert an SDK Task to a TaskUpdate, handling exactOptionalPropertyTypes
@@ -81,8 +82,7 @@ interface TransportWithProtocolVersion extends Transport {
  * Fallback freshness window for the in-memory tools cache on stateless connections.
  * Stateless servers (2026-07-28) may not push tools/list_changed (no standing stream), so the
  * cache would otherwise go stale silently. Stateful connections rely on notification-driven
- * invalidation and use no expiry. Phase 1 will replace this fixed value with the server's
- * ttlMs/cacheScope hint.
+ * invalidation and use no expiry.
  */
 const STATELESS_TOOLS_CACHE_TTL_MILLIS = 60_000;
 
@@ -703,7 +703,12 @@ export class McpClient implements IMcpClient {
     void subscription.closed.then((reason) => {
       if (reason !== 'remote' || this.modernListen !== subscription || this.isClosing) return;
       this.modernListen = undefined;
-      void this.relistenWithBackoff();
+      void this.relistenWithBackoff('Resource subscription', async () => {
+        // Another subscribe/unsubscribe may have rebuilt the stream while we backed
+        // off, or dropped the last URI — either way there is nothing left to retry.
+        if (this.modernListen || this.modernSubscribedUris.size === 0) return;
+        await this.reopenModernListen();
+      });
     });
   }
 
@@ -716,39 +721,34 @@ export class McpClient implements IMcpClient {
     if (!subscription) return;
     void subscription.closed.then((reason) => {
       if (reason !== 'remote' || this.isClosing) return;
-      void this.relistenListChangedWithBackoff(subscription.honoredFilter);
+      void this.relistenWithBackoff('listChanged', () =>
+        this.reopenListChanged(subscription.honoredFilter)
+      );
     });
   }
 
-  /** Re-establish the listChanged listen stream after a remote drop, backing off 1s → 30s. */
-  private async relistenListChangedWithBackoff(filter: SubscriptionFilter): Promise<void> {
+  /** Re-open the listChanged stream with the same filter and keep watching the new one. */
+  private async reopenListChanged(filter: SubscriptionFilter): Promise<void> {
+    const subscription = await this.client.listen(filter, this.getRequestOptions());
+    this.watchListChangedStream(subscription);
+  }
+
+  /**
+   * Retry `reopen` until it succeeds, backing off 1s → 30s. Retries indefinitely
+   * (until close): a bridge session may outlive any outage, and giving up would
+   * silently stop delivering notifications for the rest of its life.
+   */
+  private async relistenWithBackoff(label: string, reopen: () => Promise<void>): Promise<void> {
     let delayMillis = RELISTEN_INITIAL_DELAY_MILLIS;
     while (!this.isClosing) {
       await new Promise((resolve) => setTimeout(resolve, delayMillis));
       try {
-        const subscription = await this.client.listen(filter, this.getRequestOptions());
-        this.watchListChangedStream(subscription);
-        this.logger.debug('listChanged listen stream re-established');
+        await reopen();
+        this.logger.debug(`${label} listen stream re-established`);
         return;
       } catch (error) {
-        this.logger.debug(`listChanged re-listen failed, retrying in ${delayMillis * 2}ms:`, error);
         delayMillis = Math.min(delayMillis * 2, RELISTEN_MAX_DELAY_MILLIS);
-      }
-    }
-  }
-
-  /** Re-establish the resource-subscription listen stream after a remote drop, backing off 1s → 30s. */
-  private async relistenWithBackoff(): Promise<void> {
-    let delayMillis = RELISTEN_INITIAL_DELAY_MILLIS;
-    while (!this.isClosing && this.modernSubscribedUris.size > 0 && !this.modernListen) {
-      await new Promise((resolve) => setTimeout(resolve, delayMillis));
-      try {
-        await this.reopenModernListen();
-        this.logger.debug('Listen stream re-established');
-        return;
-      } catch (error) {
-        this.logger.debug(`Re-listen failed, retrying in ${delayMillis * 2}ms:`, error);
-        delayMillis = Math.min(delayMillis * 2, RELISTEN_MAX_DELAY_MILLIS);
+        this.logger.debug(`${label} re-listen failed, retrying in ${delayMillis}ms:`, error);
       }
     }
   }
@@ -803,7 +803,7 @@ export class McpClient implements IMcpClient {
       throw new ServerError(
         `logging/setLevel was removed in MCP ${this.negotiatedProtocolVersion}; ` +
           `this server no longer supports a session-wide log level. ` +
-          `Use --verbose for client-side logging instead.`
+          `Use --verbose for client-side logging instead`
       );
     }
     try {
@@ -835,14 +835,15 @@ export class McpClient implements IMcpClient {
    * vocabulary is still part of the SDK's legacy-era schema set. All task traffic is
    * funnelled through the few methods below, so adopting the SDK's tasks extension API
    * once it ships is a change to these methods only.
+   *
+   * Public so the bridge can reject `tools-call --task/--detach` up front: without that
+   * check a detached call on a modern connection would silently return a tool result
+   * where the caller expects a task ID. Always call this *outside* the try blocks below,
+   * so its message reaches the user as-is instead of nested in a "Failed to ..." wrapper.
    */
-  private assertTasksAvailable(): void {
+  assertTasksAvailable(): void {
     if (this.getProtocolEra() === 'modern') {
-      throw new ServerError(
-        `Tasks are not available on this connection: MCP ${this.negotiatedProtocolVersion} moved tasks ` +
-          `to the io.modelcontextprotocol/tasks extension, which is not supported yet. ` +
-          `Task commands currently work only on servers using protocol 2025-11-25.`
-      );
+      throw new ServerError(tasksUnavailableMessage(this.negotiatedProtocolVersion));
     }
   }
 
@@ -975,9 +976,9 @@ export class McpClient implements IMcpClient {
    * List tasks on the server
    */
   async listTasks(cursor?: string): Promise<ListTasksResult> {
+    this.assertTasksAvailable();
     try {
       this.logger.debug('Listing tasks...', cursor ? { cursor } : {});
-      this.assertTasksAvailable();
       const result = await this.client.request(
         { method: 'tasks/list', ...(cursor ? { params: { cursor } } : {}) },
         ListTasksResultSchema,
@@ -997,9 +998,9 @@ export class McpClient implements IMcpClient {
    * Get a task's current status
    */
   async getTask(taskId: string): Promise<GetTaskResult> {
+    this.assertTasksAvailable();
     try {
       this.logger.debug(`Getting task: ${taskId}`);
-      this.assertTasksAvailable();
       const result = await this.client.request(
         { method: 'tasks/get', params: { taskId } },
         GetTaskResultSchema,
@@ -1021,9 +1022,9 @@ export class McpClient implements IMcpClient {
    * the MCP `tasks/result` protocol method.
    */
   async getTaskResult(taskId: string): Promise<CallToolResult> {
+    this.assertTasksAvailable();
     try {
       this.logger.debug(`Getting task result: ${taskId}`);
-      this.assertTasksAvailable();
       const result = await this.client.request(
         { method: 'tasks/result', params: { taskId } },
         CallToolResultSchema,
@@ -1043,9 +1044,9 @@ export class McpClient implements IMcpClient {
    * Cancel a running task
    */
   async cancelTask(taskId: string): Promise<CancelTaskResult> {
+    this.assertTasksAvailable();
     try {
       this.logger.debug(`Cancelling task: ${taskId}`);
-      this.assertTasksAvailable();
       const result = await this.client.request(
         { method: 'tasks/cancel', params: { taskId } },
         CancelTaskResultSchema,

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -36,3 +36,18 @@ export function isModernProtocolVersion(version: string): boolean {
 export function isSupportedProtocolVersion(version: string): boolean {
   return SUPPORTED_PROTOCOL_VERSIONS.includes(version);
 }
+
+/**
+ * Explain why task commands do not work on a modern connection. Lives here so the
+ * CLI (which gates `tools-call --task/--detach` before dispatching) and the core
+ * client (which gates the `tasks/*` requests) report the identical reason.
+ *
+ * Intentionally has no trailing period: the CLI appends ". For details, run: ..."
+ */
+export function tasksUnavailableMessage(protocolVersion?: string): string {
+  return (
+    `Tasks are not available on this connection: MCP ${protocolVersion ?? MODERN_PROTOCOL_VERSIONS[0]} ` +
+    `moved tasks to the io.modelcontextprotocol/tasks extension, which is not supported yet. ` +
+    `Task commands currently work only on servers using protocol 2025-11-25`
+  );
+}

--- a/src/core/protocol.ts
+++ b/src/core/protocol.ts
@@ -38,16 +38,35 @@ export function isSupportedProtocolVersion(version: string): boolean {
 }
 
 /**
- * Explain why task commands do not work on a modern connection. Lives here so the
- * CLI (which gates `tools-call --task/--detach` before dispatching) and the core
- * client (which gates the `tasks/*` requests) report the identical reason.
+ * Explain why task commands do not work on a modern connection. Lives here (rather than
+ * in the core client) so the CLI — which gates `tools-call --task/--detach` before
+ * dispatching, and must not load the SDK at startup — reports the identical reason.
  *
- * Intentionally has no trailing period: the CLI appends ". For details, run: ..."
+ * Intentionally has no trailing period. Both messages surface either straight from the
+ * CLI (where period-less errors are the house style) or relayed from the bridge, which
+ * appends ". For details, run: mcpc @session logs" — a period here would double up.
  */
 export function tasksUnavailableMessage(protocolVersion?: string): string {
   return (
     `Tasks are not available on this connection: MCP ${protocolVersion ?? MODERN_PROTOCOL_VERSIONS[0]} ` +
     `moved tasks to the io.modelcontextprotocol/tasks extension, which is not supported yet. ` +
     `Task commands currently work only on servers using protocol 2025-11-25`
+  );
+}
+
+/**
+ * Explain that the server itself does not offer task-augmented tool calls, even though
+ * the protocol has them. Kept next to {@link tasksUnavailableMessage} for the same
+ * reason: both the CLI and the bridge refuse `--task`/`--detach` with this text.
+ *
+ * Intentionally has no trailing period. Both messages surface either straight from the
+ * CLI (where period-less errors are the house style) or relayed from the bridge, which
+ * appends ". For details, run: mcpc @session logs" — a period here would double up.
+ */
+export function tasksUnsupportedByServerMessage(): string {
+  return (
+    `This server does not support task-augmented tool calls ` +
+    `(no tasks.requests.tools.call capability), so --task/--detach cannot be used. ` +
+    `Re-run the command without them to call the tool synchronously`
   );
 }

--- a/test/e2e/server/index.ts
+++ b/test/e2e/server/index.ts
@@ -10,6 +10,8 @@
  *   LATENCY_MS - artificial latency in ms (default: 0)
  *   REQUIRE_AUTH - require Authorization header (default: false)
  *   NO_TOOLS - disable tools capability (default: false)
+ *   NO_TASKS - serve tools but withhold the tasks capability, so --task/--detach
+ *     must be refused rather than silently run synchronously (default: false)
  *   NO_RESOURCES - disable resources capability (default: false)
  *   NO_PROMPTS - disable prompts capability (default: false)
  *   WITH_SKILLS - enable the io.modelcontextprotocol/skills extension and
@@ -71,6 +73,8 @@ const PAGINATION_SIZE = parseInt(process.env.PAGINATION_SIZE || '0', 10);
 const LATENCY_MS = parseInt(process.env.LATENCY_MS || '0', 10);
 const REQUIRE_AUTH = process.env.REQUIRE_AUTH === 'true';
 const NO_TOOLS = process.env.NO_TOOLS === 'true';
+// Serve tools but withhold the tasks capability, so `--task`/`--detach` must refuse
+const NO_TASKS = process.env.NO_TASKS === 'true';
 const NO_RESOURCES = process.env.NO_RESOURCES === 'true';
 const NO_PROMPTS = process.env.NO_PROMPTS === 'true';
 const WITH_SKILLS = process.env.WITH_SKILLS === 'true';
@@ -143,11 +147,13 @@ function createMcpServer(): Server {
   };
   if (!NO_TOOLS) {
     capabilities.tools = { listChanged: true };
-    capabilities.tasks = {
-      list: {},
-      cancel: {},
-      requests: { tools: { call: {} } },
-    };
+    if (!NO_TASKS) {
+      capabilities.tasks = {
+        list: {},
+        cancel: {},
+        requests: { tools: { call: {} } },
+      };
+    }
   }
   if (!NO_RESOURCES) {
     capabilities.resources = { subscribe: true, listChanged: true };
@@ -256,55 +262,58 @@ function createMcpServer(): Server {
       return callTestTool(name, args);
     });
 
-    // Task management handlers
-    server.setRequestHandler(GetTaskRequestSchema, async (request) => {
-      const { taskId } = request.params;
-      const entry = taskStore.get(taskId);
-      if (!entry) {
-        throw new Error(`Task not found: ${taskId}`);
-      }
-      return entry.task;
-    });
+    // Task management handlers. Skipped under NO_TASKS: the SDK refuses to register a
+    // handler for a capability the server did not declare.
+    if (!NO_TASKS) {
+      server.setRequestHandler(GetTaskRequestSchema, async (request) => {
+        const { taskId } = request.params;
+        const entry = taskStore.get(taskId);
+        if (!entry) {
+          throw new Error(`Task not found: ${taskId}`);
+        }
+        return entry.task;
+      });
 
-    server.setRequestHandler(GetTaskPayloadRequestSchema, async (request) => {
-      const { taskId } = request.params;
-      const entry = taskStore.get(taskId);
-      if (!entry) {
-        throw new Error(`Task not found: ${taskId}`);
-      }
-      // Block until task reaches terminal state
-      while (entry.task.status === 'working' || entry.task.status === 'input_required') {
-        await new Promise((resolve) => setTimeout(resolve, 200));
-      }
-      if (entry.result) {
-        return entry.result;
-      }
-      throw new Error(`Task ${taskId} has no result (status: ${entry.task.status})`);
-    });
+      server.setRequestHandler(GetTaskPayloadRequestSchema, async (request) => {
+        const { taskId } = request.params;
+        const entry = taskStore.get(taskId);
+        if (!entry) {
+          throw new Error(`Task not found: ${taskId}`);
+        }
+        // Block until task reaches terminal state
+        while (entry.task.status === 'working' || entry.task.status === 'input_required') {
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+        if (entry.result) {
+          return entry.result;
+        }
+        throw new Error(`Task ${taskId} has no result (status: ${entry.task.status})`);
+      });
 
-    server.setRequestHandler(ListTasksRequestSchema, async () => {
-      const allTasks = Array.from(taskStore.values()).map((e) => e.task);
-      return { tasks: allTasks };
-    });
+      server.setRequestHandler(ListTasksRequestSchema, async () => {
+        const allTasks = Array.from(taskStore.values()).map((e) => e.task);
+        return { tasks: allTasks };
+      });
 
-    server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
-      const { taskId } = request.params;
-      const entry = taskStore.get(taskId);
-      if (!entry) {
-        throw new Error(`Task not found: ${taskId}`);
-      }
-      if (
-        entry.task.status === 'completed' ||
-        entry.task.status === 'failed' ||
-        entry.task.status === 'cancelled'
-      ) {
-        throw new Error(`Cannot cancel task in terminal state: ${entry.task.status}`);
-      }
-      entry.task.status = 'cancelled';
-      entry.task.lastUpdatedAt = new Date().toISOString();
-      entry.abortController?.abort();
-      return entry.task;
-    });
+      server.setRequestHandler(CancelTaskRequestSchema, async (request) => {
+        const { taskId } = request.params;
+        const entry = taskStore.get(taskId);
+        if (!entry) {
+          throw new Error(`Task not found: ${taskId}`);
+        }
+        if (
+          entry.task.status === 'completed' ||
+          entry.task.status === 'failed' ||
+          entry.task.status === 'cancelled'
+        ) {
+          throw new Error(`Cannot cancel task in terminal state: ${entry.task.status}`);
+        }
+        entry.task.status = 'cancelled';
+        entry.task.lastUpdatedAt = new Date().toISOString();
+        entry.abortController?.abort();
+        return entry.task;
+      });
+    } // end if (!NO_TASKS)
   } // end if (!NO_TOOLS)
 
   // Resources (only register handlers if capability is enabled)

--- a/test/e2e/suites/sessions/tasks-unsupported.test.sh
+++ b/test/e2e/suites/sessions/tasks-unsupported.test.sh
@@ -1,70 +1,86 @@
 #!/bin/bash
-# Test: task commands fail loudly on 2026-07-28 servers instead of degrading silently
+# Test: --task/--detach and the tasks-* commands fail loudly when this connection
+# cannot run tasks, instead of degrading to a plain synchronous tools/call.
 #
-# Regression guard: tasks moved to the io.modelcontextprotocol/tasks extension in
-# 2026-07-28 and mcpc does not support it yet. Every task command must say so. The
-# dangerous case is `tools-call --detach`, which used to fall through to a plain
-# tools/call — running the tool synchronously and handing scripts a tool result
-# where they parse a taskId, with exit code 0.
+# The flags change the shape of the output — --detach returns { taskId, status } rather
+# than a CallToolResult — so a silent fallback leaves callers parsing a taskId that is
+# not there, with exit code 0. There are two independent reasons to refuse, and this
+# suite covers one per protocol era:
+#   modern (2026-07-28) - tasks moved to the io.modelcontextprotocol/tasks extension
+#   legacy (2025-11-25) - the server does not advertise tasks.requests.tools.call
 
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "sessions/tasks-unsupported"
 
-require_server_protocol modern
-
-# Start test server
-start_test_server
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  # Modern server: tasks do not exist in the protocol at all.
+  start_test_server
+  EXPECTED="Tasks are not available on this connection"
+else
+  # Legacy server with the tasks capability withheld.
+  start_test_server NO_TASKS=true
+  EXPECTED="does not support task-augmented tool calls"
+fi
 
 SESSION=$(session_name "notasks")
 
-test_case "create session on a 2026-07-28 server"
+test_case "create session"
 run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
 assert_success
 _SESSIONS_CREATED+=("$SESSION")
-assert_contains "$STDOUT" "Protocol: 2026-07-28"
 test_pass
 
-# ── Task commands report the missing extension ────────────────
-
-for cmd in "tasks-list" "tasks-get some-id" "tasks-result some-id" "tasks-cancel some-id"; do
-  test_case "$cmd reports the tasks extension is unsupported"
-  # shellcheck disable=SC2086
-  run_mcpc "$SESSION" $cmd
-  assert_failure
-  assert_contains "$STDOUT$STDERR" "Tasks are not available on this connection"
-  assert_contains "$STDOUT$STDERR" "io.modelcontextprotocol/tasks extension"
-  test_pass
-done
-
-test_case "the era-gate message is not double-wrapped or double-punctuated"
-run_mcpc "$SESSION" tasks-list
-assert_failure
-# "Failed to list tasks: Tasks are not ... 2025-11-25.. For details" was the old shape
-assert_not_contains "$STDOUT$STDERR" "Failed to list tasks"
-assert_not_contains "$STDOUT$STDERR" "2025-11-25.."
-test_pass
-
-# ── tools-call --task / --detach must not silently run the tool ────
+# ── tools-call --task / --detach must refuse, not run the tool ──
 
 test_case "tools-call --task refuses instead of running the tool synchronously"
 run_mcpc "$SESSION" tools-call --task slow-task ms:=50 steps:=2
 assert_failure
-assert_contains "$STDOUT$STDERR" "Tasks are not available on this connection"
+assert_contains "$STDOUT$STDERR" "$EXPECTED"
 assert_not_contains "$STDOUT" "Completed 2 steps"
 test_pass
 
 test_case "tools-call --detach refuses instead of returning a tool result"
 run_mcpc --json "$SESSION" tools-call --detach slow-task ms:=50 steps:=2
 assert_failure
-assert_contains "$STDERR" "Tasks are not available on this connection"
+assert_contains "$STDERR" "$EXPECTED"
 # The killer symptom: a script reading .taskId used to get a CallToolResult + exit 0
 assert_not_contains "$STDOUT" "Completed"
 test_pass
 
+test_case "the refusal is a clean JSON error in --json mode"
+run_mcpc --json "$SESSION" tools-call --detach slow-task ms:=50 steps:=2
+assert_failure
+# stdout stays machine-readable; the reason goes to stderr with an exit code
+assert_json_valid "$STDERR"
+assert_json_eq "$STDERR" '.code' '2'
+test_pass
+
+# ── Era-specific: the tasks-* commands on a modern connection ──
+
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  for cmd in "tasks-list" "tasks-get some-id" "tasks-result some-id" "tasks-cancel some-id"; do
+    test_case "$cmd reports the tasks extension is unsupported"
+    # shellcheck disable=SC2086
+    run_mcpc "$SESSION" $cmd
+    assert_failure
+    assert_contains "$STDOUT$STDERR" "Tasks are not available on this connection"
+    assert_contains "$STDOUT$STDERR" "io.modelcontextprotocol/tasks extension"
+    test_pass
+  done
+
+  test_case "the era-gate message is not double-wrapped or double-punctuated"
+  run_mcpc "$SESSION" tasks-list
+  assert_failure
+  # "Failed to list tasks: Tasks are not ... 2025-11-25.. For details" was the old shape
+  assert_not_contains "$STDOUT$STDERR" "Failed to list tasks"
+  assert_not_contains "$STDOUT$STDERR" "2025-11-25.."
+  test_pass
+fi
+
 # ── Plain tool calls still work on the same session ────────────
 
 test_case "a plain tools-call is unaffected"
-run_mcpc "$SESSION" tools-call slow-task ms:=50 steps:=2
+run_xmcpc "$SESSION" tools-call slow-task ms:=50 steps:=2
 assert_success
 assert_contains "$STDOUT" "Completed 2 steps"
 test_pass

--- a/test/e2e/suites/sessions/tasks-unsupported.test.sh
+++ b/test/e2e/suites/sessions/tasks-unsupported.test.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Test: task commands fail loudly on 2026-07-28 servers instead of degrading silently
+#
+# Regression guard: tasks moved to the io.modelcontextprotocol/tasks extension in
+# 2026-07-28 and mcpc does not support it yet. Every task command must say so. The
+# dangerous case is `tools-call --detach`, which used to fall through to a plain
+# tools/call — running the tool synchronously and handing scripts a tool result
+# where they parse a taskId, with exit code 0.
+
+source "$(dirname "$0")/../../lib/framework.sh"
+test_init "sessions/tasks-unsupported"
+
+require_server_protocol modern
+
+# Start test server
+start_test_server
+
+SESSION=$(session_name "notasks")
+
+test_case "create session on a 2026-07-28 server"
+run_mcpc connect "$TEST_SERVER_URL" "$SESSION" --header "X-Test: true"
+assert_success
+_SESSIONS_CREATED+=("$SESSION")
+assert_contains "$STDOUT" "Protocol: 2026-07-28"
+test_pass
+
+# ── Task commands report the missing extension ────────────────
+
+for cmd in "tasks-list" "tasks-get some-id" "tasks-result some-id" "tasks-cancel some-id"; do
+  test_case "$cmd reports the tasks extension is unsupported"
+  # shellcheck disable=SC2086
+  run_mcpc "$SESSION" $cmd
+  assert_failure
+  assert_contains "$STDOUT$STDERR" "Tasks are not available on this connection"
+  assert_contains "$STDOUT$STDERR" "io.modelcontextprotocol/tasks extension"
+  test_pass
+done
+
+test_case "the era-gate message is not double-wrapped or double-punctuated"
+run_mcpc "$SESSION" tasks-list
+assert_failure
+# "Failed to list tasks: Tasks are not ... 2025-11-25.. For details" was the old shape
+assert_not_contains "$STDOUT$STDERR" "Failed to list tasks"
+assert_not_contains "$STDOUT$STDERR" "2025-11-25.."
+test_pass
+
+# ── tools-call --task / --detach must not silently run the tool ────
+
+test_case "tools-call --task refuses instead of running the tool synchronously"
+run_mcpc "$SESSION" tools-call --task slow-task ms:=50 steps:=2
+assert_failure
+assert_contains "$STDOUT$STDERR" "Tasks are not available on this connection"
+assert_not_contains "$STDOUT" "Completed 2 steps"
+test_pass
+
+test_case "tools-call --detach refuses instead of returning a tool result"
+run_mcpc --json "$SESSION" tools-call --detach slow-task ms:=50 steps:=2
+assert_failure
+assert_contains "$STDERR" "Tasks are not available on this connection"
+# The killer symptom: a script reading .taskId used to get a CallToolResult + exit 0
+assert_not_contains "$STDOUT" "Completed"
+test_pass
+
+# ── Plain tool calls still work on the same session ────────────
+
+test_case "a plain tools-call is unaffected"
+run_mcpc "$SESSION" tools-call slow-task ms:=50 steps:=2
+assert_success
+assert_contains "$STDOUT" "Completed 2 steps"
+test_pass
+
+test_case "close session"
+run_mcpc "$SESSION" close
+assert_success
+_SESSIONS_CREATED=("${_SESSIONS_CREATED[@]/$SESSION}")
+test_pass
+
+test_done

--- a/test/unit/core/mcp-client.test.ts
+++ b/test/unit/core/mcp-client.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Unit tests for the protocol-era behavior of McpClient.
+ *
+ * The interesting logic here is era-dependent and hard to reach from e2e (which only
+ * covers the happy paths against the two test servers): the 2026-07-28
+ * `subscriptions/listen` mechanics and their rollback/re-listen branches, connection
+ * mode derivation, the era fallback used by resumed sessions, the stateless tools-cache
+ * expiry, and the guards that reject removed protocol methods.
+ *
+ * The SDK Client is stubbed so each branch can be driven directly.
+ */
+
+import { vi } from 'vitest';
+import { McpClient } from '../../../src/core/mcp-client.js';
+import { ServerError } from '../../../src/lib/errors.js';
+
+vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@modelcontextprotocol/client')>();
+  // Must be a `function` (not an arrow) — McpClient calls it with `new`.
+  return {
+    ...actual,
+    Client: vi.fn(function () {
+      return stubSdkClient;
+    }),
+  };
+});
+
+/** A `subscriptions/listen` stream stub whose `closed` promise the test resolves. */
+interface StubSubscription {
+  honoredFilter: { resourceSubscriptions?: string[] };
+  closed: Promise<string>;
+  close: ReturnType<typeof vi.fn>;
+  drop: (reason: string) => void;
+}
+
+function makeSubscription(honoredUris?: string[]): StubSubscription {
+  let drop!: (reason: string) => void;
+  const closed = new Promise<string>((resolve) => {
+    drop = resolve;
+  });
+  return {
+    honoredFilter: honoredUris ? { resourceSubscriptions: honoredUris } : {},
+    closed,
+    close: vi.fn().mockResolvedValue(undefined),
+    drop,
+  };
+}
+
+/** The stub returned by the mocked SDK `Client` constructor; re-created per test. */
+let stubSdkClient: Record<string, ReturnType<typeof vi.fn> | unknown>;
+
+/** Mutable state the stub reports back to McpClient. */
+let era: 'modern' | 'legacy' | undefined;
+let negotiatedVersion: string | undefined;
+let listenQueue: StubSubscription[];
+let listenCalls: unknown[];
+
+function resetSdkStub(): void {
+  era = 'legacy';
+  negotiatedVersion = '2025-11-25';
+  listenQueue = [];
+  listenCalls = [];
+  stubSdkClient = {
+    connect: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+    getServerVersion: vi.fn().mockReturnValue({ name: 'stub', version: '1.0.0' }),
+    getServerCapabilities: vi.fn().mockReturnValue({}),
+    getInstructions: vi.fn().mockReturnValue(undefined),
+    getNegotiatedProtocolVersion: vi.fn(() => negotiatedVersion),
+    getProtocolEra: vi.fn(() => era),
+    ping: vi.fn().mockResolvedValue(undefined),
+    discover: vi.fn().mockResolvedValue({}),
+    listTools: vi.fn().mockResolvedValue({ tools: [] }),
+    setLoggingLevel: vi.fn().mockResolvedValue(undefined),
+    subscribeResource: vi.fn().mockResolvedValue(undefined),
+    unsubscribeResource: vi.fn().mockResolvedValue(undefined),
+    listen: vi.fn(async (filter: unknown) => {
+      listenCalls.push(filter);
+      const next = listenQueue.shift();
+      if (!next) throw new Error('no queued listen result');
+      return next;
+    }),
+    request: vi.fn().mockResolvedValue({}),
+    autoOpenedSubscription: undefined,
+    onerror: undefined,
+  };
+}
+
+/** Transport stubs: only `terminateSession` distinguishes HTTP from stdio. */
+function httpTransport(sessionId?: string): Record<string, unknown> {
+  return { terminateSession: vi.fn().mockResolvedValue(undefined), sessionId };
+}
+function stdioTransport(): Record<string, unknown> {
+  return {};
+}
+
+/** Connect a client to the given transport, in the given era. */
+async function connectClient(options: {
+  transport?: Record<string, unknown>;
+  era?: 'modern' | 'legacy';
+  version?: string;
+}): Promise<McpClient> {
+  era = options.era ?? 'legacy';
+  negotiatedVersion = options.version ?? (era === 'modern' ? '2026-07-28' : '2025-11-25');
+  const client = new McpClient({ name: 'test', version: '0.0.0' });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await client.connect((options.transport ?? httpTransport('sess-1')) as any);
+  return client;
+}
+
+beforeEach(() => {
+  resetSdkStub();
+  vi.clearAllMocks();
+});
+
+describe('connection mode', () => {
+  it('reports stateful for an HTTP transport that was given a session id', async () => {
+    const client = await connectClient({ transport: httpTransport('sess-1') });
+    expect((await client.getServerDetails()).connectionMode).toBe('stateful');
+  });
+
+  it('reports stateless for an HTTP transport with no session id', async () => {
+    const client = await connectClient({ transport: httpTransport(undefined), era: 'modern' });
+    expect((await client.getServerDetails()).connectionMode).toBe('stateless');
+  });
+
+  it('reports stateful for stdio, which is always a local process', async () => {
+    const client = await connectClient({ transport: stdioTransport(), era: 'modern' });
+    expect((await client.getServerDetails()).connectionMode).toBe('stateful');
+  });
+
+  it('reports unknown before connecting', async () => {
+    const client = new McpClient({ name: 'test', version: '0.0.0' });
+    expect((await client.getServerDetails()).connectionMode).toBe('unknown');
+  });
+});
+
+describe('protocol era', () => {
+  it('uses the era reported by the SDK client', async () => {
+    const client = await connectClient({ era: 'modern' });
+    expect(client.getProtocolEra()).toBe('modern');
+  });
+
+  it('derives the era from the restored version when the SDK does not know it', async () => {
+    // A resumed HTTP session skips the handshake, so the SDK client reports no era —
+    // the negotiated version restored from sessions.json is the only signal left.
+    const client = await connectClient({ era: 'modern', version: '2026-07-28' });
+    era = undefined;
+    expect(client.getProtocolEra()).toBe('modern');
+  });
+
+  it('derives the legacy era from a restored 2025-era version', async () => {
+    const client = await connectClient({ era: 'legacy', version: '2025-11-25' });
+    era = undefined;
+    expect(client.getProtocolEra()).toBe('legacy');
+  });
+
+  it('reports no era when neither the SDK nor a version is known', async () => {
+    era = undefined;
+    negotiatedVersion = undefined;
+    const client = new McpClient({ name: 'test', version: '0.0.0' });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await client.connect(httpTransport() as any);
+    expect(client.getProtocolEra()).toBeUndefined();
+  });
+});
+
+describe('removed protocol methods are rejected per era', () => {
+  it('rejects logging-set-level on a modern connection without calling the SDK', async () => {
+    const client = await connectClient({ era: 'modern' });
+    await expect(client.setLoggingLevel('debug')).rejects.toThrow(/logging\/setLevel was removed/);
+    expect(stubSdkClient.setLoggingLevel).not.toHaveBeenCalled();
+  });
+
+  it('does not wrap the era-gate message in a "Failed to ..." prefix', async () => {
+    // The CLI appends ". For details, run: ..." to the message, so a nested wrapper
+    // (and a trailing period) would render as "Failed to list tasks: Tasks are not ...25.."
+    const client = await connectClient({ era: 'modern' });
+    await expect(client.listTasks()).rejects.toThrow(/^Tasks are not available/);
+    for (const call of [
+      client.getTask('t1'),
+      client.getTaskResult('t1'),
+      client.cancelTask('t1'),
+    ]) {
+      await expect(call).rejects.toThrow(/^Tasks are not available/);
+    }
+    expect(stubSdkClient.request).not.toHaveBeenCalled();
+  });
+
+  it('does not end era-gate messages with a period', async () => {
+    const client = await connectClient({ era: 'modern' });
+    for (const call of [client.setLoggingLevel('debug'), client.listTasks()]) {
+      await expect(call).rejects.toThrow(
+        expect.objectContaining({ message: expect.not.stringMatching(/\.$/) })
+      );
+    }
+  });
+
+  it('allows logging-set-level and task requests on a legacy connection', async () => {
+    const client = await connectClient({ era: 'legacy' });
+    await client.setLoggingLevel('debug');
+    expect(stubSdkClient.setLoggingLevel).toHaveBeenCalledWith('debug', expect.anything());
+    stubSdkClient.request = vi.fn().mockResolvedValue({ tasks: [] });
+    await expect(client.listTasks()).resolves.toEqual({ tasks: [] });
+  });
+
+  it('never advertises task-augmented tool calls on a modern connection', async () => {
+    stubSdkClient.getServerCapabilities = vi
+      .fn()
+      .mockReturnValue({ tasks: { requests: { tools: { call: {} } } } });
+    const legacy = await connectClient({ era: 'legacy' });
+    expect(legacy.supportsTasksForToolCall()).toBe(true);
+    const modern = await connectClient({ era: 'modern' });
+    expect(modern.supportsTasksForToolCall()).toBe(false);
+  });
+});
+
+describe('ping', () => {
+  it('sends ping on a legacy connection', async () => {
+    const client = await connectClient({ era: 'legacy' });
+    await client.ping();
+    expect(stubSdkClient.ping).toHaveBeenCalled();
+    expect(stubSdkClient.discover).not.toHaveBeenCalled();
+  });
+
+  it('sends server/discover on a modern connection, where ping was removed', async () => {
+    const client = await connectClient({ era: 'modern' });
+    await client.ping();
+    expect(stubSdkClient.discover).toHaveBeenCalled();
+    expect(stubSdkClient.ping).not.toHaveBeenCalled();
+  });
+});
+
+describe('resource subscriptions (legacy era)', () => {
+  it('issues resources/subscribe and resources/unsubscribe', async () => {
+    const client = await connectClient({ era: 'legacy' });
+    await client.subscribeResource('res://a');
+    expect(stubSdkClient.subscribeResource).toHaveBeenCalledWith(
+      { uri: 'res://a' },
+      expect.anything()
+    );
+    await client.unsubscribeResource('res://a');
+    expect(stubSdkClient.unsubscribeResource).toHaveBeenCalledWith(
+      { uri: 'res://a' },
+      expect.anything()
+    );
+    expect(stubSdkClient.listen).not.toHaveBeenCalled();
+  });
+});
+
+describe('resource subscriptions (modern era, subscriptions/listen)', () => {
+  it('opens one listen stream carrying every subscribed URI', async () => {
+    const client = await connectClient({ era: 'modern' });
+    listenQueue = [makeSubscription(['res://a'])];
+    await client.subscribeResource('res://a');
+    expect(listenCalls).toEqual([{ resourceSubscriptions: ['res://a'] }]);
+
+    // A second subscribe re-opens the stream with both URIs, closing the first.
+    const first = listenQueue;
+    void first;
+    listenQueue = [makeSubscription(['res://a', 'res://b'])];
+    await client.subscribeResource('res://b');
+    expect(listenCalls[1]).toEqual({ resourceSubscriptions: ['res://a', 'res://b'] });
+    expect(stubSdkClient.subscribeResource).not.toHaveBeenCalled();
+  });
+
+  it('fails loudly when the server does not honor a requested URI', async () => {
+    const client = await connectClient({ era: 'modern' });
+    // Acknowledgment omits the URI — the 2026-07-28 signal for "not supported",
+    // since the resources.subscribe capability flag no longer exists.
+    const unhonored = makeSubscription([]);
+    listenQueue = [unhonored];
+    await expect(client.subscribeResource('res://a')).rejects.toThrow(ServerError);
+    expect(unhonored.close).toHaveBeenCalled();
+  });
+
+  it('rolls the rejected URI back out of the subscription set', async () => {
+    const client = await connectClient({ era: 'modern' });
+    listenQueue = [makeSubscription(['res://a'])];
+    await client.subscribeResource('res://a');
+
+    // res://b is refused: the rollback must restore a stream for res://a alone,
+    // and must not keep asking for res://b afterwards.
+    listenQueue = [makeSubscription(['res://a']), makeSubscription(['res://a'])];
+    await expect(client.subscribeResource('res://b')).rejects.toThrow(
+      /does not support subscriptions for res:\/\/b/
+    );
+    expect(listenCalls[listenCalls.length - 1]).toEqual({ resourceSubscriptions: ['res://a'] });
+  });
+
+  it('closes the stream once the last URI is unsubscribed', async () => {
+    const client = await connectClient({ era: 'modern' });
+    const subscription = makeSubscription(['res://a']);
+    listenQueue = [subscription];
+    await client.subscribeResource('res://a');
+
+    await client.unsubscribeResource('res://a');
+    expect(subscription.close).toHaveBeenCalled();
+    // Nothing left to listen for, so no new stream was opened.
+    expect(listenCalls).toHaveLength(1);
+    expect(stubSdkClient.unsubscribeResource).not.toHaveBeenCalled();
+  });
+
+  it('re-opens the stream after an unexpected remote drop', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = await connectClient({ era: 'modern' });
+      const subscription = makeSubscription(['res://a']);
+      listenQueue = [subscription];
+      await client.subscribeResource('res://a');
+
+      listenQueue = [makeSubscription(['res://a'])];
+      subscription.drop('remote');
+      await vi.advanceTimersByTimeAsync(1_100);
+
+      expect(listenCalls).toHaveLength(2);
+      expect(listenCalls[1]).toEqual({ resourceSubscriptions: ['res://a'] });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not re-open after a deliberate local close', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = await connectClient({ era: 'modern' });
+      const subscription = makeSubscription(['res://a']);
+      listenQueue = [subscription];
+      await client.subscribeResource('res://a');
+
+      subscription.drop('local');
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      expect(listenCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps retrying with backoff until the re-listen succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = await connectClient({ era: 'modern' });
+      const subscription = makeSubscription(['res://a']);
+      listenQueue = [subscription];
+      await client.subscribeResource('res://a');
+
+      // First two re-listens fail (empty queue throws), the third succeeds.
+      subscription.drop('remote');
+      await vi.advanceTimersByTimeAsync(1_100); // attempt 1 fails
+      expect(listenCalls).toHaveLength(2);
+      await vi.advanceTimersByTimeAsync(2_100); // attempt 2 fails
+      expect(listenCalls).toHaveLength(3);
+
+      listenQueue = [makeSubscription(['res://a'])];
+      await vi.advanceTimersByTimeAsync(4_100); // attempt 3 succeeds
+      expect(listenCalls).toHaveLength(4);
+
+      // No further attempts once re-established.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(listenCalls).toHaveLength(4);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('re-opens the auto-opened listChanged stream after a remote drop', async () => {
+    vi.useFakeTimers();
+    try {
+      const autoOpened = makeSubscription();
+      stubSdkClient.autoOpenedSubscription = autoOpened;
+      await connectClient({ era: 'modern' });
+
+      listenQueue = [makeSubscription()];
+      autoOpened.drop('remote');
+      await vi.advanceTimersByTimeAsync(1_100);
+
+      expect(listenCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('tools cache', () => {
+  it('caches indefinitely on a stateful connection', async () => {
+    const client = await connectClient({ transport: httpTransport('sess-1'), era: 'legacy' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }] });
+
+    await client.listAllTools();
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+
+    // Even far in the future — stateful connections rely on list_changed pushes.
+    vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 3_600_000);
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+    vi.mocked(Date.now).mockRestore();
+  });
+
+  it('expires the cache on a stateless connection, which cannot push list_changed', async () => {
+    const client = await connectClient({ transport: httpTransport(undefined), era: 'modern' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }] });
+
+    const start = Date.now();
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+
+    vi.spyOn(Date, 'now').mockReturnValue(start + 30_000);
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+
+    vi.mocked(Date.now).mockReturnValue(start + 61_000);
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(2);
+    vi.mocked(Date.now).mockRestore();
+  });
+
+  it('refetches on an explicit refresh and after invalidation', async () => {
+    const client = await connectClient({ era: 'legacy' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }] });
+
+    await client.listAllTools();
+    expect(client.getCachedTools()).toEqual([{ name: 'a' }]);
+
+    await client.listAllTools({ refreshCache: true });
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(2);
+
+    client.invalidateToolsCache();
+    expect(client.getCachedTools()).toBeNull();
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('close', () => {
+  it('tears down the listen stream before terminating the session', async () => {
+    const client = await connectClient({ era: 'modern' });
+    const subscription = makeSubscription(['res://a']);
+    listenQueue = [subscription];
+    await client.subscribeResource('res://a');
+
+    await client.close();
+    expect(subscription.close).toHaveBeenCalled();
+    expect(stubSdkClient.close).toHaveBeenCalled();
+  });
+
+  it('does not re-listen for a drop that arrives during close', async () => {
+    vi.useFakeTimers();
+    try {
+      const client = await connectClient({ era: 'modern' });
+      const subscription = makeSubscription(['res://a']);
+      listenQueue = [subscription];
+      await client.subscribeResource('res://a');
+
+      const closing = client.close();
+      subscription.drop('remote');
+      await vi.advanceTimersByTimeAsync(5_000);
+      await closing;
+
+      expect(listenCalls).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/test/unit/core/protocol.test.ts
+++ b/test/unit/core/protocol.test.ts
@@ -9,6 +9,7 @@ import {
   SUPPORTED_PROTOCOL_VERSIONS,
   isModernProtocolVersion,
   isSupportedProtocolVersion,
+  tasksUnavailableMessage,
 } from '../../../src/core/protocol.js';
 import { resolveVersionOptions } from '../../../src/core/mcp-client.js';
 import { ClientError } from '../../../src/lib/errors.js';
@@ -35,6 +36,26 @@ describe('protocol version constants', () => {
     expect(isSupportedProtocolVersion('2024-10-07')).toBe(true);
     expect(isSupportedProtocolVersion('1999-01-01')).toBe(false);
     expect(isSupportedProtocolVersion('')).toBe(false);
+  });
+});
+
+describe('tasksUnavailableMessage', () => {
+  // Shared by the CLI (which gates tools-call --task/--detach) and McpClient (which
+  // gates the tasks/* requests), so both report the identical reason.
+  it('names the negotiated version and the extension', () => {
+    const message = tasksUnavailableMessage('2026-07-28');
+    expect(message).toContain('2026-07-28');
+    expect(message).toContain('io.modelcontextprotocol/tasks extension');
+    expect(message).toContain('2025-11-25');
+  });
+
+  it('has no trailing period, since callers append ". For details, run: ..."', () => {
+    expect(tasksUnavailableMessage('2026-07-28')).not.toMatch(/\.$/);
+    expect(tasksUnavailableMessage(undefined)).not.toMatch(/\.$/);
+  });
+
+  it('falls back to the latest modern version when none is known', () => {
+    expect(tasksUnavailableMessage(undefined)).toContain(MODERN_PROTOCOL_VERSIONS[0]!);
   });
 });
 

--- a/test/unit/core/protocol.test.ts
+++ b/test/unit/core/protocol.test.ts
@@ -10,6 +10,7 @@ import {
   isModernProtocolVersion,
   isSupportedProtocolVersion,
   tasksUnavailableMessage,
+  tasksUnsupportedByServerMessage,
 } from '../../../src/core/protocol.js';
 import { resolveVersionOptions } from '../../../src/core/mcp-client.js';
 import { ClientError } from '../../../src/lib/errors.js';
@@ -49,13 +50,31 @@ describe('tasksUnavailableMessage', () => {
     expect(message).toContain('2025-11-25');
   });
 
-  it('has no trailing period, since callers append ". For details, run: ..."', () => {
+  it('has no trailing period, so the bridge\'s ". For details, run: ..." never doubles up', () => {
     expect(tasksUnavailableMessage('2026-07-28')).not.toMatch(/\.$/);
     expect(tasksUnavailableMessage(undefined)).not.toMatch(/\.$/);
   });
 
   it('falls back to the latest modern version when none is known', () => {
     expect(tasksUnavailableMessage(undefined)).toContain(MODERN_PROTOCOL_VERSIONS[0]!);
+  });
+});
+
+describe('tasksUnsupportedByServerMessage', () => {
+  it('names the missing capability and how to proceed', () => {
+    const message = tasksUnsupportedByServerMessage();
+    expect(message).toContain('tasks.requests.tools.call');
+    expect(message).toContain('--task/--detach');
+    // The flags are refused, so the message must say what to run instead.
+    expect(message).toMatch(/without them/);
+  });
+
+  it('has no trailing period, so the bridge\'s ". For details, run: ..." never doubles up', () => {
+    expect(tasksUnsupportedByServerMessage()).not.toMatch(/\.$/);
+  });
+
+  it('is distinct from the protocol-era reason', () => {
+    expect(tasksUnsupportedByServerMessage()).not.toEqual(tasksUnavailableMessage('2026-07-28'));
   });
 });
 


### PR DESCRIPTION
Follow-up review fixes on top of #316. `tools-call --detach` silently fell through to a plain synchronous `tools/call` on 2026-07-28 connections, handing scripts a tool result with exit 0 where they parse a `taskId` — while the README, CHANGELOG and skill all promised an error. Also adds the unit-test file `mcp-client.ts` was missing.

- Gate `--task`/`--detach` in `shouldUseTask` (the CLI decides before the bridge sees it), sharing one message with the `tasks/*` gate
- Hoist `assertTasksAvailable()` out of the task try blocks, so the reason is no longer nested in `Failed to list tasks: …` with a doubled period
- Add `test/unit/core/mcp-client.test.ts` (29 cases) for the era-dependent logic: `subscriptions/listen` open/rollback/re-listen, connection mode, resumed-session era fallback, stateless tools-cache expiry, per-era gates
- Add a modern-only e2e suite guarding the task gates end to end
- Merge the duplicated re-listen backoff loops; README: sampling is not deprecated by MCP (it gained `context`/`tools` in 2026-07-28)

Refs #316

https://claude.ai/code/session_01DgotfZLGkL4CeYE6GGuq2F