### PR TITLE
Fix x402 retries for tools without proactive metadata

### DIFF
--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -174,7 +174,7 @@ async function getOrSignPayment(
   paymentCache: X402PaymentCache,
   schemePreference?: SchemePreference
 ): Promise<string | undefined> {
-  if (!getToolByName || !init?.body) {
+  if (!init?.body) {
     return undefined;
   }
 
@@ -186,6 +186,18 @@ async function getOrSignPayment(
   // Parse the request body to find tools/call requests
   const toolName = extractToolCallName(init.body);
   if (!toolName) {
+    return undefined;
+  }
+
+  // The bridge can populate this cache after receiving a payment-required
+  // CallToolResult. That retry must not depend on proactive tools/list metadata:
+  // challenge-first servers may omit _meta.x402 entirely.
+  if (paymentCache.signature) {
+    logger.debug(`Using cached payment signature for tool "${toolName}"`);
+    return paymentCache.signature;
+  }
+
+  if (!getToolByName) {
     return undefined;
   }
 
@@ -201,12 +213,6 @@ async function getOrSignPayment(
   const x402 = meta?.x402;
   if (!x402 || !x402.paymentRequired) {
     return undefined;
-  }
-
-  // Return cached signature if available
-  if (paymentCache.signature) {
-    logger.debug(`Using cached payment signature for tool "${toolName}"`);
-    return paymentCache.signature;
   }
 
   const accept = selectAcceptFromToolMeta(x402, schemePreference);

--- a/test/unit/lib/x402/fetch-middleware.test.ts
+++ b/test/unit/lib/x402/fetch-middleware.test.ts
@@ -97,6 +97,31 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('createX402FetchMiddleware proactive sign', () => {
+  it('reuses a challenge-signed cache entry when the tool has no proactive x402 metadata', async () => {
+    const cachedPayload = {
+      x402Version: 2,
+      payload: { signature: '0xsig', authorization: { from: WALLET.address } },
+    };
+    const cachedSignature = Buffer.from(JSON.stringify(cachedPayload)).toString('base64');
+    const cache: X402PaymentCache = { signature: cachedSignature };
+    const baseFetch = vi.fn().mockResolvedValue(new Response('', { status: 200 }));
+    const fetchFn = createX402FetchMiddleware(baseFetch as never, {
+      wallet: WALLET,
+      getToolByName: () => undefined,
+      paymentCache: cache,
+      schemePreference: 'exact',
+    });
+
+    await fetchFn('https://example.test/mcp', { method: 'POST', body: toolsCallBody('paid-tool') });
+
+    expect(mockSignPayment).not.toHaveBeenCalled();
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+    const init = baseFetch.mock.calls[0]?.[1] as RequestInit;
+    expect(new Headers(init.headers).get('PAYMENT-SIGNATURE')).toBe(cachedSignature);
+    const body = JSON.parse(String(init.body));
+    expect(body.params._meta['x402/payment']).toEqual(cachedPayload);
+  });
+
   it('with schemePreference=exact and accepts=[exact, upto], signs exact', async () => {
     const tool = makePaidTool({ accepts: [EXACT_ACCEPT, UPTO_ACCEPT], ...UPTO_ACCEPT });
     const cache: X402PaymentCache = { signature: null };


### PR DESCRIPTION
## Problem

After a payment-required `CallToolResult`, the bridge signs a fresh payment and stores it in `paymentCache` before retrying the tool. `getOrSignPayment` currently checks the tool cache and `_meta.x402` before it checks that signed cache entry. Challenge-first servers that omit proactive x402 tool metadata therefore retry unpaid even though a fresh signature exists.

## Fix

Reuse a challenge-signed cache entry immediately after confirming that the outgoing request is a `tools/call`. Proactive signing still requires `_meta.x402`, and all non-tool requests remain unchanged.

The regression test covers a missing tool-metadata record and proves that the cached signature is attached to both `PAYMENT-SIGNATURE` and `_meta["x402/payment"]` without another signing call.

## Verification

- `pnpm run build`
- `pnpm run test:unit` (1007 tests passed)
- targeted x402 middleware test (10 tests passed)
- ESLint produced no errors; Prettier check passed