### PR TITLE
Install mcpc with Homebrew via apify/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,30 +315,30 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
-      # ── Homebrew tap (must never affect the release itself) ────────
-      - name: Update Homebrew tap
+      # ── Homebrew tap ───────────────────────────────────────────────
+      - name: Homebrew formula update instructions
         if: inputs.type == 'release'
-        # apify/homebrew-tap owns the formula and its update flow: the dispatched
-        # workflow points Formula/mcpc.rb at the new npm tarball, installs and
-        # `brew test`s it on Linux and macOS, then merges the bump. It polls the
-        # registry itself, so it tolerates npm publish propagation.
+        # The formula bump in apify/homebrew-tap is started by hand for now, so
+        # this step only prints the command — it deliberately does not dispatch
+        # anything. To automate it later, run the printed command in this step
+        # (with GH_TOKEN: secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN) and keep it
+        # last and continue-on-error, so a Homebrew hiccup can never fail a
+        # release that is already tagged, published to npm and announced.
         #
-        # Deliberately the last step, and continue-on-error: by this point the
-        # version is tagged, published to npm and has a GitHub release, so a
-        # Homebrew hiccup (tap not reachable, workflow renamed, missing token, no
-        # `gh` on the runner) must not fail the release or hide what did succeed.
-        # Homebrew users keep the previous version until the bump is re-run from
-        # the tap's Actions tab; npm and Bun users are unaffected.
+        # The dispatched workflow points Formula/mcpc.rb at the new npm tarball,
+        # installs and `brew test`s it on Linux and macOS, then merges the bump.
+        # It polls the registry itself, so it tolerates publish propagation.
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
           VERSION: ${{ steps.release.outputs.version }}
         run: |
-          DISPATCH=(gh workflow run update_formula.yaml --repo apify/homebrew-tap
-            --field package=mcpc --field npm_package=@apify/mcpc --field version="$VERSION")
-          if "${DISPATCH[@]}"; then
-            echo "Dispatched the Homebrew formula update for ${VERSION}."
-          else
-            echo "::warning::Could not dispatch the Homebrew formula update for ${VERSION}. \
-            The npm release is unaffected — re-run the bump manually: ${DISPATCH[*]}"
-          fi
+          {
+            echo "### Homebrew"
+            echo ""
+            echo "The formula bump is manual for now. To ship \`${VERSION}\` to \`brew\`, run:"
+            echo ""
+            echo '```bash'
+            echo "gh workflow run update_formula.yaml --repo apify/homebrew-tap \\"
+            echo "  --field package=mcpc --field npm_package=@apify/mcpc --field version=${VERSION}"
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,6 +292,26 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Update Homebrew tap
+        if: inputs.type == 'release'
+        # apify/homebrew-tap owns the formula and its update flow: the dispatched
+        # workflow points Formula/mcpc.rb at the new npm tarball, installs and
+        # `brew test`s it on Linux and macOS, then merges the bump. It polls the
+        # registry itself, so it tolerates npm publish propagation.
+        #
+        # A failure here must not fail an already-published release — the bump can
+        # be re-run from the tap's Actions tab with the same inputs.
+        env:
+          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          DISPATCH=(gh workflow run update_formula.yaml --repo apify/homebrew-tap
+            --field package=mcpc --field npm_package=@apify/mcpc --field version="$VERSION")
+          if ! "${DISPATCH[@]}"; then
+            echo "::warning::Could not dispatch the Homebrew formula update for ${VERSION}. \
+            Re-run it manually: ${DISPATCH[*]}"
+          fi
+
       - name: Create GitHub release
         if: inputs.type == 'release'
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,26 +292,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Update Homebrew tap
-        if: inputs.type == 'release'
-        # apify/homebrew-tap owns the formula and its update flow: the dispatched
-        # workflow points Formula/mcpc.rb at the new npm tarball, installs and
-        # `brew test`s it on Linux and macOS, then merges the bump. It polls the
-        # registry itself, so it tolerates npm publish propagation.
-        #
-        # A failure here must not fail an already-published release — the bump can
-        # be re-run from the tap's Actions tab with the same inputs.
-        env:
-          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
-          VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          DISPATCH=(gh workflow run update_formula.yaml --repo apify/homebrew-tap
-            --field package=mcpc --field npm_package=@apify/mcpc --field version="$VERSION")
-          if ! "${DISPATCH[@]}"; then
-            echo "::warning::Could not dispatch the Homebrew formula update for ${VERSION}. \
-            Re-run it manually: ${DISPATCH[*]}"
-          fi
-
       - name: Create GitHub release
         if: inputs.type == 'release'
         uses: softprops/action-gh-release@v2
@@ -334,3 +314,31 @@ jobs:
             ${{ steps.install-size.outputs.report }}
         env:
           GITHUB_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+
+      # ── Homebrew tap (must never affect the release itself) ────────
+      - name: Update Homebrew tap
+        if: inputs.type == 'release'
+        # apify/homebrew-tap owns the formula and its update flow: the dispatched
+        # workflow points Formula/mcpc.rb at the new npm tarball, installs and
+        # `brew test`s it on Linux and macOS, then merges the bump. It polls the
+        # registry itself, so it tolerates npm publish propagation.
+        #
+        # Deliberately the last step, and continue-on-error: by this point the
+        # version is tagged, published to npm and has a GitHub release, so a
+        # Homebrew hiccup (tap not reachable, workflow renamed, missing token, no
+        # `gh` on the runner) must not fail the release or hide what did succeed.
+        # Homebrew users keep the previous version until the bump is re-run from
+        # the tap's Actions tab; npm and Bun users are unaffected.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          DISPATCH=(gh workflow run update_formula.yaml --repo apify/homebrew-tap
+            --field package=mcpc --field npm_package=@apify/mcpc --field version="$VERSION")
+          if "${DISPATCH[@]}"; then
+            echo "Dispatched the Homebrew formula update for ${VERSION}."
+          else
+            echo "::warning::Could not dispatch the Homebrew formula update for ${VERSION}. \
+            The npm release is unaffected — re-run the bump manually: ${DISPATCH[*]}"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- mcpc can now be installed with Homebrew on macOS and Linux: `brew install apify/tap/mcpc`. The formula brings its own Node.js, so no separate runtime setup is needed.
 - New `mcpc login <server> --grant id-jag` for MCP's [Enterprise-Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization) extension: sign in once with your corporate SSO (`--idp <issuer>`), and mcpc obtains MCP server tokens via identity assertion grants (ID-JAG) without per-server consent screens.
 - Support for MCP protocol version 2026-07-28: mcpc now probes each server with `server/discover` and talks the new stateless protocol when supported, falling back to older protocol versions (2025-11-25 down to 2024-10-07) automatically. Resource subscriptions use the new `subscriptions/listen` stream (with automatic re-listen on drops), and `ping` transparently uses `server/discover` on 2026-07-28 servers. mcpc now uses the official TypeScript SDK v2 (`@modelcontextprotocol/client`).
 - `mcpc --json` now reports each session's server `capabilities`, plus `hasInstructions` to tell whether the server provided instructions (read them with `mcpc --json @<session>`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -787,6 +787,8 @@ Before releasing:
 
 The script validates preconditions locally, then triggers the `release.yml` GitHub Actions workflow which handles: lint, build, test, version bump, changelog update, README update, git commit/tag/push, npm publish (with provenance), and GitHub release creation.
 
+A full release also dispatches the `update_formula.yaml` workflow in [apify/homebrew-tap](https://github.com/apify/homebrew-tap), which points `Formula/mcpc.rb` at the new npm tarball, installs and `brew test`s it on Linux and macOS, and merges the bump. The formula itself lives in the tap repository, not here; a failed dispatch only warns (the release is already published) and can be re-run from the tap's Actions tab.
+
 For pre-releases: `pnpm run release:pre` (or `pnpm run release:pre -- minor`)
 
 Monitor the release progress at the GitHub Actions URL that opens automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -787,7 +787,14 @@ Before releasing:
 
 The script validates preconditions locally, then triggers the `release.yml` GitHub Actions workflow which handles: lint, build, test, version bump, changelog update, README update, git commit/tag/push, npm publish (with provenance), and GitHub release creation.
 
-A full release also dispatches the `update_formula.yaml` workflow in [apify/homebrew-tap](https://github.com/apify/homebrew-tap), which points `Formula/mcpc.rb` at the new npm tarball, installs and `brew test`s it on Linux and macOS, and merges the bump. The formula itself lives in the tap repository, not here; a failed dispatch only warns (the release is already published) and can be re-run from the tap's Actions tab.
+The Homebrew formula lives in [apify/homebrew-tap](https://github.com/apify/homebrew-tap), not here, and its bump is **started manually for now** — the release workflow only prints the command in its run summary:
+
+```bash
+gh workflow run update_formula.yaml --repo apify/homebrew-tap \
+  --field package=mcpc --field npm_package=@apify/mcpc --field version=<version>
+```
+
+That workflow points `Formula/mcpc.rb` at the new npm tarball, installs and `brew test`s it on Linux and macOS, and merges the bump. Skipping it only leaves Homebrew users on the previous version; npm and Bun installs are unaffected.
 
 For pre-releases: `pnpm run release:pre` (or `pnpm run release:pre -- minor`)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ many AI agents on the same machine. Authenticate once, reuse everywhere.
 
 ## Install
 
-Requires a JavaScript runtime — install the latest [Node.js](https://nodejs.org/en/download) or [Bun](https://bun.sh) if you don't have one yet.
+With [Homebrew](https://brew.sh) (macOS and Linux), which brings its own Node.js:
+
+```bash
+brew install apify/tap/mcpc
+```
+
+Otherwise install the latest [Node.js](https://nodejs.org/en/download) or [Bun](https://bun.sh) first, then:
 
 ```bash
 npm install -g @apify/mcpc


### PR DESCRIPTION
Lets macOS and Linux users install mcpc with `brew install apify/tap/mcpc` instead of setting up Node.js or Bun first. The formula lives in [apify/homebrew-tap](https://github.com/apify/homebrew-tap) next to `apify-cli` (added in apify/homebrew-tap#55).

Its bump is started **manually for now** — the release workflow only prints the `gh workflow run` command in its run summary rather than dispatching it. That workflow points `Formula/mcpc.rb` at the new npm tarball, installs and `brew test`s it on Linux and macOS, then merges the bump.

- README documents Homebrew as the first install option
- Changelog entry, plus the manual bump command in the release section of `CLAUDE.md`
- The release step is last and `continue-on-error`, so nothing Homebrew-related can fail a release that is already tagged, published to npm and announced
- Skipping a bump only leaves Homebrew users on the previous version; npm and Bun installs are unaffected

Merge apify/homebrew-tap#55 before the first bump, otherwise there is no formula to update.

Fixes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcRjUSnuwKjKhQRgKQ1zzv