### PR TITLE
Support MCP 2026-07-28 server/discover result fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
 - `mcpc --json` now reports each session's server `capabilities`, plus `hasInstructions` to tell whether the server provided instructions (read them with `mcpc --json @<session>`).
 - New `--protocol-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--protocol-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as a `protocolVersion` field in mcp.json config entries.
+- Server details from 2026-07-28 servers now include everything their `server/discover` result carries: `supportedVersions` (every protocol version the server offers, listed by `mcpc @session` too) and the result's `_meta`. Reported by `connect`, `restart` and `mcpc @session` in `--json`, and kept in `sessions.json`.
 
 ### Changed
 
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resumed sessions also keep their server capabilities and instructions, which previously vanished after a bridge restart: `mcpc @session` showed no capabilities, `grep` no longer found the server instructions, and `resources-subscribe` wrongly refused with "server does not support resource subscriptions".
 - `mcpc login` no longer prints the SDK warning about a missing `discoveryState()` implementation. The OAuth provider now records the discovered authorization server between the redirect and the code exchange, enabling the SEP-2352 mix-up attack check (the code is only redeemed at the server that minted it).
 - Bridge logs no longer report the spurious `authProvider.tokens() is NOT a function - this is a bug!` error when connecting with OAuth — a stale debug check left over from the SDK v1 era; authentication itself was unaffected.
+- `tools-list` now always refetches from the server: against a 2026-07-28 server that sends caching hints, the SDK's response cache could serve a stale tools list. The cached list also honors the server's `ttlMs` hint now, instead of always using mcpc's own freshness window.
 - Bridge logs no longer show a scary `Transport error: ... Bad Request: No valid session ID provided` stack trace when connecting to a server without 2026-07-28 support. That HTTP 400 is the server declining the `server/discover` version probe — the expected signal to fall back to the older protocol — and is now logged as a single debug line.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
 - `mcpc --json` now reports each session's server `capabilities`, plus `hasInstructions` to tell whether the server provided instructions (read them with `mcpc --json @<session>`).
 - New `--protocol-version` option for `mcpc connect` to pin the MCP protocol version (e.g. `--protocol-version 2025-11-25`) instead of auto-negotiating; the connection fails if the server does not support the pinned version. Also supported as a `protocolVersion` field in mcp.json config entries.
-- Server details from 2026-07-28 servers now include everything their `server/discover` result carries: `supportedVersions` (every protocol version the server offers, listed by `mcpc @session` too) and the result's `_meta`. Reported by `connect`, `restart` and `mcpc @session` in `--json`, and kept in `sessions.json`.
+- Server details from 2026-07-28 servers now include everything their `server/discover` result carries: `supportedVersions` (every protocol version the server offers) and the result's `_meta`. Reported by `connect`, `restart` and `mcpc @session` in `--json`, and kept in `sessions.json`.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,8 @@ When making changes, follow these rules to maintain the security posture:
 
 **Era-dependent behavior in mcpc:** `ping` maps to `server/discover` on modern connections; `logging-set-level` and the task commands are 2025-11-25-only (tasks moved to the `io.modelcontextprotocol/tasks` extension, which the SDK does not implement yet); `resources-subscribe` uses `subscriptions/listen` on modern connections and `resources/subscribe` on legacy ones.
 
+**One server-details shape for both eras:** `ServerDetails` (`src/lib/types.ts`) reconciles `InitializeResult` and `DiscoverResult` — the fields both carry (`protocolVersion`, `capabilities`, `serverInfo`, `instructions`) plus the discover-only `supportedVersions` and `_meta`, which are absent on legacy connections. It is what `mcpc connect --json`, `mcpc @session --json` and `restart --json` print, and what the bridge persists in `sessions.json` (so a resumed session, which skips the handshake, can still report all of it). Never fabricate an era's missing field — a legacy connection has no `supportedVersions` because the server never advertised one.
+
 **MCP Primitives:**
 
 - **Instructions**: Server-provided instructions fetched and stored
@@ -722,7 +724,7 @@ Bridge logs location: `~/.mcpc/logs/bridge-<session>.log`
 - **IPC Layer**: Unix socket communication between CLI and bridge (BridgeClient, SessionClient)
 - **Target Resolution**: URL/session/config resolution logic (sessions and HTTP servers working)
 - **CLI-to-MCP Integration**: Full integration via direct connection and session bridge
-- **Caching**: In-memory tools cache in the bridge, invalidated by `tools/list_changed` notifications (no TTL on stateful connections; 60s TTL fallback for stateless connections that can't push notifications)
+- **Caching**: In-memory tools cache in the bridge, invalidated by `tools/list_changed` notifications (a server-sent `ttlMs` cache hint wins when present; otherwise no TTL on stateful connections and a 60s TTL fallback for stateless connections that can't push notifications)
 - **Notification Handling**: Full notification support in the bridge process
   - `tools/list_changed`, `resources/list_changed`, `prompts/list_changed` notifications
   - Automatic cache invalidation on list changes, timestamps tracked in `sessions.json`

--- a/README.md
+++ b/README.md
@@ -895,9 +895,13 @@ mcpc @apify
 mcpc @apify --json
 ```
 
-In [JSON mode](#json-mode), the resulting object adheres
-to [`InitializeResult`](https://modelcontextprotocol.io/specification/latest/schema#initializeresult) object schema,
-and includes the `_mcpc` field with relevant server/session metadata.
+In [JSON mode](#json-mode), the resulting object adheres to the schema of the server's
+handshake result — [`InitializeResult`](https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult)
+on `2025-11-25` connections, [`DiscoverResult`](https://modelcontextprotocol.io/specification/2026-07-28/schema#discoverresult)
+on `2026-07-28` ones — and includes the `_mcpc` field with relevant server/session metadata.
+`protocolVersion` is always the version actually in use, while `supportedVersions` (every
+version the server offers) and `_meta` come from `server/discover` and are therefore absent
+on `2025-11-25` connections.
 
 ```json
 {
@@ -912,6 +916,7 @@ and includes the `_mcpc` field with relevant server/session metadata.
     }
   },
   "protocolVersion": "2026-07-28",
+  "supportedVersions": ["2026-07-28", "2025-11-25"],
   "capabilities": {
     "logging": {},
     "prompts": {},
@@ -922,7 +927,13 @@ and includes the `_mcpc` field with relevant server/session metadata.
     "name": "apify-mcp-server",
     "version": "1.0.0"
   },
-  "instructions": "Apify is the largest marketplace of tools for web scraping..."
+  "instructions": "Apify is the largest marketplace of tools for web scraping...",
+  "_meta": {
+    "io.modelcontextprotocol/serverInfo": {
+      "name": "apify-mcp-server",
+      "version": "1.0.0"
+    }
+  }
 }
 ```
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -153,7 +153,7 @@ class BridgeProcess {
   // reports no serverInfo/capabilities/instructions of its own (see #325).
   private resumedHandshakeDetails: Pick<
     ServerDetails,
-    'serverInfo' | 'capabilities' | 'instructions'
+    'serverInfo' | 'capabilities' | 'instructions' | 'supportedVersions' | '_meta'
   > | null = null;
 
   // Promise to track when auth credentials are received (for startup sequencing)
@@ -795,6 +795,10 @@ class BridgeProcess {
         ...(sessionData.serverInfo && { serverInfo: sessionData.serverInfo }),
         ...(sessionData.capabilities && { capabilities: sessionData.capabilities }),
         ...(sessionData.instructions && { instructions: sessionData.instructions }),
+        ...(sessionData.supportedVersions && {
+          supportedVersions: sessionData.supportedVersions,
+        }),
+        ...(sessionData._meta && { _meta: sessionData._meta }),
       };
     }
 
@@ -843,6 +847,14 @@ class BridgeProcess {
     }
     if (serverDetails.serverInfo) {
       sessionUpdate.serverInfo = serverDetails.serverInfo;
+    }
+    // Every version the server offered, and the discover result's `_meta` — 2026-07-28
+    // connections only, so absent on legacy ones (see ServerDetails).
+    if (serverDetails.supportedVersions) {
+      sessionUpdate.supportedVersions = serverDetails.supportedVersions;
+    }
+    if (serverDetails._meta) {
+      sessionUpdate._meta = serverDetails._meta;
     }
     // Capabilities and instructions come from the handshake only, so persist them for
     // future resumptions. They travel together: writing instructions unconditionally
@@ -905,6 +917,12 @@ class BridgeProcess {
     }
     if (!details.instructions && persisted.instructions) {
       details.instructions = persisted.instructions;
+    }
+    if (!details.supportedVersions && persisted.supportedVersions) {
+      details.supportedVersions = persisted.supportedVersions;
+    }
+    if (!details._meta && persisted._meta) {
+      details._meta = persisted._meta;
     }
     return details;
   }

--- a/src/cli/commands/connect.ts
+++ b/src/cli/commands/connect.ts
@@ -96,10 +96,11 @@ async function checkPortAvailable(host: string, port: number): Promise<boolean> 
 
 /**
  * One entry in the unified JSON array returned by `mcpc connect`.
- * Mirrors MCP `InitializeResult` (protocolVersion/capabilities/serverInfo/instructions),
- * extended with `toolNames` and an `_mcpc` metadata block. The same shape is used for
- * both single-server and multi-server connects so consumers can always treat the output
- * as an array.
+ * Mirrors the server's handshake result — MCP `InitializeResult` on 2025-11-25
+ * connections, `DiscoverResult` on 2026-07-28 ones (see `ServerDetails`) — extended with
+ * `toolNames` and an `_mcpc` metadata block. The same shape is used for both
+ * single-server and multi-server connects so consumers can always treat the output as an
+ * array.
  *
  * For failed/skipped entries only the `_mcpc` block is populated.
  */
@@ -116,7 +117,15 @@ export type ConnectResultEntry = {
     stateless?: boolean | null; // true=stateless, false=stateful, null=not yet determined
   };
 } & Partial<
-  Pick<ServerDetails, 'protocolVersion' | 'capabilities' | 'serverInfo' | 'instructions'>
+  Pick<
+    ServerDetails,
+    | 'protocolVersion'
+    | 'supportedVersions'
+    | 'capabilities'
+    | 'serverInfo'
+    | 'instructions'
+    | '_meta'
+  >
 > & {
     toolNames?: string[];
   };
@@ -142,8 +151,8 @@ type ConnectSessionOptions = {
 };
 
 /**
- * Connect to a session via the bridge and build a populated ConnectResultEntry from
- * its InitializeResult and tools list. The entry's `_mcpc.server` headers are redacted.
+ * Connect to a session via the bridge and build a populated ConnectResultEntry from its
+ * server details and tools list. The entry's `_mcpc.server` headers are redacted.
  */
 async function buildConnectResultEntry(
   sessionName: string,
@@ -188,9 +197,13 @@ async function buildConnectResultEntry(
           ...statelessField(serverDetails.connectionMode),
         },
         ...(serverDetails.protocolVersion && { protocolVersion: serverDetails.protocolVersion }),
+        ...(serverDetails.supportedVersions && {
+          supportedVersions: serverDetails.supportedVersions,
+        }),
         ...(serverDetails.capabilities && { capabilities: serverDetails.capabilities }),
         ...(serverDetails.serverInfo && { serverInfo: serverDetails.serverInfo }),
         ...(serverDetails.instructions && { instructions: serverDetails.instructions }),
+        ...(serverDetails._meta && { _meta: serverDetails._meta }),
         ...(tools.length > 0 && { toolNames: tools.map((t) => t.name) }),
       };
     }

--- a/src/cli/commands/sessions.ts
+++ b/src/cli/commands/sessions.ts
@@ -291,8 +291,15 @@ export async function showServerDetails(
 ): Promise<void> {
   await withMcpClient(target, options, async (client, context) => {
     const serverDetails = await client.getServerDetails();
-    const { serverInfo, capabilities, instructions, protocolVersion, connectionMode } =
-      serverDetails;
+    const {
+      serverInfo,
+      capabilities,
+      instructions,
+      protocolVersion,
+      supportedVersions,
+      connectionMode,
+      _meta,
+    } = serverDetails;
 
     // Get tools list (uses bridge cache when available, no extra server call)
     const cachedToolsResult = await client.listAllTools();
@@ -314,10 +321,11 @@ export async function showServerDetails(
         )
       );
     } else {
-      // JSON output MUST match MCP InitializeResult structure!
-      // InitializeResult is a 2025-11-25-only concept (2026-07-28 replaced the initialize
-      // handshake with server/discover's DiscoverResult) — see
+      // JSON output MUST match the server's handshake result: MCP `InitializeResult` on
+      // 2025-11-25 connections, `DiscoverResult` (`supportedVersions`, `_meta`) on
+      // 2026-07-28 ones. `ServerDetails` reconciles the two — see its doc comment.
       // https://modelcontextprotocol.io/specification/2025-11-25/schema#initializeresult
+      // https://modelcontextprotocol.io/specification/2026-07-28/schema#discoverresult
       // Build _mcpc.server with redacted headers for security
       const server: ServerConfig = {
         ...context.serverConfig,
@@ -349,9 +357,11 @@ export async function showServerDetails(
               ...(resourceSubscriptions.length > 0 && { resourceSubscriptions }),
             },
             protocolVersion,
+            ...(supportedVersions && { supportedVersions }),
             capabilities,
             serverInfo,
             instructions,
+            ...(_meta && { _meta }),
             ...(tools.length > 0 && { toolNames: tools.map((t) => t.name) }),
           },
           'json'

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -21,14 +21,22 @@ export const SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2026-0
 export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification/2025-11-25/schema';
 
 /**
- * The one JSON shape every server-details command returns: MCP `InitializeResult`
- * extended with `toolNames` and an `_mcpc` metadata block. `connect` returns an array
- * of these (one per session), the session details screens return a single one.
+ * The one JSON shape every server-details command returns: the server's handshake result
+ * — MCP `InitializeResult` on 2025-11-25 connections, `DiscoverResult` on 2026-07-28 ones
+ * — extended with `toolNames` and an `_mcpc` metadata block. `connect` returns an array of
+ * these (one per session), the session details screens return a single one.
+ *
+ * `supportedVersions` and `_meta` only appear on 2026-07-28 connections (the legacy
+ * handshake carries neither); `protocolVersion` is always the version actually in use.
  */
 const SERVER_DETAILS_JSON_SHAPE =
-  '{ protocolVersion?, capabilities?, serverInfo?, instructions?, toolNames?, _mcpc: { sessionName, server?, ... } }';
+  '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { sessionName, server?, ... } }';
 
 const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc` metadata';
+
+/** Which MCP result the shape mirrors, per protocol era. */
+const SERVER_DETAILS_JSON_ERAS =
+  '`InitializeResult` on MCP 2025-11-25, `DiscoverResult` on 2026-07-28';
 
 /**
  * The shared description of that output: what a command returns and the shape example
@@ -38,11 +46,17 @@ const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc` metadata
 function serverDetailsJson(returns: 'object' | 'array'): { subject: string; shape: string } {
   return returns === 'array'
     ? {
-        subject: 'Array of `InitializeResult` objects (one per session),',
+        subject: `array of server details objects, one per session (${SERVER_DETAILS_JSON_ERAS}),`,
         shape: `\`[${SERVER_DETAILS_JSON_SHAPE}]\``,
       }
-    : { subject: '`InitializeResult` object', shape: `\`${SERVER_DETAILS_JSON_SHAPE}\`` };
+    : {
+        subject: `server details object (${SERVER_DETAILS_JSON_ERAS})`,
+        shape: `\`${SERVER_DETAILS_JSON_SHAPE}\``,
+      };
 }
+
+/** Both handshake-result schemas, each on the spec page whose anchor resolves. */
+const SERVER_DETAILS_SCHEMA_URLS = `${LEGACY_SCHEMA_BASE}#initializeresult (2025-11-25), ${SCHEMA_BASE}#discoverresult (2026-07-28)`;
 
 /**
  * Standard "JSON output (--json):" block for the commands that print server details:
@@ -51,9 +65,9 @@ function serverDetailsJson(returns: 'object' | 'array'): { subject: string; shap
 export function serverDetailsJsonHelp(returns: 'object' | 'array'): string {
   const { subject, shape } = serverDetailsJson(returns);
   return jsonHelp(
-    `${subject} ${SERVER_DETAILS_JSON_META}`,
+    `${subject.charAt(0).toUpperCase()}${subject.slice(1)} ${SERVER_DETAILS_JSON_META}`,
     shape,
-    `${LEGACY_SCHEMA_BASE}#initializeresult`
+    SERVER_DETAILS_SCHEMA_URLS
   );
 }
 
@@ -66,6 +80,6 @@ export const SERVER_DETAILS_JSON_HELP_INLINE = ((): string => {
   const { subject, shape } = serverDetailsJson('object');
   return `With --json, returns the ${subject} ${SERVER_DETAILS_JSON_META}:
 ${shape}
-Schema: ${LEGACY_SCHEMA_BASE}#initializeresult
+Schema: ${SERVER_DETAILS_SCHEMA_URLS}
 `;
 })();

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -28,35 +28,36 @@ export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification
  *
  * `supportedVersions` and `_meta` only appear on 2026-07-28 connections (the legacy
  * handshake carries neither); `protocolVersion` is always the version actually in use.
+ * `_mcpc` is abbreviated here — `mcpc @session --json` shows the block in full.
  */
 const SERVER_DETAILS_JSON_SHAPE =
-  '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { sessionName, server?, ... } }';
+  '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { sessionName, ... } }';
 
 const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc` metadata';
-
-/** Which MCP result the shape mirrors, per protocol era. */
-const SERVER_DETAILS_JSON_ERAS =
-  '`InitializeResult` on MCP 2025-11-25, `DiscoverResult` on 2026-07-28';
 
 /**
  * The shared description of that output: what a command returns and the shape example
  * for it. Rendered two ways below — as the standard `jsonHelp()` block, or as one inline
  * sentence — so the wording and the example never drift between the two.
+ *
+ * Which of the two results it is follows from `protocolVersion`, so the eras are named
+ * once here and not spelled out per field — help output has to stay skimmable.
  */
 function serverDetailsJson(returns: 'object' | 'array'): { subject: string; shape: string } {
   return returns === 'array'
     ? {
-        subject: `array of server details objects, one per session (${SERVER_DETAILS_JSON_ERAS}),`,
+        subject:
+          'server details, one per session (`InitializeResult` or `DiscoverResult` objects),',
         shape: `\`[${SERVER_DETAILS_JSON_SHAPE}]\``,
       }
     : {
-        subject: `server details object (${SERVER_DETAILS_JSON_ERAS})`,
+        subject: 'server details (`InitializeResult` or `DiscoverResult` object)',
         shape: `\`${SERVER_DETAILS_JSON_SHAPE}\``,
       };
 }
 
 /** Both handshake-result schemas, each on the spec page whose anchor resolves. */
-const SERVER_DETAILS_SCHEMA_URLS = `${LEGACY_SCHEMA_BASE}#initializeresult (2025-11-25), ${SCHEMA_BASE}#discoverresult (2026-07-28)`;
+const SERVER_DETAILS_SCHEMA_URLS = `${LEGACY_SCHEMA_BASE}#initializeresult, ${SCHEMA_BASE}#discoverresult`;
 
 /**
  * Standard "JSON output (--json):" block for the commands that print server details:

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -6,6 +6,7 @@
  * instead of being repeated — or drifting — across command definitions.
  */
 
+import chalk from 'chalk';
 import { jsonHelp } from './output.js';
 
 /** Base URL of the MCP schema reference the `--json` help sections link to */
@@ -33,54 +34,45 @@ export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification
 const SERVER_DETAILS_JSON_SHAPE =
   '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { sessionName, ... } }';
 
-const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc` metadata';
-
-/**
- * The shared description of that output: what a command returns and the shape example
- * for it. Rendered two ways below — as the standard `jsonHelp()` block, or as one inline
- * sentence — so the wording and the example never drift between the two.
- *
- * Which of the two results it is follows from `protocolVersion`, so the eras are named
- * once here and not spelled out per field — help output has to stay skimmable.
- */
-function serverDetailsJson(returns: 'object' | 'array'): { subject: string; shape: string } {
-  return returns === 'array'
-    ? {
-        subject:
-          'server details, one per session (`InitializeResult` or `DiscoverResult` objects),',
-        shape: `\`[${SERVER_DETAILS_JSON_SHAPE}]\``,
-      }
-    : {
-        subject: 'server details (`InitializeResult` or `DiscoverResult` object)',
-        shape: `\`${SERVER_DETAILS_JSON_SHAPE}\``,
-      };
-}
+const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc`';
 
 /** Both handshake-result schemas, each on the spec page whose anchor resolves. */
-const SERVER_DETAILS_SCHEMA_URLS = `${LEGACY_SCHEMA_BASE}#initializeresult, ${SCHEMA_BASE}#discoverresult`;
+const SERVER_DETAILS_SCHEMA_URLS = [
+  `${LEGACY_SCHEMA_BASE}#initializeresult`,
+  `${SCHEMA_BASE}#discoverresult`,
+];
 
 /**
- * Standard "JSON output (--json):" block for the commands that print server details:
- * `connect` (an array of entries) and `restart` (the details of the restarted session).
+ * Standard "JSON output (--json):" block for every command that prints server details:
+ * `connect` (an array of entries), `restart` (the restarted session), and the `mcpc
+ * @session` screen below.
+ *
+ * Which of the two results a caller gets follows from `protocolVersion`, so the eras are
+ * named once — not per field and not per schema link. Help output has to stay skimmable.
  */
 export function serverDetailsJsonHelp(returns: 'object' | 'array'): string {
-  const { subject, shape } = serverDetailsJson(returns);
-  return jsonHelp(
-    `${subject.charAt(0).toUpperCase()}${subject.slice(1)} ${SERVER_DETAILS_JSON_META}`,
-    shape,
-    SERVER_DETAILS_SCHEMA_URLS
-  );
+  const subject =
+    returns === 'array'
+      ? '`InitializeResult` or `DiscoverResult` objects, one per session,'
+      : '`InitializeResult` or `DiscoverResult` object';
+  const shape =
+    returns === 'array' ? `\`[${SERVER_DETAILS_JSON_SHAPE}]\`` : `\`${SERVER_DETAILS_JSON_SHAPE}\``;
+  return jsonHelp(`${subject} ${SERVER_DETAILS_JSON_META}`, shape, SERVER_DETAILS_SCHEMA_URLS);
 }
 
 /**
- * Same content as one inline sentence, for the `mcpc @session` help screen. A
- * "JSON output (--json):" heading there would read as if it described every subcommand
- * listed above it, while it only applies to the no-command details output.
+ * Titled "Output:" section describing what a command prints in human mode. Pairs with the
+ * "JSON output (--json):" block below it — a loose sentence hanging off the command list
+ * reads like a footnote next to a titled section.
  */
-export const SERVER_DETAILS_JSON_HELP_INLINE = ((): string => {
-  const { subject, shape } = serverDetailsJson('object');
-  return `With --json, returns the ${subject} ${SERVER_DETAILS_JSON_META}:
-${shape}
-Schema: ${SERVER_DETAILS_SCHEMA_URLS}
-`;
-})();
+export function outputHelp(text: string): string {
+  return `\n${chalk.bold('Output:')}\n  ${text}\n`;
+}
+
+/**
+ * Trailing help for the `mcpc @session` screen: what the no-command invocation prints,
+ * then the same JSON block every other server-details command shows.
+ */
+export const SESSION_DETAILS_HELP =
+  outputHelp('When no command is given, shows session, server info, capabilities, and tools.') +
+  serverDetailsJsonHelp('object');

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -29,11 +29,10 @@ export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification
  *
  * `supportedVersions` and `_meta` only appear on 2026-07-28 connections (the legacy
  * handshake carries neither); `protocolVersion` is always the version actually in use.
- * `_mcpc` is abbreviated here — `mcpc @session --json` shows the block in full.
+ * `_mcpc` is abbreviated to keep the line short — run the command to see the block.
  */
-function serverDetailsJsonShape(mcpcFields: string): string {
-  return `{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { ${mcpcFields} } }`;
-}
+const SERVER_DETAILS_JSON_SHAPE =
+  '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { ... } }';
 
 const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc`';
 
@@ -52,16 +51,12 @@ const SERVER_DETAILS_SCHEMA_URLS = [
  * named once — not per field and not per schema link. Help output has to stay skimmable.
  */
 export function serverDetailsJsonHelp(returns: 'object' | 'array'): string {
-  // One entry per session in the array form, so its `_mcpc` block stays abbreviated —
-  // `mcpc @session --json` documents the block itself.
   const subject =
     returns === 'array'
       ? 'Array of `InitializeResult` or `DiscoverResult` objects'
       : '`InitializeResult` or `DiscoverResult` object';
   const shape =
-    returns === 'array'
-      ? `\`[${serverDetailsJsonShape('...')}]\``
-      : `\`${serverDetailsJsonShape('sessionName, ...')}\``;
+    returns === 'array' ? `\`[${SERVER_DETAILS_JSON_SHAPE}]\`` : `\`${SERVER_DETAILS_JSON_SHAPE}\``;
   return jsonHelp(`${subject} ${SERVER_DETAILS_JSON_META}`, shape, SERVER_DETAILS_SCHEMA_URLS);
 }
 

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -31,8 +31,9 @@ export const LEGACY_SCHEMA_BASE = 'https://modelcontextprotocol.io/specification
  * handshake carries neither); `protocolVersion` is always the version actually in use.
  * `_mcpc` is abbreviated here — `mcpc @session --json` shows the block in full.
  */
-const SERVER_DETAILS_JSON_SHAPE =
-  '{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { sessionName, ... } }';
+function serverDetailsJsonShape(mcpcFields: string): string {
+  return `{ protocolVersion?, supportedVersions?, capabilities?, serverInfo?, instructions?, _meta?, toolNames?, _mcpc: { ${mcpcFields} } }`;
+}
 
 const SERVER_DETAILS_JSON_META = 'extended with `toolNames` and `_mcpc`';
 
@@ -51,22 +52,26 @@ const SERVER_DETAILS_SCHEMA_URLS = [
  * named once — not per field and not per schema link. Help output has to stay skimmable.
  */
 export function serverDetailsJsonHelp(returns: 'object' | 'array'): string {
+  // One entry per session in the array form, so its `_mcpc` block stays abbreviated —
+  // `mcpc @session --json` documents the block itself.
   const subject =
     returns === 'array'
-      ? '`InitializeResult` or `DiscoverResult` objects, one per session,'
+      ? 'Array of `InitializeResult` or `DiscoverResult` objects'
       : '`InitializeResult` or `DiscoverResult` object';
   const shape =
-    returns === 'array' ? `\`[${SERVER_DETAILS_JSON_SHAPE}]\`` : `\`${SERVER_DETAILS_JSON_SHAPE}\``;
+    returns === 'array'
+      ? `\`[${serverDetailsJsonShape('...')}]\``
+      : `\`${serverDetailsJsonShape('sessionName, ...')}\``;
   return jsonHelp(`${subject} ${SERVER_DETAILS_JSON_META}`, shape, SERVER_DETAILS_SCHEMA_URLS);
 }
 
 /**
  * Titled "Output:" section describing what a command prints in human mode. Pairs with the
  * "JSON output (--json):" block below it — a loose sentence hanging off the command list
- * reads like a footnote next to a titled section.
+ * reads like a footnote next to a titled section. Pass several lines as an array.
  */
-export function outputHelp(text: string): string {
-  return `\n${chalk.bold('Output:')}\n  ${text}\n`;
+export function outputHelp(text: string | string[]): string {
+  return `\n${chalk.bold('Output:')}\n  ${[text].flat().join('\n  ')}\n`;
 }
 
 /**

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -517,7 +517,10 @@ ${chalk.bold('Protocol version:')}
 ${chalk.bold('x402 payments (experimental):')}
   --x402 pays for paid tool calls from the wallet set up with mcpc x402.
   Schemes: auto (default, prefers upto), upto, exact.
-${serverDetailsJsonHelp('array')}`
+${outputHelp([
+  'For a single server, shows session, server info, capabilities, and tools.',
+  'Bulk connects list every session with its state, then a summary.',
+])}${serverDetailsJsonHelp('array')}`
     )
     .action(async (server, sessionName, opts, command) => {
       const globalOpts = getOptionsFromCommand(command);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,7 +14,8 @@ import { formatJson, formatJsonError, jsonHelp, rainbow, theme } from './output.
 import {
   SCHEMA_BASE,
   LEGACY_SCHEMA_BASE,
-  SERVER_DETAILS_JSON_HELP_INLINE,
+  SESSION_DETAILS_HELP,
+  outputHelp,
   serverDetailsJsonHelp,
 } from './help-text.js';
 import * as tools from './commands/tools.js';
@@ -636,7 +637,8 @@ ${serverDetailsJsonHelp('array')}`
     .description('Restart a session (losing all state)')
     .addHelpText(
       'after',
-      `\nAfter restarting, the session details are shown again.\n${serverDetailsJsonHelp('object')}`
+      outputHelp('After restarting, the session details are shown again.') +
+        serverDetailsJsonHelp('object')
     )
     .action(async (sessionName, _opts, command) => {
       if (!sessionName) {
@@ -1022,7 +1024,8 @@ function registerSessionCommands(program: Command, session: string): void {
     .description('Restart MCP session (losing all state).')
     .addHelpText(
       'after',
-      `\nAfter restarting, the session details are shown again.\n${serverDetailsJsonHelp('object')}`
+      outputHelp('After restarting, the session details are shown again.') +
+        serverDetailsJsonHelp('object')
     )
     .action(async (_options, command) => {
       await sessions.restartSession(session, getOptionsFromCommand(command));
@@ -1523,12 +1526,7 @@ function createSessionProgram(): Command {
     .option('--timeout <seconds>', 'Request timeout in seconds (default: 60)')
     .option('--max-chars <n>', 'Truncate output to n characters (ignored in --json mode)')
     .option('--insecure', 'Skip TLS certificate verification (for self-signed certs)')
-    .addHelpText(
-      'after',
-      `
-When no command is given, shows server info, capabilities, and tools.
-${SERVER_DETAILS_JSON_HELP_INLINE}`
-    );
+    .addHelpText('after', SESSION_DETAILS_HELP);
 
   return program;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -637,7 +637,7 @@ ${serverDetailsJsonHelp('array')}`
     .description('Restart a session (losing all state)')
     .addHelpText(
       'after',
-      outputHelp('After restarting, the session details are shown again.') +
+      outputHelp('After restarting, shows session, server info, capabilities, and tools.') +
         serverDetailsJsonHelp('object')
     )
     .action(async (sessionName, _opts, command) => {
@@ -1024,7 +1024,7 @@ function registerSessionCommands(program: Command, session: string): void {
     .description('Restart MCP session (losing all state).')
     .addHelpText(
       'after',
-      outputHelp('After restarting, the session details are shown again.') +
+      outputHelp('After restarting, shows session, server info, capabilities, and tools.') +
         serverDetailsJsonHelp('object')
     )
     .action(async (_options, command) => {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1614,8 +1614,15 @@ export function formatServerDetails(
   const bullet = chalk.dim('*');
   const bt = chalk.gray('`'); // backtick
 
-  const { serverInfo, capabilities, instructions, protocolVersion, connectionMode, transport } =
-    details;
+  const {
+    serverInfo,
+    capabilities,
+    instructions,
+    protocolVersion,
+    supportedVersions,
+    connectionMode,
+    transport,
+  } = details;
 
   // One line for how mcpc is talking to the server: the negotiated protocol version
   // ("(pinned)" when --protocol-version fixed it), the transport, and whether that
@@ -1627,7 +1634,15 @@ export function formatServerDetails(
     const pinned = pinnedProtocolVersion ? ` ${chalk.gray('(pinned)')}` : '';
     const mode = connectionMode && connectionMode !== 'unknown' ? ` (${connectionMode})` : '';
     const via = transport ? chalk.gray(' / ') + `${formatTransportKind(transport)}${mode}` : '';
-    lines.push(chalk.bold('MCP:') + ` version ${protocolVersion}${pinned}${via}`);
+    // `server/discover` (2026-07-28) reports every version the server offers — worth a
+    // note when it can speak more than the one in use, since --protocol-version can pin
+    // any of them. The legacy handshake reports only the version it agreed on.
+    const otherVersions = (supportedVersions ?? []).filter((v) => v !== protocolVersion);
+    const alsoSupported =
+      otherVersions.length > 0
+        ? chalk.gray(` (server also offers ${otherVersions.join(', ')})`)
+        : '';
+    lines.push(chalk.bold('MCP:') + ` version ${protocolVersion}${pinned}${alsoSupported}${via}`);
     lines.push('');
   }
 

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1827,10 +1827,17 @@ export function formatServerDetails(
 
 /**
  * Format a JSON output help line with backtick-style Markdown formatting.
- * Optional schemaUrl adds a "Schema:" link for AI agents.
+ * Optional schemaUrl adds a "Schema:" link for AI agents — pass several (e.g. one per
+ * protocol era) to get one per line, each aligned under the first.
  */
-export function jsonHelp(description: string, shape?: string, schemaUrl?: string): string {
+export function jsonHelp(
+  description: string,
+  shape?: string,
+  schemaUrl?: string | string[]
+): string {
   const line = shape ? `  ${description}:\n  ${shape}` : `  ${description}`;
-  const link = schemaUrl ? `\n  Schema: ${schemaUrl}` : '';
+  const urls = schemaUrl === undefined ? [] : [schemaUrl].flat();
+  const schemaIndent = '\n' + ' '.repeat('  Schema: '.length);
+  const link = urls.length > 0 ? `\n  Schema: ${urls.join(schemaIndent)}` : '';
   return `\n${chalk.bold('JSON output (--json):')}\n${line}${link}\n`;
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1614,15 +1614,8 @@ export function formatServerDetails(
   const bullet = chalk.dim('*');
   const bt = chalk.gray('`'); // backtick
 
-  const {
-    serverInfo,
-    capabilities,
-    instructions,
-    protocolVersion,
-    supportedVersions,
-    connectionMode,
-    transport,
-  } = details;
+  const { serverInfo, capabilities, instructions, protocolVersion, connectionMode, transport } =
+    details;
 
   // One line for how mcpc is talking to the server: the negotiated protocol version
   // ("(pinned)" when --protocol-version fixed it), the transport, and whether that
@@ -1630,19 +1623,12 @@ export function formatServerDetails(
   // to the version: a 2025-11-25 HTTP server that issues no session id is stateless too,
   // while stdio is always stateful. Mirrored in `--json` as `_mcpc.transport`/`stateless`.
   // Comes first: the connection is what the rest of the screen is reported over.
+  // The server's other supported versions stay a `--json`-only detail (supportedVersions).
   if (protocolVersion) {
     const pinned = pinnedProtocolVersion ? ` ${chalk.gray('(pinned)')}` : '';
     const mode = connectionMode && connectionMode !== 'unknown' ? ` (${connectionMode})` : '';
     const via = transport ? chalk.gray(' / ') + `${formatTransportKind(transport)}${mode}` : '';
-    // `server/discover` (2026-07-28) reports every version the server offers — worth a
-    // note when it can speak more than the one in use, since --protocol-version can pin
-    // any of them. The legacy handshake reports only the version it agreed on.
-    const otherVersions = (supportedVersions ?? []).filter((v) => v !== protocolVersion);
-    const alsoSupported =
-      otherVersions.length > 0
-        ? chalk.gray(` (server also offers ${otherVersions.join(', ')})`)
-        : '';
-    lines.push(chalk.bold('MCP:') + ` version ${protocolVersion}${pinned}${alsoSupported}${via}`);
+    lines.push(chalk.bold('MCP:') + ` version ${protocolVersion}${pinned}${via}`);
     lines.push('');
   }
 

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -6,6 +6,7 @@
 import {
   Client as SDKClient,
   MAX_CACHE_TTL_MS,
+  SERVER_INFO_META_KEY,
   SdkHttpError,
   type ClientOptions,
 } from '@modelcontextprotocol/client';
@@ -435,14 +436,21 @@ export class McpClient implements IMcpClient {
    * `InitializeResult` and `DiscoverResult` come from the SDK's accessors, which are
    * populated by whichever handshake ran, and the discover-only `supportedVersions` /
    * `_meta` are read off the `server/discover` result on modern connections.
+   *
+   * 2026-07-28 moved the server identity out of the handshake into a `_meta` key that
+   * servers SHOULD stamp on every response, so the latest discover result is the freshest
+   * identity we hold: a modern connection reads `serverInfo` from there, and only falls
+   * back to the SDK accessor (frozen at connect) when the server sent none. Both fields
+   * then come from the same snapshot — `ping` re-runs `server/discover` on modern
+   * connections, which refreshes `_meta` but not the accessor.
    */
   getServerDetails(): Promise<ServerDetails> {
     const details: ServerDetails = {};
-    const serverInfo = this.client.getServerVersion();
     const capabilities = this.client.getServerCapabilities();
     const instructions = this.client.getInstructions();
     // Undefined on legacy connections — there is no DiscoverResult on that path.
     const discovered = this.client.getDiscoverResult();
+    const serverInfo = discovered?._meta?.[SERVER_INFO_META_KEY] ?? this.client.getServerVersion();
 
     if (this.negotiatedProtocolVersion) details.protocolVersion = this.negotiatedProtocolVersion;
     if (discovered?.supportedVersions) details.supportedVersions = discovered.supportedVersions;

--- a/src/core/mcp-client.ts
+++ b/src/core/mcp-client.ts
@@ -5,6 +5,7 @@
 
 import {
   Client as SDKClient,
+  MAX_CACHE_TTL_MS,
   SdkHttpError,
   type ClientOptions,
 } from '@modelcontextprotocol/client';
@@ -89,7 +90,8 @@ interface TransportWithProtocolVersion extends Transport {
 }
 
 /**
- * Fallback freshness window for the in-memory tools cache on stateless connections.
+ * Fallback freshness window for the in-memory tools cache on stateless connections, used
+ * when the server sends no `ttlMs` cache hint (see deriveToolsCacheExpiry).
  * Stateless servers (2026-07-28) may not push tools/list_changed (no standing stream), so the
  * cache would otherwise go stale silently. Stateful connections rely on notification-driven
  * invalidation and use no expiry.
@@ -428,18 +430,26 @@ export class McpClient implements IMcpClient {
   /**
    * Get all server information in a single call
    * Returns a Promise for interface compatibility with SessionClient
-   * Structure matches MCP InitializeResult for consistency
+   *
+   * Era-neutral by construction (see ServerDetails): the fields common to
+   * `InitializeResult` and `DiscoverResult` come from the SDK's accessors, which are
+   * populated by whichever handshake ran, and the discover-only `supportedVersions` /
+   * `_meta` are read off the `server/discover` result on modern connections.
    */
   getServerDetails(): Promise<ServerDetails> {
     const details: ServerDetails = {};
     const serverInfo = this.client.getServerVersion();
     const capabilities = this.client.getServerCapabilities();
     const instructions = this.client.getInstructions();
+    // Undefined on legacy connections — there is no DiscoverResult on that path.
+    const discovered = this.client.getDiscoverResult();
 
     if (this.negotiatedProtocolVersion) details.protocolVersion = this.negotiatedProtocolVersion;
+    if (discovered?.supportedVersions) details.supportedVersions = discovered.supportedVersions;
     if (capabilities) details.capabilities = capabilities;
     if (serverInfo) details.serverInfo = serverInfo;
     if (instructions) details.instructions = instructions;
+    if (discovered?._meta) details._meta = discovered._meta;
     details.connectionMode = this.deriveConnectionMode();
     const transport = this.deriveTransportKind();
     if (transport) details.transport = transport;
@@ -515,12 +525,16 @@ export class McpClient implements IMcpClient {
   }
 
   /**
-   * List available tools (single page)
+   * List available tools (single page).
+   * `refresh` forces a wire request, bypassing the SDK's own response cache.
    */
-  async listTools(cursor?: string): Promise<ListToolsResult> {
+  async listTools(cursor?: string, refresh?: boolean): Promise<ListToolsResult> {
     try {
       this.logger.debug('Listing tools...', cursor ? { cursor } : {});
-      const result = await this.client.listTools({ cursor }, this.getRequestOptions());
+      const result = await this.client.listTools(
+        { cursor },
+        { ...this.getRequestOptions(), ...(refresh && { cacheMode: 'refresh' as const }) }
+      );
       this.logger.debug(`Found ${result.tools.length} tools`);
       return result;
     } catch (error) {
@@ -540,19 +554,44 @@ export class McpClient implements IMcpClient {
       return { tools: this.cachedTools };
     }
 
+    let firstPage: ListToolsResult | undefined;
     const allTools: Tool[] = await fetchAllPages(
-      (cursor) => this.listTools(cursor),
+      async (cursor) => {
+        const page = await this.listTools(cursor, options?.refreshCache);
+        firstPage ??= page;
+        return page;
+      },
       (page) => page.tools
     );
 
     this.cachedTools = allTools;
-    // Stateless connections get a time-based expiry as a fallback for absent list_changed
-    // pushes; stateful connections keep no expiry (notifications/explicit invalidation drive it).
-    this.cachedToolsExpiresAt =
-      this.deriveConnectionMode() === 'stateless'
-        ? Date.now() + STATELESS_TOOLS_CACHE_TTL_MILLIS
-        : null;
+    this.cachedToolsExpiresAt = this.deriveToolsCacheExpiry(firstPage);
     return { tools: allTools };
+  }
+
+  /**
+   * When the cached tools list goes stale, as an absolute timestamp (`null` = never).
+   *
+   * A 2026-07-28 server MAY attach the `ttlMs` cache hint to `tools/list` (SEP-2549);
+   * it wins when present, clamped to the same 24h ceiling the SDK applies, with `0`
+   * meaning "immediately stale". Without a hint, stateless connections fall back to a
+   * fixed window (they may not push `tools/list_changed`, so the cache would otherwise go
+   * stale silently) and stateful connections keep no expiry at all — notification-driven
+   * and explicit invalidation drive those.
+   *
+   * The companion `cacheScope` hint needs no handling: every cache here lives inside one
+   * bridge process serving exactly one session, i.e. one authorization context, so a
+   * `private` result is never shared with another principal.
+   */
+  private deriveToolsCacheExpiry(firstPage: ListToolsResult | undefined): number | null {
+    // Typed `unknown` — the hint rides the result's loose passthrough fields.
+    const ttlMillis = firstPage?.ttlMs;
+    if (typeof ttlMillis === 'number') {
+      return Date.now() + Math.min(Math.max(0, ttlMillis), MAX_CACHE_TTL_MS);
+    }
+    return this.deriveConnectionMode() === 'stateless'
+      ? Date.now() + STATELESS_TOOLS_CACHE_TTL_MILLIS
+      : null;
   }
 
   private isToolsCacheExpired(): boolean {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -511,8 +511,9 @@ export interface ServerDetails {
   /**
    * `_meta` of the server's `server/discover` result, verbatim. 2026-07-28 connections
    * only (the SDK does not surface the legacy `initialize` result's `_meta`). Holds the
-   * spec's `io.modelcontextprotocol/serverInfo` — already lifted into `serverInfo` — and
-   * any extension metadata the server attached to it.
+   * spec's `io.modelcontextprotocol/serverInfo` — the identity 2026-07-28 servers stamp on
+   * every response, lifted into `serverInfo` above — plus any extension metadata the
+   * server attached to it.
    */
   _meta?: Record<string, unknown>;
   /** Whether the connection carries server-side session state (derived from transport + session id) */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -181,12 +181,15 @@ export interface SessionData {
   insecure?: boolean; // Skip TLS certificate verification
   pid?: number; // Bridge process PID
   protocolVersion?: string; // Negotiated MCP version
+  /**
+   * Every protocol version the server advertised in its `server/discover` result
+   * (2026-07-28 connections only — see `ServerDetails.supportedVersions`).
+   */
+  supportedVersions?: string[];
   mcpSessionId?: string; // Server-assigned MCP session ID for resumption (stateful Streamable HTTP only)
   connectionMode?: ConnectionMode; // Whether the connection carries server-side session state (derived at connect)
-  serverInfo?: {
-    name: string;
-    version: string;
-  };
+  /** Server identity, as reported by the handshake (`initialize`) or `server/discover`. */
+  serverInfo?: Implementation;
   /**
    * Server capabilities reported by the initialize handshake. Persisted because a
    * resumed session reuses the server-side session and therefore skips the handshake,
@@ -199,6 +202,12 @@ export interface SessionData {
    * read on every command), and omitted when the server sends none.
    */
   instructions?: string | undefined;
+  /**
+   * `_meta` of the server's `server/discover` result, verbatim (2026-07-28 connections
+   * only — see `ServerDetails._meta`). Persisted alongside `capabilities` so a resumed
+   * session can still report it.
+   */
+  _meta?: Record<string, unknown>;
   status?: SessionStatus; // Session health status (default: active)
   proxy?: ProxyConfig; // Proxy server configuration (if enabled)
   notifications?: SessionNotifications; // Last list change notification timestamps
@@ -473,18 +482,39 @@ export interface WalletsStorage {
 
 /**
  * Combined server details returned by getServerDetails()
- * Structure matches MCP InitializeResult for consistency
+ *
+ * One era-neutral shape for both handshakes: the fields that MCP `InitializeResult`
+ * (2025-11-25 `initialize`) and `DiscoverResult` (2026-07-28 `server/discover`) have in
+ * common, plus the discover-only `supportedVersions` and `_meta`, plus two fields mcpc
+ * derives itself (`connectionMode`, `transport`). On a 2026-07-28 connection the result
+ * satisfies both schemas: `serverInfo` is lifted out of the discover result's `_meta`, and
+ * `protocolVersion` is the version actually negotiated (the discover result only lists the
+ * versions on offer).
+ *
  * Fetched once during initialization, cached locally
  */
 export interface ServerDetails {
   /** Negotiated protocol version */
   protocolVersion?: string;
+  /**
+   * Every protocol version the server advertises (`DiscoverResult.supportedVersions`).
+   * 2026-07-28 connections only: the legacy `initialize` handshake reports nothing but the
+   * single version it agreed on.
+   */
+  supportedVersions?: string[];
   /** Server capabilities */
   capabilities?: ServerCapabilities;
   /** Server implementation details (name, version, etc.) - matches MCP serverInfo field */
   serverInfo?: Implementation;
   /** Server-provided instructions for the client */
   instructions?: string;
+  /**
+   * `_meta` of the server's `server/discover` result, verbatim. 2026-07-28 connections
+   * only (the SDK does not surface the legacy `initialize` result's `_meta`). Holds the
+   * spec's `io.modelcontextprotocol/serverInfo` — already lifted into `serverInfo` — and
+   * any extension metadata the server attached to it.
+   */
+  _meta?: Record<string, unknown>;
   /** Whether the connection carries server-side session state (derived from transport + session id) */
   connectionMode?: ConnectionMode;
   /** Transport carrying the connection (derived from the live transport) */

--- a/test/e2e/suites/basic/connect-discover.test.sh
+++ b/test/e2e/suites/basic/connect-discover.test.sh
@@ -196,7 +196,7 @@ test_pass
 # Test: JSON output is structured and lists discovered/results/skipped
 # =============================================================================
 
-test_case "--json output is an array of InitializeResult entries with _mcpc metadata"
+test_case "--json output is an array of server-details entries with _mcpc metadata"
 run_mcpc_discover --json connect
 assert_success "json discovery should succeed"
 
@@ -217,12 +217,12 @@ skipped_reason=$(echo "$STDOUT" | jq -r '[.[] | select(._mcpc.status == "skipped
 assert_eq "$skipped_name" "@shared"
 assert_eq "$skipped_reason" "duplicate"
 
-# Connected entry should expose InitializeResult fields (serverInfo at minimum)
+# Connected entry should expose the handshake-result fields (serverInfo at minimum)
 connected_name=$(echo "$STDOUT" | jq -r '[.[] | select(._mcpc.status == "active" or ._mcpc.status == "created")][0]._mcpc.sessionName')
 connected_server=$(echo "$STDOUT" | jq -r '[.[] | select(._mcpc.status == "active" or ._mcpc.status == "created")][0].serverInfo.name // empty')
 assert_eq "$connected_name" "@shared"
 if [[ -z "$connected_server" ]]; then
-  test_fail "connected entry should include serverInfo.name from InitializeResult"
+  test_fail "connected entry should include serverInfo.name from the handshake result"
   exit 1
 fi
 test_pass

--- a/test/e2e/suites/basic/json-schema.test.sh
+++ b/test/e2e/suites/basic/json-schema.test.sh
@@ -21,7 +21,9 @@ test_pass
 
 # =============================================================================
 # Test: mcpc @session --json (server details / handshake result)
-# MCP spec: InitializeResult contains protocolVersion, capabilities, serverInfo
+# MCP spec: InitializeResult (2025-11-25) contains protocolVersion, capabilities,
+# serverInfo; DiscoverResult (2026-07-28) replaces it and adds supportedVersions
+# plus a `_meta` block carrying the server identity.
 # =============================================================================
 
 test_case "server details JSON has protocolVersion"
@@ -64,11 +66,40 @@ assert_success
 assert_json "$STDOUT" '.instructions' "should have instructions field (check for typos)"
 test_pass
 
+test_case "server details JSON reports the discover-only fields per era"
+run_mcpc "$SESSION" --json
+assert_success
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  # DiscoverResult.supportedVersions must list the version actually negotiated
+  assert_json "$STDOUT" '.supportedVersions' "should have supportedVersions field"
+  negotiated=$(json_get '.protocolVersion')
+  if ! echo "$STDOUT" | jq -e --arg v "$negotiated" '.supportedVersions | index($v)' >/dev/null; then
+    test_fail "supportedVersions should contain the negotiated version $negotiated"
+  fi
+  # `_meta` is passed through verbatim, including the server identity the SDK lifts
+  # into serverInfo
+  assert_json "$STDOUT" '._meta' "should have the discover result's _meta"
+  assert_json "$STDOUT" '._meta."io.modelcontextprotocol/serverInfo".name' "_meta should carry serverInfo"
+else
+  # The legacy initialize handshake carries neither field
+  if echo "$STDOUT" | jq -e 'has("supportedVersions")' >/dev/null; then
+    test_fail "supportedVersions must not appear on a 2025-11-25 connection"
+  fi
+  if echo "$STDOUT" | jq -e 'has("_meta")' >/dev/null; then
+    test_fail "_meta must not appear on a 2025-11-25 connection"
+  fi
+fi
+test_pass
+
 test_case "server details JSON has exact expected fields"
 run_mcpc "$SESSION" --json
 assert_success
-# MCP InitializeResult - validate exact top-level fields (no more, no less)
+# Validate exact top-level fields (no more, no less). The 2026-07-28 handshake result
+# carries two fields the 2025-11-25 one does not: supportedVersions and _meta.
 expected_fields="_mcpc,capabilities,instructions,protocolVersion,serverInfo,toolNames"
+if [[ "$E2E_SERVER_PROTOCOL" == "modern" ]]; then
+  expected_fields="_mcpc,_meta,capabilities,instructions,protocolVersion,serverInfo,supportedVersions,toolNames"
+fi
 actual_fields=$(echo "$STDOUT" | jq -r 'keys | sort | join(",")')
 if [[ "$actual_fields" != "$expected_fields" ]]; then
   test_fail "unexpected top-level fields: expected [$expected_fields], got [$actual_fields]"

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1074,7 +1074,7 @@ describe('formatServerDetails', () => {
     expect(output).toContain('MCP: version 2026-07-28 / Streamable HTTP (stateless)');
   });
 
-  it('notes the other protocol versions a 2026-07-28 server offers', () => {
+  it('keeps supportedVersions out of the human-mode version line (a --json-only detail)', () => {
     const details: ServerDetails = {
       protocolVersion: '2026-07-28',
       supportedVersions: ['2026-07-28', '2025-11-25'],
@@ -1086,24 +1086,8 @@ describe('formatServerDetails', () => {
 
     const output = formatServerDetails(details, '@s');
 
-    expect(output).toContain(
-      'MCP: version 2026-07-28 (server also offers 2025-11-25) / Streamable HTTP (stateless)'
-    );
-  });
-
-  it('omits the note when the server offers only the version in use', () => {
-    const details: ServerDetails = {
-      protocolVersion: '2026-07-28',
-      supportedVersions: ['2026-07-28'],
-      capabilities: {},
-      serverInfo: { name: 'Single Server', version: '1.0.0' },
-      transport: 'streamable-http',
-    };
-
-    const output = formatServerDetails(details, '@s');
-
-    expect(output).toContain('MCP: version 2026-07-28 / Streamable HTTP');
-    expect(output).not.toContain('also offers');
+    expect(output).toContain('MCP: version 2026-07-28 / Streamable HTTP (stateless)');
+    expect(output).not.toContain('2025-11-25');
   });
 
   it('names the stdio transport', () => {

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -1074,6 +1074,38 @@ describe('formatServerDetails', () => {
     expect(output).toContain('MCP: version 2026-07-28 / Streamable HTTP (stateless)');
   });
 
+  it('notes the other protocol versions a 2026-07-28 server offers', () => {
+    const details: ServerDetails = {
+      protocolVersion: '2026-07-28',
+      supportedVersions: ['2026-07-28', '2025-11-25'],
+      capabilities: {},
+      serverInfo: { name: 'Dual Server', version: '1.0.0' },
+      connectionMode: 'stateless',
+      transport: 'streamable-http',
+    };
+
+    const output = formatServerDetails(details, '@s');
+
+    expect(output).toContain(
+      'MCP: version 2026-07-28 (server also offers 2025-11-25) / Streamable HTTP (stateless)'
+    );
+  });
+
+  it('omits the note when the server offers only the version in use', () => {
+    const details: ServerDetails = {
+      protocolVersion: '2026-07-28',
+      supportedVersions: ['2026-07-28'],
+      capabilities: {},
+      serverInfo: { name: 'Single Server', version: '1.0.0' },
+      transport: 'streamable-http',
+    };
+
+    const output = formatServerDetails(details, '@s');
+
+    expect(output).toContain('MCP: version 2026-07-28 / Streamable HTTP');
+    expect(output).not.toContain('also offers');
+  });
+
   it('names the stdio transport', () => {
     const details: ServerDetails = {
       protocolVersion: '2025-11-25',

--- a/test/unit/core/mcp-client.test.ts
+++ b/test/unit/core/mcp-client.test.ts
@@ -56,12 +56,15 @@ let era: 'modern' | 'legacy' | undefined;
 let negotiatedVersion: string | undefined;
 let listenQueue: StubSubscription[];
 let listenCalls: unknown[];
+/** The `server/discover` result the stub reports; undefined on legacy connections. */
+let discoverResult: Record<string, unknown> | undefined;
 
 function resetSdkStub(): void {
   era = 'legacy';
   negotiatedVersion = '2025-11-25';
   listenQueue = [];
   listenCalls = [];
+  discoverResult = undefined;
   stubSdkClient = {
     connect: vi.fn().mockResolvedValue(undefined),
     close: vi.fn().mockResolvedValue(undefined),
@@ -70,6 +73,7 @@ function resetSdkStub(): void {
     getInstructions: vi.fn().mockReturnValue(undefined),
     getNegotiatedProtocolVersion: vi.fn(() => negotiatedVersion),
     getProtocolEra: vi.fn(() => era),
+    getDiscoverResult: vi.fn(() => discoverResult),
     ping: vi.fn().mockResolvedValue(undefined),
     discover: vi.fn().mockResolvedValue({}),
     listTools: vi.fn().mockResolvedValue({ tools: [] }),
@@ -151,6 +155,33 @@ describe('transport kind', () => {
   it('reports nothing before connecting', async () => {
     const client = new McpClient({ name: 'test', version: '0.0.0' });
     expect((await client.getServerDetails()).transport).toBeUndefined();
+  });
+});
+
+describe('server details', () => {
+  it('reports the discover-only fields on a modern connection', async () => {
+    discoverResult = {
+      supportedVersions: ['2026-07-28', '2025-11-25'],
+      capabilities: {},
+      _meta: { 'io.modelcontextprotocol/serverInfo': { name: 'stub', version: '1.0.0' } },
+    };
+    const client = await connectClient({ era: 'modern' });
+
+    const details = await client.getServerDetails();
+    expect(details.protocolVersion).toBe('2026-07-28');
+    expect(details.supportedVersions).toEqual(['2026-07-28', '2025-11-25']);
+    expect(details._meta).toEqual({
+      'io.modelcontextprotocol/serverInfo': { name: 'stub', version: '1.0.0' },
+    });
+  });
+
+  it('omits them on a legacy connection, which has no discover result', async () => {
+    const client = await connectClient({ era: 'legacy' });
+
+    const details = await client.getServerDetails();
+    expect(details.protocolVersion).toBe('2025-11-25');
+    expect(details.supportedVersions).toBeUndefined();
+    expect(details._meta).toBeUndefined();
   });
 });
 
@@ -433,6 +464,52 @@ describe('tools cache', () => {
     await client.listAllTools();
     expect(stubSdkClient.listTools).toHaveBeenCalledTimes(2);
     vi.mocked(Date.now).mockRestore();
+  });
+
+  it('honors a server-sent ttlMs cache hint over the stateless fallback', async () => {
+    const client = await connectClient({ transport: httpTransport(undefined), era: 'modern' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }], ttlMs: 5_000 });
+
+    const start = Date.now();
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+
+    // Still fresh per the hint, even though the stateless fallback would also hold here.
+    vi.spyOn(Date, 'now').mockReturnValue(start + 4_000);
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(1);
+
+    // Expired per the hint, long before the 60s stateless fallback would have.
+    vi.mocked(Date.now).mockReturnValue(start + 6_000);
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(2);
+    vi.mocked(Date.now).mockRestore();
+  });
+
+  it('treats ttlMs 0 as immediately stale on a stateful connection', async () => {
+    const client = await connectClient({ transport: httpTransport('sess-1'), era: 'modern' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }], ttlMs: 0 });
+
+    await client.listAllTools();
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenCalledTimes(2);
+  });
+
+  it('bypasses the SDK response cache when refreshing', async () => {
+    const client = await connectClient({ era: 'legacy' });
+    stubSdkClient.listTools = vi.fn().mockResolvedValue({ tools: [{ name: 'a' }] });
+
+    await client.listAllTools();
+    expect(stubSdkClient.listTools).toHaveBeenLastCalledWith(
+      { cursor: undefined },
+      expect.not.objectContaining({ cacheMode: expect.anything() })
+    );
+
+    await client.listAllTools({ refreshCache: true });
+    expect(stubSdkClient.listTools).toHaveBeenLastCalledWith(
+      { cursor: undefined },
+      expect.objectContaining({ cacheMode: 'refresh' })
+    );
   });
 
   it('refetches on an explicit refresh and after invalidation', async () => {

--- a/test/unit/core/mcp-client.test.ts
+++ b/test/unit/core/mcp-client.test.ts
@@ -175,6 +175,30 @@ describe('server details', () => {
     });
   });
 
+  it('takes the server identity from the discover result, not the connect-time accessor', async () => {
+    // `ping` re-runs server/discover on a modern connection, which refreshes the discover
+    // result but not the SDK's connect-time accessor — so `serverInfo` and `_meta` would
+    // otherwise disagree after a server redeploy.
+    discoverResult = {
+      supportedVersions: ['2026-07-28'],
+      capabilities: {},
+      _meta: { 'io.modelcontextprotocol/serverInfo': { name: 'stub', version: '2.0.0' } },
+    };
+    const client = await connectClient({ era: 'modern' });
+
+    const details = await client.getServerDetails();
+    expect(details.serverInfo).toEqual({ name: 'stub', version: '2.0.0' });
+  });
+
+  it('falls back to the accessor when a modern server sends no identity', async () => {
+    // Sending it is only a SHOULD, so a modern connect can leave the identity unset.
+    discoverResult = { supportedVersions: ['2026-07-28'], capabilities: {} };
+    const client = await connectClient({ era: 'modern' });
+
+    const details = await client.getServerDetails();
+    expect(details.serverInfo).toEqual({ name: 'stub', version: '1.0.0' });
+  });
+
   it('omits them on a legacy connection, which has no discover result', async () => {
     const client = await connectClient({ era: 'legacy' });
 


### PR DESCRIPTION
`mcpc connect` / `mcpc @session` / `restart` returned an `InitializeResult`-shaped object, so on 2026-07-28 connections everything `server/discover` carries beyond the legacy handshake was dropped, and none of it reached `sessions.json`. `ServerDetails` now reconciles both results — the fields they share, plus the discover-only `supportedVersions` and `_meta` (absent on legacy connections; never synthesized there).

- `--json` and `sessions.json` gained `supportedVersions` and `_meta`; both are restored for resumed sessions, which skip the handshake
- `SessionData.serverInfo` is typed as the full `Implementation` it already stored
- Fixes the server identity on modern connections: 2026-07-28 moved `serverInfo` into a per-response `_meta` key, and the SDK only lifts it at connect while `ping` refreshes the discover result — so after a mid-session redeploy, details reported a stale `serverInfo` beside a fresh `_meta`. Both now come from the same snapshot
- Tools cache honors a server-sent `ttlMs` hint (SEP-2549), and explicit refreshes (`tools-list`, `list_changed`) pass `cacheMode: 'refresh'` so the SDK's response cache cannot answer them with a stale list. `cacheScope` needs no handling: one bridge serves one session, i.e. one authorization context
- Reformatted the help for these commands: titled `Output:` / `JSON output (--json):` sections instead of trailing prose, one schema link per line, and the protocol eras named once

Refs #345

https://claude.ai/code/session_01RZJucu49mLZKJvUYiaY3UV