### PR TITLE
Fix config-entry protocolVersion being silently dropped

### DIFF
--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -219,6 +219,20 @@ async function renderConnectedSession(
 }
 
 /**
+ * Reject a pinned protocol version that mcpc cannot speak, before any connection is attempted.
+ * A pin can come from `--protocol-version` or from a config entry's `protocolVersion` field,
+ * so both are checked and get the same error.
+ */
+function assertSupportedProtocolVersion(version: string | undefined): void {
+  if (version && !isSupportedProtocolVersion(version)) {
+    throw new ClientError(
+      `Unsupported MCP protocol version: ${version}\n` +
+        `Supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')}`
+    );
+  }
+}
+
+/**
  * Creates a new session, starts a bridge process, and instructs it to connect an MCP server.
  * If session already exists with crashed bridge, reconnects it automatically
  */
@@ -262,12 +276,7 @@ export async function connectSession(
   }
 
   // Validate --protocol-version (if provided)
-  if (options.protocolVersion && !isSupportedProtocolVersion(options.protocolVersion)) {
-    throw new ClientError(
-      `Unsupported MCP protocol version: ${options.protocolVersion}\n` +
-        `Supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(', ')}`
-    );
-  }
+  assertSupportedProtocolVersion(options.protocolVersion);
 
   // Check if session already exists
   const existingSession = await getSession(name);
@@ -302,6 +311,9 @@ export async function connectSession(
 
   // Resolve target to transport config
   const serverConfig = await resolveTarget(target, options);
+
+  // Re-check the effective pin, which may come from a config entry's `protocolVersion`
+  assertSupportedProtocolVersion(serverConfig.protocolVersion);
 
   // Detect conflicting auth flags: --profile and --header "Authorization: ..." are mutually exclusive
   const hasExplicitAuthHeader = serverConfig.headers?.Authorization !== undefined;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -103,11 +103,16 @@ export function getServerConfig(config: McpConfig, serverName: string): ServerCo
  * Substitute environment variables in a server configuration
  * Supports ${VAR_NAME} syntax
  *
+ * All fields are copied through and only the ones that can contain `${VAR_NAME}` (or need
+ * normalizing) are rewritten. Keep it that way rather than reverting to a per-field allowlist,
+ * which silently dropped every field it forgot — that is how a config entry's `protocolVersion`
+ * came to be ignored, and the next new `ServerConfig` field would meet the same fate.
+ *
  * @param config - Server configuration
  * @returns Configuration with environment variables substituted
  */
 function substituteEnvVars(config: ServerConfig): ServerConfig {
-  const result: ServerConfig = {};
+  const result: ServerConfig = { ...config };
 
   if (config.url !== undefined) {
     // Substitute environment variables and normalize URL
@@ -135,10 +140,6 @@ function substituteEnvVars(config: ServerConfig): ServerConfig {
 
   if (config.headers !== undefined) {
     result.headers = substituteEnvObject(config.headers);
-  }
-
-  if (config.timeout !== undefined) {
-    result.timeout = config.timeout;
   }
 
   return result;

--- a/test/e2e/suites/basic/protocol-version.test.sh
+++ b/test/e2e/suites/basic/protocol-version.test.sh
@@ -91,4 +91,43 @@ test_pass
 
 run_mcpc "$MISMATCH_SESSION" close 2>/dev/null || true
 
+# =============================================================================
+# Test: a config entry's `protocolVersion` field pins the same way
+# =============================================================================
+
+CONFIG_FILE="$(to_native_path "$TEST_TMP/pinned-server.json")"
+cat > "$CONFIG_FILE" <<EOF
+{
+  "mcpServers": {
+    "pinned": {
+      "url": "$TEST_SERVER_URL",
+      "headers": { "X-Test": "true" },
+      "protocolVersion": "$MATCH_VERSION"
+    },
+    "bogus": {
+      "url": "$TEST_SERVER_URL",
+      "headers": { "X-Test": "true" },
+      "protocolVersion": "1999-01-01"
+    }
+  }
+}
+EOF
+
+test_case "config entry protocolVersion pins the connection"
+CONFIG_SESSION=$(session_name "cfg")
+run_mcpc connect "$CONFIG_FILE:pinned" "$CONFIG_SESSION"
+assert_success
+_SESSIONS_CREATED+=("$CONFIG_SESSION")
+assert_contains "$STDOUT" "Protocol: $MATCH_VERSION"
+assert_contains "$STDOUT" "pinned"
+test_pass
+
+run_mcpc "$CONFIG_SESSION" close 2>/dev/null || true
+
+test_case "config entry with an unsupported protocolVersion is rejected"
+run_mcpc connect "$CONFIG_FILE:bogus" "$(session_name "cfgbad")"
+assert_failure
+assert_contains "$STDERR" "Unsupported MCP protocol version: 1999-01-01"
+test_pass
+
 test_done

--- a/test/unit/lib/config.test.ts
+++ b/test/unit/lib/config.test.ts
@@ -15,6 +15,7 @@ import {
   scanMcpConfigFiles,
 } from '../../../src/lib/config.js';
 import { ClientError } from '../../../src/lib/errors.js';
+import type { McpConfig } from '../../../src/lib/types.js';
 
 const TEST_DIR = join(process.cwd(), 'test-tmp-config');
 
@@ -133,6 +134,28 @@ describe('getServerConfig', () => {
     expect(() => getServerConfig(config, 'unknown')).toThrow(
       'Available servers: http-server, stdio-server'
     );
+  });
+
+  it('should preserve protocolVersion from the config entry', () => {
+    const pinned = {
+      mcpServers: {
+        pinned: { url: 'https://api.example.com', protocolVersion: '2024-10-07' },
+      },
+    };
+    expect(getServerConfig(pinned, 'pinned').protocolVersion).toBe('2024-10-07');
+  });
+
+  it('should pass through fields it does not substitute', () => {
+    // Guards against the copier silently dropping fields it does not know about
+    // (both future ServerConfig fields and keys used by other MCP clients).
+    const extra = {
+      mcpServers: {
+        server: { url: 'https://api.example.com', type: 'http', futureField: 42 },
+      },
+    } as unknown as McpConfig;
+    const serverConfig = getServerConfig(extra, 'server') as Record<string, unknown>;
+    expect(serverConfig.type).toBe('http');
+    expect(serverConfig.futureField).toBe(42);
   });
 });
 


### PR DESCRIPTION
A `protocolVersion` field in an mcp.json entry never reached the client, so `mcpc connect cfg.json:entry` auto-negotiated instead of pinning, with no error or warning — only the `--protocol-version` flag worked. `substituteEnvVars()` rebuilt each entry from a per-field allowlist and simply forgot the field.

- The config copier now passes every field through and rewrites only those needing env-var substitution or URL normalization, so future `ServerConfig` fields can't be dropped the same way.
- An unsupported pin from a config entry is now rejected up front with the same error as the flag, instead of failing later inside the bridge.
- Unit tests for the preserved pin and unknown-field pass-through, plus e2e coverage in `basic/protocol-version.test.sh` (both protocol eras).

No changelog entry: config-entry `protocolVersion` is still in `[Unreleased]` (#320), so the existing "Added" line already describes the working behaviour.

Fixes #323
Refs #320

https://claude.ai/code/session_01D4Y47mxUVcz73X13R5f4sJ