### PR TITLE
Update MCP spec links to latest 2026-07-28 spec version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -270,7 +270,7 @@ Run `mcpc --help` and `mcpc help <command>` for the authoritative, always-curren
 
 ### Security Considerations
 
-Implements [MCP security best practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices):
+Implements [MCP security best practices](https://modelcontextprotocol.io/specification/2026-07-28/basic/security_best_practices):
 
 **Credential protection:**
 

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ mcpc @apify tools-list
 ### OAuth profiles
 
 For OAuth-enabled remote MCP servers, `mcpc` implements the full OAuth 2.1 flow with PKCE as
-mandated by the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization):
+mandated by the [MCP authorization spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization):
 `WWW-Authenticate` 401 challenges, Protected Resource Metadata and authorization server metadata
 discovery, all three [client registration approaches](#client-registration-approaches),
 [resource indicators (RFC 8707)](https://www.rfc-editor.org/rfc/rfc8707), and automatic
@@ -479,7 +479,7 @@ mcpc logout mcp.apify.com --profile work
 ### Client registration approaches
 
 When logging in, `mcpc` supports all three OAuth client registration approaches defined in the
-[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-registration-approaches),
+[MCP authorization spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#client-registration-approaches),
 picking the one the authorization server advertises in its OAuth metadata:
 
 | **Approach**                            | **`mcpc login` flags**                              |
@@ -511,7 +511,7 @@ mcpc login mcp.example.com --client-metadata-url https://example.com/my-client.j
 mcpc login mcp.example.com --no-client-metadata-url
 ```
 
-See the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-registration-approaches)
+See the [MCP authorization spec](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#client-registration-approaches)
 for details on each approach and the format of Client ID Metadata Documents.
 
 ### Authentication precedence

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -315,7 +315,7 @@ export async function showServerDetails(
       );
     } else {
       // JSON output MUST match MCP InitializeResult structure!
-      // See https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult
+      // See https://modelcontextprotocol.io/specification/2026-07-28/schema#initializeresult
       // Build _mcpc.server with redacted headers for security
       const server: ServerConfig = {
         ...context.serverConfig,

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -315,7 +315,9 @@ export async function showServerDetails(
       );
     } else {
       // JSON output MUST match MCP InitializeResult structure!
-      // See https://modelcontextprotocol.io/specification/2026-07-28/schema#initializeresult
+      // InitializeResult is a 2025-11-25-only concept (2026-07-28 replaced the initialize
+      // handshake with server/discover's DiscoverResult) — see
+      // https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult
       // Build _mcpc.server with redacted headers for security
       const server: ServerConfig = {
         ...context.serverConfig,

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -12,6 +12,15 @@ import { jsonHelp } from './output.js';
 export const SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2026-07-28/schema';
 
 /**
+ * `InitializeResult`, `CreateTaskResult`, and `Task` are 2025-11-25-only concepts: the
+ * 2026-07-28 stateless era dropped the `initialize` handshake in favor of `server/discover`
+ * (returning `DiscoverResult`, not `InitializeResult`), and moved tasks out to the
+ * `io.modelcontextprotocol/tasks` extension, which no longer appears in the core schema.
+ * Those anchors only resolve on the legacy schema page, so link there instead of SCHEMA_BASE.
+ */
+export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2025-11-25/schema';
+
+/**
  * The one JSON shape every server-details command returns: MCP `InitializeResult`
  * extended with `toolNames` and an `_mcpc` metadata block. `connect` returns an array
  * of these (one per session), the session details screens return a single one.
@@ -44,7 +53,7 @@ export function serverDetailsJsonHelp(returns: 'object' | 'array'): string {
   return jsonHelp(
     `${subject} ${SERVER_DETAILS_JSON_META}`,
     shape,
-    `${SCHEMA_BASE}#initializeresult`
+    `${LEGACY_SCHEMA_BASE}#initializeresult`
   );
 }
 
@@ -57,6 +66,6 @@ export const SERVER_DETAILS_JSON_HELP_INLINE = ((): string => {
   const { subject, shape } = serverDetailsJson('object');
   return `With --json, returns the ${subject} ${SERVER_DETAILS_JSON_META}:
 ${shape}
-Schema: ${SCHEMA_BASE}#initializeresult
+Schema: ${LEGACY_SCHEMA_BASE}#initializeresult
 `;
 })();

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -9,7 +9,7 @@
 import { jsonHelp } from './output.js';
 
 /** Base URL of the MCP schema reference the `--json` help sections link to */
-export const SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2025-11-25/schema';
+export const SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2026-07-28/schema';
 
 /**
  * The one JSON shape every server-details command returns: MCP `InitializeResult`

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1366,8 +1366,7 @@ ${jsonHelp(
   '`ReadResourceResult`: `{ contents: [{ uri, mimeType?, text? | blob? }], ttlMs?, cacheScope? }`',
   undefined,
   `${SCHEMA_BASE}#readresourceresult`
-)}
-  \`ttlMs\`/\`cacheScope\` are caching hints only present on 2026-07-28 connections.`
+)}`
     )
     .action(async (name, options, command) => {
       await skills.getSkill(session, name, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1117,6 +1117,10 @@ ${jsonHelp(
     `${SCHEMA_BASE}#calltoolresult`
   );
 
+  // TODO: CreateTaskResult/Task only exist on the 2025-11-25 schema page — tasks moved to the
+  // io.modelcontextprotocol/tasks extension for 2026-07-28, which the SDK doesn't implement yet
+  // (see CLAUDE.md). Once the SDK adds it, point this (and the #task links on tasks-list/
+  // tasks-get/tasks-result) at wherever that extension's schema ends up living.
   const toolsCallCombinedJsonHelp = `
 ${chalk.bold('JSON output (--json):')}
   \`CallToolResult\` object:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1264,9 +1264,10 @@ ${chalk.bold('Output:')}
   matching <uri> (or the first one) — use --json to get all items.
 ${jsonHelp(
   '`ReadResourceResult` object',
-  '`{ contents: [{ uri, mimeType?, text? | blob? }] }`',
+  '`{ contents: [{ uri, mimeType?, text? | blob? }], ttlMs?, cacheScope? }`',
   `${SCHEMA_BASE}#readresourceresult`
 )}
+  \`ttlMs\`/\`cacheScope\` are caching hints only present on 2026-07-28 connections.
   With \`-o\`: \`{ uri, file, bytes, mimeType? }\` summary instead.
 `
     )
@@ -1358,10 +1359,11 @@ ${chalk.bold('Names:')}
   \`name\`, \`nested/path\`, or \`skill://...\` URI. For \`archive\` skills, use
   \`resources-read <url>\`. With --json, --raw is ignored.
 ${jsonHelp(
-  '`ReadResourceResult`: `{ contents: [{ uri, mimeType?, text? | blob? }] }`',
+  '`ReadResourceResult`: `{ contents: [{ uri, mimeType?, text? | blob? }], ttlMs?, cacheScope? }`',
   undefined,
   `${SCHEMA_BASE}#readresourceresult`
-)}`
+)}
+  \`ttlMs\`/\`cacheScope\` are caching hints only present on 2026-07-28 connections.`
     )
     .action(async (name, options, command) => {
       await skills.getSkill(session, name, {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -698,7 +698,7 @@ ${chalk.bold('Client registration (how mcpc identifies itself to the server):')}
   3. Dynamic Client Registration (DCR): fallback when CIMD is unsupported or
      disabled and the server exposes a registration_endpoint.
 
-  See https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization
+  See https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization
 
 ${chalk.bold('Machine-to-machine authentication (for CI/CD and daemons):')}
   Pass --grant client-credentials, --client-id, and one credential:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1240,7 +1240,7 @@ ${toolsCallCombinedJsonHelp}`
       'after',
       jsonHelp(
         'Array of `Resource` objects',
-        '`[{ uri, name?, description?, mimeType? }, ...]`',
+        '`[{ uri, name, description?, mimeType? }, ...]`',
         `${SCHEMA_BASE}#resource`
       )
     )
@@ -1315,7 +1315,7 @@ ${jsonHelp('`{ subscribed: true, uri, file, bytes, mimeType? }`')}`
       'after',
       jsonHelp(
         'Array of `ResourceTemplate` objects',
-        '`[{ uriTemplate, name?, description?, mimeType? }, ...]`',
+        '`[{ uriTemplate, name, description?, mimeType? }, ...]`',
         `${SCHEMA_BASE}#resourcetemplate`
       )
     )

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,6 +13,7 @@ import chalk from 'chalk';
 import { formatJson, formatJsonError, jsonHelp, rainbow, theme } from './output.js';
 import {
   SCHEMA_BASE,
+  LEGACY_SCHEMA_BASE,
   SERVER_DETAILS_JSON_HELP_INLINE,
   serverDetailsJsonHelp,
 } from './help-text.js';
@@ -1124,7 +1125,7 @@ ${chalk.bold('JSON output (--json):')}
 
   With \`--detach\`: \`CreateTaskResult\` object:
   \`{ taskId: string, status: string }\`
-  Schema: ${SCHEMA_BASE}#createtaskresult
+  Schema: ${LEGACY_SCHEMA_BASE}#createtaskresult
 `;
 
   program
@@ -1186,7 +1187,7 @@ ${toolsCallCombinedJsonHelp}`
       jsonHelp(
         '`{ tasks: Task[] }`',
         '`{ tasks: [{ taskId, status, ttl, createdAt, lastUpdatedAt, statusMessage?, pollInterval? }] }`',
-        `${SCHEMA_BASE}#task`
+        `${LEGACY_SCHEMA_BASE}#task`
       )
     )
     .action(async (_options, command) => {
@@ -1201,7 +1202,7 @@ ${toolsCallCombinedJsonHelp}`
       jsonHelp(
         '`Task` object',
         '`{ taskId, status, ttl, createdAt, lastUpdatedAt, statusMessage?, pollInterval? }`',
-        `${SCHEMA_BASE}#task`
+        `${LEGACY_SCHEMA_BASE}#task`
       )
     )
     .action(async (taskId, _options, command) => {
@@ -1224,7 +1225,7 @@ ${toolsCallCombinedJsonHelp}`
       jsonHelp(
         '`Task` object',
         '`{ taskId, status, ttl, createdAt, lastUpdatedAt, statusMessage?, pollInterval? }`',
-        `${SCHEMA_BASE}#task`
+        `${LEGACY_SCHEMA_BASE}#task`
       )
     )
     .action(async (taskId, _options, command) => {

--- a/test/e2e/suites/basic/json-schema.test.sh
+++ b/test/e2e/suites/basic/json-schema.test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Test: JSON output schema consistency with MCP specification
 # Ensures --json output matches the MCP protocol specification
-# Reference: https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle
+# Reference: https://modelcontextprotocol.io/specification/2026-07-28/basic/lifecycle
 
 source "$(dirname "$0")/../../lib/framework.sh"
 test_init "basic/json-schema"


### PR DESCRIPTION
Updates all version-pinned MCP spec links (schema, authorization, security best practices, lifecycle) from `2025-11-25` to `2026-07-28`, so docs and `--help` output point at the latest live spec.

Three anchors don't exist on the 2026-07-28 schema page and stay on `2025-11-25` on purpose, via a new `LEGACY_SCHEMA_BASE` constant:
- `InitializeResult` — the stateless era replaced the `initialize` handshake with `server/discover`'s `DiscoverResult`
- `CreateTaskResult`/`Task` — tasks moved out to the `io.modelcontextprotocol/tasks` extension, not yet implemented by the SDK; added a TODO to revisit these links once that support lands

The README sessions section keeps its `2025-11-25` lifecycle link too, but that one's deliberate as a historical reference to the stateful protocol era, not a miss.

Also fixed two related doc gaps found while cross-checking the schemas:
- `resources-list`/`resources-templates-list` `--help` showed `name?` (optional) even though `name` is required per `BaseMetadata` in both spec versions
- `resources-read`/`skills-get` `--help` didn't mention `ttlMs`/`cacheScope`, new caching-hint fields `ReadResourceResult` gained in 2026-07-28

All links (updated and kept-as-is) verified live against both spec pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XYydaLm3b4Lger6sdkv7vE