### PR TITLE
Accept MCP JSON-RPC method names as silent command aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Session commands now also accept MCP's JSON-RPC method names (e.g. `tools/list`, `logging/setLevel`) as aliases for the hyphenated CLI form (`tools-list`, `logging-set-level`).
 - On servers using MCP 2026-07-28, `logging-set-level` returns an error (the protocol removed `logging/setLevel`) and the task commands (`tasks-list`, `tasks-get`, `tasks-result`, `tasks-cancel`, `tools-call --task/--detach`) report that the new tasks extension is not supported yet — they keep working unchanged on 2025-11-25 servers.
 - `mcpc @session` now reports the connection on one line — `MCP: version 2025-11-25 / Streamable HTTP (stateless)` — naming the protocol (the label was just `Protocol:`) and the transport carrying it. `--json` gained the matching `_mcpc.transport` field next to `_mcpc.stateless`.
 - `mcpc @session` no longer suggests commands that cannot work on a 2026-07-28 connection: the `logging` and `tasks` capabilities are flagged as era-limited, and `logging-set-level` / `tasks-*` are left out of the suggested commands.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -48,6 +48,8 @@ import {
   hasSubcommand,
   optionTakesValue,
   suggestCommand,
+  normalizeSlashCommand,
+  normalizeSlashCommandArgs,
   KNOWN_COMMANDS,
   KNOWN_SESSION_COMMANDS,
 } from './parser.js';
@@ -346,7 +348,11 @@ async function main(): Promise<void> {
   const outputMode: OutputMode = opts.json ? 'json' : 'human';
 
   const allCommands = [...KNOWN_COMMANDS, ...KNOWN_SESSION_COMMANDS];
-  if (allCommands.includes(firstNonOption)) {
+  // Accept MCP JSON-RPC-style method names (e.g. "tools/list") silently, in case
+  // this is a session subcommand typed without a session target — undocumented,
+  // never advertised in the message itself.
+  const normalizedFirstNonOption = normalizeSlashCommand(firstNonOption);
+  if (allCommands.includes(normalizedFirstNonOption)) {
     // It's a session subcommand used without @session
     if (outputMode === 'json') {
       console.error(
@@ -354,12 +360,12 @@ async function main(): Promise<void> {
       );
     } else {
       console.error(`Error: Missing session target for command: ${firstNonOption}`);
-      console.error(`\nDid you mean: mcpc <@session> ${firstNonOption}`);
+      console.error(`\nDid you mean: mcpc <@session> ${normalizedFirstNonOption}`);
       console.error(`Run "mcpc --help" for usage information.\n`);
     }
   } else {
     // Try to suggest the closest matching command
-    const suggestion = suggestCommand(firstNonOption, allCommands);
+    const suggestion = suggestCommand(normalizedFirstNonOption, allCommands);
     if (outputMode === 'json') {
       console.error(formatJsonError(new Error(`Unknown command: ${firstNonOption}`), 1));
     } else {
@@ -1583,7 +1589,13 @@ function extractToolsCallHelpTarget(args: string[]): string | undefined {
 /**
  * Handle commands for a session target (@name)
  */
-async function handleSessionCommands(session: string, args: string[]): Promise<void> {
+async function handleSessionCommands(session: string, rawArgs: string[]): Promise<void> {
+  // Accept MCP JSON-RPC-style method names (e.g. "tools/list", "logging/setLevel")
+  // as silent aliases for the hyphenated command form — undocumented, never
+  // advertised in help or suggestions. Must happen before any other parsing below
+  // so hasSubcommand/extractToolsCallHelpTarget/Commander all see the normalized form.
+  const args = normalizeSlashCommandArgs(rawArgs, KNOWN_SESSION_COMMANDS, 2);
+
   // Check if no subcommand provided - show server info (unless --help is requested)
   const argsSlice = args.slice(2);
   if (!hasSubcommand(args) && !argsSlice.includes('--help') && !argsSlice.includes('-h')) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -223,6 +223,59 @@ export function suggestCommand(
 }
 
 /**
+ * Normalize an MCP JSON-RPC-style method name (e.g. "tools/list",
+ * "logging/setLevel", "resources/templates/list") into mcpc's hyphenated
+ * command form ("tools-list", "logging-set-level", "resources-templates-list").
+ * Returns the input unchanged if it contains no '/'.
+ *
+ * Undocumented convenience: accepted silently as an alias wherever a command
+ * name is expected, for users who reach for the raw protocol method name out
+ * of habit. Never advertised in --help or "Did you mean?" suggestions.
+ */
+export function normalizeSlashCommand(token: string): string {
+  if (!token.includes('/')) return token;
+  return token
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/\//g, '-');
+}
+
+/**
+ * Rewrite the first positional command token in `args` if it's a slash-style
+ * MCP method name (see normalizeSlashCommand) that maps to a known hyphenated
+ * command. Only the command-name slot is touched — later positional args
+ * (tool names, resource URIs, etc.) are left untouched even if they contain '/'.
+ *
+ * @param startIndex where to start scanning for the first positional token
+ *   (2 when `args` mirrors process.argv with its [node, script] prefix, 0 when
+ *   `args` is already a bare argument list).
+ */
+export function normalizeSlashCommandArgs(
+  args: string[],
+  knownCommands: string[],
+  startIndex: number
+): string[] {
+  for (let i = startIndex; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg) continue;
+    if (arg.startsWith('-')) {
+      if (optionTakesValue(arg) && !arg.includes('=')) i++; // skip option value
+      continue;
+    }
+    if (arg.includes('/')) {
+      const normalized = normalizeSlashCommand(arg);
+      if (knownCommands.includes(normalized)) {
+        const result = [...args];
+        result[i] = normalized;
+        return result;
+      }
+    }
+    return args;
+  }
+  return args;
+}
+
+/**
  * Check if an option always takes a value
  */
 export function optionTakesValue(arg: string): boolean {

--- a/test/e2e/suites/basic/errors.test.sh
+++ b/test/e2e/suites/basic/errors.test.sh
@@ -109,6 +109,22 @@ assert_contains "$STDERR" "Missing session target for command: tools-list"
 assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-list"
 test_pass
 
+# Test: MCP JSON-RPC-style method name without @session is recognized (silent alias)
+# and hints the hyphenated form, not the raw method name.
+test_case "slash-style method name without @session suggests hyphenated form"
+run_mcpc tools/list
+assert_failure
+assert_contains "$STDERR" "Missing session target for command: tools/list"
+assert_contains "$STDERR" "Did you mean: mcpc <@session> tools-list"
+test_pass
+
+# Test: unmatched slash-style token is still reported as unknown (no false alias)
+test_case "unmatched slash-style token stays unknown"
+run_mcpc @test foo/bar
+assert_failure
+assert_contains "$STDERR" "Unknown command: foo/bar"
+test_pass
+
 # Test: bare "tools" without @session suggests session subcommand
 test_case "top-level bare tools suggests session subcommand"
 run_mcpc tools

--- a/test/e2e/suites/basic/human-output.test.sh
+++ b/test/e2e/suites/basic/human-output.test.sh
@@ -28,6 +28,16 @@ assert_success
 assert_contains "$STDOUT" "Tools ("
 test_pass
 
+# MCP JSON-RPC-style method names (e.g. "tools/list") are silently accepted as
+# aliases for the hyphenated CLI commands — undocumented convenience, not shown
+# in --help or "Did you mean?" suggestions.
+test_case "tools/list (slash-style alias) behaves like tools-list"
+run_mcpc "$SESSION" tools/list
+assert_success
+assert_contains "$STDOUT" "Tools ("
+assert_contains "$STDOUT" "\`echo ("
+test_pass
+
 test_case "tools-list contains tool names in backticks"
 run_mcpc "$SESSION" tools-list
 assert_success

--- a/test/unit/cli/parser.test.ts
+++ b/test/unit/cli/parser.test.ts
@@ -11,6 +11,8 @@ import {
   optionTakesValue,
   hasSubcommand,
   suggestCommand,
+  normalizeSlashCommand,
+  normalizeSlashCommandArgs,
   preProcessX402Argv,
 } from '../../../src/cli/parser.js';
 import { ClientError } from '../../../src/lib/errors.js';
@@ -590,6 +592,74 @@ describe('suggestCommand', () => {
     expect(suggestCommand('tools-lst', commands, 0)).toBeUndefined();
     // With higher maxDistance, more distant matches are accepted
     expect(suggestCommand('tools-lst', commands, 1)).toBe('tools-list');
+  });
+});
+
+describe('normalizeSlashCommand', () => {
+  it('returns the input unchanged when there is no slash', () => {
+    expect(normalizeSlashCommand('tools-list')).toBe('tools-list');
+    expect(normalizeSlashCommand('connect')).toBe('connect');
+  });
+
+  it('converts simple slash method names to hyphenated form', () => {
+    expect(normalizeSlashCommand('tools/list')).toBe('tools-list');
+    expect(normalizeSlashCommand('tools/call')).toBe('tools-call');
+    expect(normalizeSlashCommand('resources/read')).toBe('resources-read');
+    expect(normalizeSlashCommand('prompts/get')).toBe('prompts-get');
+    expect(normalizeSlashCommand('server/discover')).toBe('server-discover');
+  });
+
+  it('converts multi-segment slash method names', () => {
+    expect(normalizeSlashCommand('resources/templates/list')).toBe('resources-templates-list');
+  });
+
+  it('splits camelCase segments into kebab-case', () => {
+    expect(normalizeSlashCommand('logging/setLevel')).toBe('logging-set-level');
+  });
+});
+
+describe('normalizeSlashCommandArgs', () => {
+  const commands = ['tools-list', 'tools-call', 'resources-read', 'logging-set-level'];
+
+  it('rewrites the first positional token when it maps to a known command', () => {
+    expect(normalizeSlashCommandArgs(['node', 'script', 'tools/list'], commands, 2)).toEqual([
+      'node',
+      'script',
+      'tools-list',
+    ]);
+  });
+
+  it('skips leading global options (and their values) before the command token', () => {
+    expect(
+      normalizeSlashCommandArgs(['node', 'script', '--json', 'tools/call', 'my-tool'], commands, 2)
+    ).toEqual(['node', 'script', '--json', 'tools-call', 'my-tool']);
+    expect(
+      normalizeSlashCommandArgs(
+        ['node', 'script', '--timeout', '30', 'logging/setLevel', 'debug'],
+        commands,
+        2
+      )
+    ).toEqual(['node', 'script', '--timeout', '30', 'logging-set-level', 'debug']);
+  });
+
+  it('leaves the args unchanged when the slash token has no known mapping', () => {
+    const args = ['node', 'script', 'foo/bar'];
+    expect(normalizeSlashCommandArgs(args, commands, 2)).toBe(args);
+  });
+
+  it('leaves already-hyphenated commands unchanged', () => {
+    const args = ['node', 'script', 'tools-list'];
+    expect(normalizeSlashCommandArgs(args, commands, 2)).toBe(args);
+  });
+
+  it('does not touch positional args after the command token even if they contain a slash', () => {
+    expect(
+      normalizeSlashCommandArgs(['node', 'script', 'resources-read', 'file:///tmp/x'], commands, 2)
+    ).toEqual(['node', 'script', 'resources-read', 'file:///tmp/x']);
+  });
+
+  it('respects a bare (no node/script prefix) argument list via startIndex 0', () => {
+    expect(normalizeSlashCommandArgs(['tools/list'], commands, 0)).toEqual(['tools-list']);
   });
 });
 


### PR DESCRIPTION
mcpc now silently accepts MCP's JSON-RPC-style method names (e.g. `tools/list`, `logging/setLevel`) as aliases for the hyphenated CLI command form (`tools-list`, `logging-set-level`), for users who reach for the raw protocol method name out of habit.

- Normalizes the command token before Commander parses or "Unknown command" errors are raised
- Undocumented on purpose — not shown in `--help` or "Did you mean?" suggestions
- Unmatched slash-style tokens still fail as unknown commands

https://claude.ai/code/session_01JSUxP3WUuz3zEgPZmu2hAZ