### PR TITLE
Implement OAuth discovery state (SEP-2352) and drop stale authProvider debug check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `mcpc login --grant client-credentials` now finds the authorization server via protected resource metadata (RFC 9728), so it works against servers whose authorization server lives on a different origin. Previously discovery only probed the MCP server's own origin and failed with "Could not find an OAuth token endpoint", forcing you to pass `--token-endpoint` by hand.
 - Sessions resumed after a bridge restart (e.g. crash recovery) no longer lose their negotiated protocol version: session details showed `Protocol: unknown` and, worse, requests were sent without the required `MCP-Protocol-Version` header. The stored version is now restored on resumption, and the server name is shown again in session details.
 - Resumed sessions also keep their server capabilities and instructions, which previously vanished after a bridge restart: `mcpc @session` showed no capabilities, `grep` no longer found the server instructions, and `resources-subscribe` wrongly refused with "server does not support resource subscriptions".
+- `mcpc login` no longer prints the SDK warning about a missing `discoveryState()` implementation. The OAuth provider now records the discovered authorization server between the redirect and the code exchange, enabling the SEP-2352 mix-up attack check (the code is only redeemed at the server that minted it).
+- Bridge logs no longer report the spurious `authProvider.tokens() is NOT a function - this is a bug!` error when connecting with OAuth — a stale debug check left over from the SDK v1 era; authentication itself was unaffected.
 
 ### Deprecated
 

--- a/src/core/transports.ts
+++ b/src/core/transports.ts
@@ -129,24 +129,6 @@ export function createStreamableHttpTransport(
     fetch: fetchFn,
   });
 
-  // Verify authProvider is correctly attached
-  // @ts-expect-error accessing private property for debugging
-  const hasAuthProvider = !!transport._authProvider;
-  logger.debug('Transport created, authProvider attached:', hasAuthProvider);
-
-  // Verification: Test that tokens() is actually callable
-  // Note: This is a non-blocking test - the actual tokens() call during requests
-  // is what matters. This just verifies the authProvider is correctly attached.
-  if (hasAuthProvider) {
-    // @ts-expect-error accessing private property for debugging
-    const authProvider = transport._authProvider as OAuthClientProvider;
-    if (typeof authProvider.tokens === 'function') {
-      logger.debug('authProvider.tokens() is a function - verification passed');
-    } else {
-      logger.error('authProvider.tokens() is NOT a function - this is a bug!');
-    }
-  }
-
   return transport as Transport;
 }
 

--- a/src/lib/auth/oauth-provider.ts
+++ b/src/lib/auth/oauth-provider.ts
@@ -16,6 +16,7 @@ import type {
   OAuthClientProvider,
   OAuthClientMetadata,
   OAuthClientInformationMixed,
+  OAuthDiscoveryState,
   OAuthTokens,
 } from '@modelcontextprotocol/client';
 import { OAuthTokenManager } from './oauth-token-manager.js';
@@ -133,6 +134,7 @@ export class OAuthProvider implements OAuthClientProvider {
   // Auth flow state (only used during interactive OAuth)
   private _authProfile?: AuthProfile;
   private _codeVerifier?: string;
+  private _discoveryState?: OAuthDiscoveryState;
   private _clientInformation?: OAuthClientInformationMixed;
 
   constructor(options: OAuthProviderOptions) {
@@ -373,5 +375,21 @@ export class OAuthProvider implements OAuthClientProvider {
       throw new Error('Code verifier not found');
     }
     return this._codeVerifier;
+  }
+
+  /**
+   * Persist OAuth discovery state (SEP-2352). The SDK records the discovered
+   * authorization server here on the redirect leg and reads it back on the
+   * callback leg to verify the code is redeemed at the same server that
+   * minted it (mix-up attack defense). The spec requires the same durability
+   * as `codeVerifier`, which mcpc keeps in memory — both legs of the login
+   * flow run through one provider instance in a single process.
+   */
+  async saveDiscoveryState(state: OAuthDiscoveryState): Promise<void> {
+    this._discoveryState = state;
+  }
+
+  async discoveryState(): Promise<OAuthDiscoveryState | undefined> {
+    return this._discoveryState;
   }
 }

--- a/test/unit/lib/auth/oauth-provider.test.ts
+++ b/test/unit/lib/auth/oauth-provider.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the OAuthProvider (MCP SDK OAuthClientProvider implementation)
+ */
+
+import type { OAuthDiscoveryState } from '@modelcontextprotocol/client';
+import { OAuthProvider } from '../../../../src/lib/auth/oauth-provider.js';
+
+describe('OAuthProvider discovery state (SEP-2352)', () => {
+  const makeProvider = () =>
+    new OAuthProvider({
+      serverUrl: 'https://mcp.example.com',
+      profileName: 'default',
+      redirectUrl: 'http://127.0.0.1:13316/callback',
+    });
+
+  const discovery: OAuthDiscoveryState = {
+    authorizationServerUrl: 'https://auth.example.com',
+    resourceMetadataUrl: 'https://mcp.example.com/.well-known/oauth-protected-resource',
+  };
+
+  it('implements saveDiscoveryState/discoveryState so the SDK can bind the callback leg', () => {
+    const provider = makeProvider();
+    // The SDK checks for the methods' presence: without them it can only warn
+    // that the SEP-2352 authorization-server binding cannot be verified.
+    expect(typeof provider.saveDiscoveryState).toBe('function');
+    expect(typeof provider.discoveryState).toBe('function');
+  });
+
+  it('round-trips discovery state within one provider instance', async () => {
+    const provider = makeProvider();
+    expect(await provider.discoveryState()).toBeUndefined();
+
+    await provider.saveDiscoveryState(discovery);
+    expect(await provider.discoveryState()).toEqual(discovery);
+  });
+
+  it('keeps discovery state with the same durability as the code verifier', async () => {
+    // Both legs of the login flow share one provider instance in one process,
+    // so in-memory storage is the required durability (matches _codeVerifier).
+    const provider = makeProvider();
+    await provider.saveCodeVerifier('verifier-123');
+    await provider.saveDiscoveryState(discovery);
+
+    expect(await provider.codeVerifier()).toBe('verifier-123');
+    expect(await provider.discoveryState()).toEqual(discovery);
+
+    // A fresh instance (new process) starts clean — no cross-instance leakage.
+    const fresh = makeProvider();
+    expect(await fresh.discoveryState()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes two OAuth-related log annoyances, one of which was masking a real security check. `mcpc login` printed an SDK warning that the provider does not implement `saveDiscoveryState()`/`discoveryState()`, leaving the SEP-2352 callback-leg authorization-server binding unchecked; the provider now records the discovered authorization server in memory (same durability as the PKCE code verifier — both login legs share one provider instance in one process), so the SDK verifies the authorization code is redeemed at the server that minted it.

- Implement `saveDiscoveryState()`/`discoveryState()` on `OAuthProvider` (+ unit tests)
- Remove a stale debug block in `createStreamableHttpTransport()` that logged a spurious `authProvider.tokens() is NOT a function - this is a bug!` error on every OAuth connection (SDK v2 wraps the provider in an adapter exposing `token()`, so the check asserted an obsolete shape)

https://claude.ai/code/session_01Cy2yB65N7awpCvjMyLjJC1