### PR TITLE
docs: add a live x402-priced MCP server to try the payment flow against

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,22 @@ mcpc x402 remove
 
 After creating a wallet, **fund it with USDC on Base** (mainnet or Sepolia testnet) to enable payments.
 
+### Try it against a live server
+
+[scrape402](https://x402.shizu.me) is an independently operated MCP server whose tools are priced via x402 (USDC on Base mainnet), so you can exercise the full payment flow against something real:
+
+```bash
+# Connect (no wallet needed yet — initialize and discovery are free)
+mcpc connect https://x402.shizu.me/mcp/rpc --x402
+
+# Free: list its tools
+mcpc @x402 tools-list
+
+# Paid: the tool answers with an x402 payment-required result, which mcpc
+# signs and retries automatically ($0.003 per call, settled on Base mainnet)
+mcpc @x402 tools-call crypto_price pair:=BTC-USD
+```
+
 ### Manual payment signing
 
 You can manually sign a payment from a server's `PAYMENT-REQUIRED` header using `x402 sign`.


### PR DESCRIPTION
The x402 section documents wallet setup and signing, but there is currently no server a reader can point mcpc at to watch the payment flow actually run. This adds a short "Try it against a live server" subsection with a working sequence: connect, free tools-list, and a paid tools-call that exercises the payment-required → sign → retry loop for real.

The server is scrape402 (https://x402.shizu.me/mcp/rpc), an MCP server whose data tools are priced per call via x402 (exact scheme, USDC on Base mainnet, $0.003/call). Tool calls without payment return the spec-shaped payment-required result with `accepts`, and tools advertise pricing in `_meta.x402` (accepts[] plus the flat fallback fields), so both your proactive-signing path and the retry path apply. Verified against mcpc 0.6.0: connect and tools-list work as shown; the snippet keeps the real cost visible so nobody is surprised by mainnet settlement.

Disclosure: I operate scrape402. If you'd rather point at a different live server, the section stands on its own — the value is that the docs demonstrate the feature end-to-end against something real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
