### PR TITLE
Fix flaky sessions/logs E2E test racing the bridge on sessions.json

### DIFF
--- a/test/e2e/lib/framework.sh
+++ b/test/e2e/lib/framework.sh
@@ -430,6 +430,59 @@ create_session() {
   echo "$session"
 }
 
+# Edit sessions.json through a jq filter, holding the same lock mcpc uses.
+# Usage: edit_sessions_json <jq-arg>... '<jq-filter>'
+#
+# A live bridge rewrites sessions.json on every keepalive ping (load, merge,
+# save — all under a lock). A plain `jq ... > tmp && mv` from a test is not
+# locked, so a bridge that loads the file before the mv and saves after it
+# silently drops whatever the test just injected, and the next mcpc command
+# fails with "Session not found".
+#
+# proper-lockfile's lock is simply the directory "<file>.lock", created with
+# mkdir, so bash can take the very same lock. It is treated as stale after
+# 10s — never hold it across anything slower than a jq run.
+edit_sessions_json() {
+  local sessions_file="$MCPC_HOME_DIR/sessions.json"
+  local lock_dir="${sessions_file}.lock"
+  local tmp_file="${sessions_file}.e2e.$$"
+
+  if [[ ! -f "$sessions_file" ]]; then
+    echo '{"sessions":{}}' > "$sessions_file"
+  fi
+
+  local waited=0 steals=0
+  until mkdir "$lock_dir" 2>/dev/null; do
+    sleep 0.1
+    ((waited++)) || true
+    if [[ $waited -ge 100 ]]; then
+      if [[ $steals -ge 1 ]]; then
+        test_fail "timed out acquiring lock on $sessions_file"
+        return 1
+      fi
+      # Held (or leaked by a SIGKILLed bridge) for longer than the 10s
+      # staleness window — mcpc breaks the lock here too, so do the same.
+      rmdir "$lock_dir" 2>/dev/null || true
+      waited=0
+      ((steals++)) || true
+    fi
+  done
+
+  local status=0
+  if jq "$@" "$sessions_file" > "$tmp_file"; then
+    mv "$tmp_file" "$sessions_file" || status=1
+  else
+    status=1
+  fi
+  rm -f "$tmp_file"
+  rmdir "$lock_dir" 2>/dev/null || true
+
+  if [[ $status -ne 0 ]]; then
+    test_fail "failed to edit $sessions_file"
+    return 1
+  fi
+}
+
 # ============================================================================
 # Test Case Management
 # ============================================================================

--- a/test/e2e/suites/sessions/logs.test.sh
+++ b/test/e2e/suites/sessions/logs.test.sh
@@ -170,14 +170,8 @@ test_pass
 
 FOLD_SESSION="@fold-$(date +%s)"
 _SESSIONS_CREATED+=("$FOLD_SESSION")
-fold_sessions_file="$MCPC_HOME_DIR/sessions.json"
-if [[ ! -f "$fold_sessions_file" ]]; then
-  echo '{"sessions":{}}' > "$fold_sessions_file"
-fi
-jq --arg name "$FOLD_SESSION" --arg url "$TEST_SERVER_URL" \
-  '.sessions[$name] = { name: $name, server: { url: $url }, transport: "http", status: "live", createdAt: "2026-04-28T00:00:00.000Z" }' \
-  "$fold_sessions_file" > "$fold_sessions_file.tmp"
-mv "$fold_sessions_file.tmp" "$fold_sessions_file"
+edit_sessions_json --arg name "$FOLD_SESSION" --arg url "$TEST_SERVER_URL" \
+  '.sessions[$name] = { name: $name, server: { url: $url }, transport: "http", status: "live", createdAt: "2026-04-28T00:00:00.000Z" }'
 
 mkdir -p "$MCPC_HOME_DIR/logs"
 cat > "$MCPC_HOME_DIR/logs/bridge-${FOLD_SESSION}.log" <<'FOLDLOG'
@@ -214,19 +208,14 @@ ROTATION_SESSION="@rot-$(date +%s)"
 _SESSIONS_CREATED+=("$ROTATION_SESSION")
 
 # Add a synthetic session entry so `mcpc logs` accepts the target.
-sessions_file="$MCPC_HOME_DIR/sessions.json"
-if [[ ! -f "$sessions_file" ]]; then
-  echo '{"sessions":{}}' > "$sessions_file"
-fi
-jq --arg name "$ROTATION_SESSION" --arg url "$TEST_SERVER_URL" \
+edit_sessions_json --arg name "$ROTATION_SESSION" --arg url "$TEST_SERVER_URL" \
   '.sessions[$name] = {
      name: $name,
      server: { url: $url },
      transport: "http",
      status: "live",
      createdAt: "2026-04-28T00:00:00.000Z"
-   }' "$sessions_file" > "$sessions_file.tmp"
-mv "$sessions_file.tmp" "$sessions_file"
+   }'
 
 ROT_LOG_DIR="$MCPC_HOME_DIR/logs"
 ROT_LOG_FILE="$ROT_LOG_DIR/bridge-${ROTATION_SESSION}.log"
@@ -329,15 +318,14 @@ test_case "error from broken session points to 'mcpc <session> logs'"
 # already has an @) since session names can only contain one @ at the start.
 BROKEN="@broken-$(date +%s)-$$"
 # Add a manually-crafted session entry pointing at a server that 401s.
-jq --arg name "$BROKEN" --arg url "$TEST_SERVER_URL" \
+edit_sessions_json --arg name "$BROKEN" --arg url "$TEST_SERVER_URL" \
   '.sessions[$name] = {
      name: $name,
      server: { url: $url, headers: { "Authorization": "InvalidScheme bogus" } },
      transport: "http",
      status: "unauthorized",
      createdAt: "2026-04-28T00:00:00.000Z"
-   }' "$sessions_file" > "$sessions_file.tmp"
-mv "$sessions_file.tmp" "$sessions_file"
+   }'
 _SESSIONS_CREATED+=("$BROKEN")
 
 run_mcpc "$BROKEN" tools-list

--- a/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
+++ b/test/e2e/suites/sessions/unauthorized-auto-detect.test.sh
@@ -46,9 +46,7 @@ assert_success
 # - status: 'crashed' (no pid alive)
 # - lastConnectionAttemptAt aged past the 10s auto-retry cooldown
 # - bad Authorization header so the auto-restart hits 401
-sessions_file="$MCPC_HOME_DIR/sessions.json"
 old_iso="2000-01-01T00:00:00.000Z"
-tmp_file="$TEST_TMP/sessions.json.$$"
 
 # Save bad headers to the keychain used by restartBridge on auto-reconnect
 # (headers are loaded from the keychain, not sessions.json, on restart).
@@ -71,7 +69,7 @@ NATIVE_MCPC_HOME="$(to_native_path "$MCPC_HOME_DIR")"
 
 # Reconstruct the session entry: crashed state, no pid, old attempt timestamp,
 # headers placeholder so the restart path knows to load headers from keychain.
-jq --arg name "$SESSION" \
+edit_sessions_json --arg name "$SESSION" \
    --arg url "$TEST_SERVER_URL" \
    --arg when "$old_iso" \
    '.sessions[$name] = {
@@ -84,9 +82,7 @@ jq --arg name "$SESSION" \
       "createdAt": $when,
       "lastConnectionAttemptAt": $when,
       "status": "crashed"
-    }' \
-  "$sessions_file" > "$tmp_file"
-mv "$tmp_file" "$sessions_file"
+    }'
 
 test_pass
 

--- a/test/e2e/suites/sessions/unauthorized-persist.test.sh
+++ b/test/e2e/suites/sessions/unauthorized-persist.test.sh
@@ -64,12 +64,9 @@ assert_file_exists "$sessions_file"
 # original failed connect. Leaving pid set would short-circuit the retry path
 # via `!session.pid`, hiding the bug we are trying to catch.
 old_iso="2000-01-01T00:00:00.000Z"
-tmp_file="$TEST_TMP/sessions.json.$$"
-jq --arg name "$SESSION" --arg when "$old_iso" \
+edit_sessions_json --arg name "$SESSION" --arg when "$old_iso" \
   '.sessions[$name].lastConnectionAttemptAt = $when
-   | del(.sessions[$name].pid)' \
-  "$sessions_file" > "$tmp_file"
-mv "$tmp_file" "$sessions_file"
+   | del(.sessions[$name].pid)'
 
 # Re-run the list command — consolidateSessions() runs on every list.
 run_mcpc --json


### PR DESCRIPTION
The Windows/Bun leg of the last release run failed on `sessions/logs` test 10 with `Session not found: @fold-...`. Suites that inject synthetic session entries did an unlocked `jq ... > tmp && mv` on `sessions.json` while a live bridge rewrote the same file on every keepalive ping — when the bridge loaded the file before the `mv` and saved after it, the injected entry vanished. Test-only flake, no product bug.

- Add an `edit_sessions_json` framework helper that takes the same `proper-lockfile` lock mcpc uses (the `<file>.lock` directory, created with `mkdir`)
- Break the lock once after 10s, matching proper-lockfile's staleness rule, so a SIGKILLed bridge's leaked lock can't hang a suite
- Route the five unlocked fixture edits through it: three in `sessions/logs`, one each in `unauthorized-auto-detect` and `unauthorized-persist`

Verified against a keepalive-style concurrent writer: the old pattern lost 2 of 60 injected entries, the helper lost 0 of 60. Full `sessions/` suite (18 tests) passes.

Refs https://github.com/apify/mcpc/actions/runs/30614984280

https://claude.ai/code/session_01LV8fLqLtF7s3VMqiL73qfv