### PR TITLE
Stop logging the declined server/discover probe as a transport error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resumed sessions also keep their server capabilities and instructions, which previously vanished after a bridge restart: `mcpc @session` showed no capabilities, `grep` no longer found the server instructions, and `resources-subscribe` wrongly refused with "server does not support resource subscriptions".
 - `mcpc login` no longer prints the SDK warning about a missing `discoveryState()` implementation. The OAuth provider now records the discovered authorization server between the redirect and the code exchange, enabling the SEP-2352 mix-up attack check (the code is only redeemed at the server that minted it).
 - Bridge logs no longer report the spurious `authProvider.tokens() is NOT a function - this is a bug!` error when connecting with OAuth — a stale debug check left over from the SDK v1 era; authentication itself was unaffected.
+- Bridge logs no longer show a scary `Transport error: ... Bad Request: No valid session ID provided` stack trace when connecting to a server without 2026-07-28 support. That HTTP 400 is the server declining the `server/discover` version probe — the expected signal to fall back to the older protocol — and is now logged as a single debug line.
 
 ### Deprecated
 

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -3,7 +3,11 @@
  * Wraps the @modelcontextprotocol/client (SDK v2) Client class with additional functionality
  */
 
-import { Client as SDKClient, type ClientOptions } from '@modelcontextprotocol/client';
+import {
+  Client as SDKClient,
+  SdkHttpError,
+  type ClientOptions,
+} from '@modelcontextprotocol/client';
 import type {
   Transport,
   McpSubscription,
@@ -191,6 +195,22 @@ export function resolveVersionOptions(
 }
 
 /**
+ * True for the expected HTTP rejection of the connect-time `server/discover` version
+ * probe: servers that don't speak 2026-07-28 answer the probe POST with a 4xx
+ * (typically 400 "no valid session ID", 404, or 405), the transport surfaces it via
+ * `onerror`, and the SDK then falls back to the legacy `initialize` handshake on the
+ * same connection. 401/403 are excluded — those mean the server wants authentication,
+ * which the negotiation reports as a real error.
+ *
+ * Exported for unit tests.
+ */
+export function isExpectedProbeRejection(error: unknown): error is SdkHttpError {
+  if (!(error instanceof SdkHttpError)) return false;
+  const { status } = error;
+  return status >= 400 && status < 500 && status !== 401 && status !== 403;
+}
+
+/**
  * MCP Client wrapper class
  * Provides a convenient interface to the MCP SDK Client with error handling and logging
  * Implements IMcpClient interface for compatibility with SessionClient
@@ -208,6 +228,13 @@ export class McpClient implements IMcpClient {
   private cachedTools: Tool[] | null = null;
   private cachedToolsExpiresAt: number | null = null;
   private isClosing = false;
+  /**
+   * Whether the connection auto-negotiates the protocol version, i.e. a declined
+   * `server/discover` probe falls back to the legacy `initialize` handshake instead of
+   * failing. Pinned connections either skip the probe (legacy pin) or treat a declined
+   * probe as a real failure (modern pin), so their errors are never rewritten.
+   */
+  private readonly autoNegotiates: boolean;
   /** Resource URIs subscribed on a 2026-07-28 connection (served by one listen stream). */
   private modernSubscribedUris = new Set<string>();
   /** The open `subscriptions/listen` stream backing modernSubscribedUris, if any. */
@@ -219,6 +246,7 @@ export class McpClient implements IMcpClient {
       this.requestTimeoutMillis = options.requestTimeoutMillis;
     }
     this.configuredRequestTimeoutMillis = this.requestTimeoutMillis;
+    this.autoNegotiates = options.protocolVersion === undefined;
 
     this.client = new SDKClient(clientInfo, {
       capabilities: options.capabilities || {},
@@ -281,6 +309,16 @@ export class McpClient implements IMcpClient {
         // Ignore abort errors - these occur when connection is closed intentionally
         if (isShutdownError(error)) {
           this.logger.debug('Transport aborted (expected during close)');
+          return;
+        }
+        // A 4xx answer to the connect-time server/discover probe is how servers
+        // without 2026-07-28 support decline it — the SDK falls back to the legacy
+        // initialize handshake, so don't log it as a transport error.
+        if (!this.hasConnected && this.autoNegotiates && isExpectedProbeRejection(error)) {
+          this.logger.debug(
+            `Server declined the server/discover version probe (HTTP ${error.status}), ` +
+              'falling back to the legacy initialize handshake'
+          );
           return;
         }
         // Don't duplicate logging of errors on initial connection

--- a/test/unit/core/mcp-client.test.ts
+++ b/test/unit/core/mcp-client.test.ts
@@ -11,8 +11,10 @@
  */
 
 import { vi } from 'vitest';
-import { McpClient } from '../../../src/core/mcp-client.js';
+import { SdkHttpError, SdkErrorCode } from '@modelcontextprotocol/client';
+import { McpClient, isExpectedProbeRejection } from '../../../src/core/mcp-client.js';
 import { ServerError } from '../../../src/lib/errors.js';
+import { Logger } from '../../../src/lib/logger.js';
 
 vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@modelcontextprotocol/client')>();
@@ -479,5 +481,81 @@ describe('close', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('server/discover probe rejection', () => {
+  function probeRejection(status: number): SdkHttpError {
+    return new SdkHttpError(
+      SdkErrorCode.ClientHttpNotImplemented,
+      'Error POSTing to endpoint: {"jsonrpc":"2.0","error":{"code":-32000,"message":"Bad Request"},"id":null}',
+      { status, statusText: 'Bad Request' }
+    );
+  }
+
+  function makeLoggerSpy() {
+    const logger = new Logger('test');
+    return {
+      logger,
+      debug: vi.spyOn(logger, 'debug').mockImplementation(() => {}),
+      log: vi.spyOn(logger, 'log').mockImplementation(() => {}),
+    };
+  }
+
+  it('recognizes non-auth 4xx probe answers as expected', () => {
+    expect(isExpectedProbeRejection(probeRejection(400))).toBe(true);
+    expect(isExpectedProbeRejection(probeRejection(404))).toBe(true);
+    expect(isExpectedProbeRejection(probeRejection(405))).toBe(true);
+  });
+
+  it('keeps auth failures, server errors, and plain errors as real errors', () => {
+    expect(isExpectedProbeRejection(probeRejection(401))).toBe(false);
+    expect(isExpectedProbeRejection(probeRejection(403))).toBe(false);
+    expect(isExpectedProbeRejection(probeRejection(500))).toBe(false);
+    expect(isExpectedProbeRejection(new Error('boom'))).toBe(false);
+  });
+
+  it('logs a clean fallback line instead of a transport error during auto negotiation', async () => {
+    const { logger, debug, log } = makeLoggerSpy();
+    // Mimic the real timing: the probe is declined mid-connect, before hasConnected is set.
+    (stubSdkClient.connect as ReturnType<typeof vi.fn>).mockImplementation(
+      async (transport: { onerror?: (error: Error) => void }) => {
+        transport.onerror?.(probeRejection(400));
+      }
+    );
+    const client = new McpClient({ name: 'test', version: '0.0.0' }, { logger });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await client.connect(httpTransport('sess-1') as any);
+
+    expect(debug).toHaveBeenCalledWith(expect.stringContaining('server/discover'));
+    expect(log).not.toHaveBeenCalledWith(expect.anything(), 'Transport error:', expect.anything());
+  });
+
+  it('keeps the raw transport error when the protocol version is pinned', async () => {
+    const { logger, log } = makeLoggerSpy();
+    (stubSdkClient.connect as ReturnType<typeof vi.fn>).mockImplementation(
+      async (transport: { onerror?: (error: Error) => void }) => {
+        transport.onerror?.(probeRejection(400));
+      }
+    );
+    const client = new McpClient(
+      { name: 'test', version: '0.0.0' },
+      { logger, protocolVersion: '2025-11-25' }
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await client.connect(httpTransport('sess-1') as any);
+
+    expect(log).toHaveBeenCalledWith('debug', 'Transport error:', expect.any(SdkHttpError));
+  });
+
+  it('keeps logging 4xx transport errors once the connection is established', async () => {
+    const { logger, log } = makeLoggerSpy();
+    const transport = httpTransport('sess-1');
+    const client = new McpClient({ name: 'test', version: '0.0.0' }, { logger });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await client.connect(transport as any);
+
+    (transport.onerror as (error: Error) => void)(probeRejection(400));
+    expect(log).toHaveBeenCalledWith('error', 'Transport error:', expect.any(SdkHttpError));
   });
 });


### PR DESCRIPTION
Connecting to a server without 2026-07-28 support dumped a scary `Transport error: SdkHttpError ... Bad Request: No valid session ID provided` stack trace into the bridge log on every connect. That HTTP 400 is the expected way such servers decline the `server/discover` version probe — the SDK falls back to the legacy `initialize` handshake and the connection succeeds — so it is now logged as a single debug line instead.

- Recognize the expected probe rejection (pre-connect, auto negotiation, non-auth 4xx) in the transport error handler
- Keep full error logging for 401/403, 5xx, pinned `--protocol-version` connections, and post-connect errors
- Unit tests for the classifier and all three logging paths; verified end-to-end against the legacy e2e server

Refs #347 (removed a different spurious log message; this one remained).

https://claude.ai/code/session_01DceGk44vcV9jfyAHYKpp4h