### PR TITLE
Fix OAuth refresh token persistence for non-rotating servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `mcpc help tools/list` and other MCP method names now show the command's help instead of failing with "Unknown command" — they already worked as aliases everywhere else.
 - x402 payments now work against servers that only reveal a tool's price when it is called: the payment signed for such a challenge is attached to the retried call, which used to go out unpaid and return the payment-required result again. The signature stays scoped to the tools the server charges for, so calls to free tools never carry a payment.
+- Sessions no longer lose their saved OAuth refresh token when a server that does not rotate refresh tokens omits `refresh_token` from the refresh response. The bridge used to overwrite the stored token with nothing, so the session could not authenticate after the access token expired and required a new `mcpc login`.
 
 ## [0.6.0] - 2026-08-02
 

--- a/src/lib/auth/oauth-token-manager.ts
+++ b/src/lib/auth/oauth-token-manager.ts
@@ -23,6 +23,11 @@ const EXPIRY_BUFFER_SECONDS = 60;
 /**
  * Callback invoked when tokens are refreshed
  * Allows callers to persist the new tokens (e.g., to keychain)
+ *
+ * `tokens.refresh_token` always carries the effective refresh token: the rotated
+ * one when the server returned a new one, otherwise the previous one. Callers can
+ * persist the whole object without erasing a refresh token that a non-rotating
+ * server omitted from the refresh response.
  */
 export type OnTokenRefreshCallback = (tokens: OAuthTokenResponse) => void | Promise<void>;
 
@@ -170,9 +175,11 @@ export class OAuthTokenManager {
 
       logger.debug(`Access token refreshed successfully for profile: ${this.profileName}`);
 
-      // Notify callback for persistence
+      // Notify callback for persistence. Pass the effective refresh token: a
+      // non-rotating server omits refresh_token from the response, and persisting
+      // the raw response would erase the stored one (#371).
       if (this.onTokenRefresh) {
-        await this.onTokenRefresh(tokenResponse);
+        await this.onTokenRefresh({ ...tokenResponse, refresh_token: this.refreshToken });
       }
 
       return tokenResponse;

--- a/test/unit/lib/auth/oauth-token-manager.test.ts
+++ b/test/unit/lib/auth/oauth-token-manager.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Unit tests for OAuthTokenManager token refresh and persistence callback
+ */
+
+import { vi } from 'vitest';
+import type { OAuthTokenResponse } from '../../../../src/lib/auth/oauth-utils.js';
+
+vi.mock('../../../../src/lib/auth/oauth-utils.js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../../../../src/lib/auth/oauth-utils.js')>();
+  return {
+    ...original,
+    discoverAndRefreshToken: vi.fn(),
+  };
+});
+
+import { discoverAndRefreshToken } from '../../../../src/lib/auth/oauth-utils.js';
+import { OAuthTokenManager } from '../../../../src/lib/auth/oauth-token-manager.js';
+
+const mockRefresh = vi.mocked(discoverAndRefreshToken);
+
+const makeManager = (overrides?: Partial<ConstructorParameters<typeof OAuthTokenManager>[0]>) =>
+  new OAuthTokenManager({
+    serverUrl: 'https://mcp.example.com',
+    profileName: 'default',
+    clientId: 'client-123',
+    refreshToken: 'original-refresh-token',
+    ...overrides,
+  });
+
+beforeEach(() => {
+  mockRefresh.mockReset();
+});
+
+describe('OAuthTokenManager refresh-token persistence (#371)', () => {
+  it('passes the previous refresh token to onTokenRefresh when the server omits it', async () => {
+    // Non-rotating servers return refresh_token only once, during initial auth
+    mockRefresh.mockResolvedValue({
+      access_token: 'new-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+    });
+
+    const persisted: OAuthTokenResponse[] = [];
+    const manager = makeManager({
+      onTokenRefresh: (tokens) => {
+        persisted.push(tokens);
+      },
+    });
+
+    await manager.refreshAccessToken();
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]?.refresh_token).toBe('original-refresh-token');
+    expect(persisted[0]?.access_token).toBe('new-access-token');
+  });
+
+  it('passes the rotated refresh token to onTokenRefresh when the server rotates it', async () => {
+    mockRefresh.mockResolvedValue({
+      access_token: 'new-access-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      refresh_token: 'rotated-refresh-token',
+    });
+
+    const persisted: OAuthTokenResponse[] = [];
+    const manager = makeManager({
+      onTokenRefresh: (tokens) => {
+        persisted.push(tokens);
+      },
+    });
+
+    await manager.refreshAccessToken();
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]?.refresh_token).toBe('rotated-refresh-token');
+  });
+
+  it('keeps using the preserved refresh token on subsequent refreshes', async () => {
+    mockRefresh.mockResolvedValue({
+      access_token: 'access-1',
+      token_type: 'Bearer',
+      // expires_in omitted and no rotation — worst case for state tracking
+    });
+
+    const manager = makeManager();
+    await manager.refreshAccessToken();
+    await manager.refreshAccessToken();
+
+    expect(mockRefresh).toHaveBeenCalledTimes(2);
+    expect(mockRefresh).toHaveBeenNthCalledWith(
+      2,
+      'https://mcp.example.com',
+      'original-refresh-token',
+      'client-123'
+    );
+  });
+
+  it('prefers a refresh token rotated by another process via onBeforeRefresh', async () => {
+    mockRefresh.mockResolvedValue({
+      access_token: 'new-access-token',
+      token_type: 'Bearer',
+    });
+
+    const persisted: OAuthTokenResponse[] = [];
+    const manager = makeManager({
+      onBeforeRefresh: async () => ({ refreshToken: 'externally-rotated-token' }),
+      onTokenRefresh: (tokens) => {
+        persisted.push(tokens);
+      },
+    });
+
+    await manager.refreshAccessToken();
+
+    expect(mockRefresh).toHaveBeenCalledWith(
+      'https://mcp.example.com',
+      'externally-rotated-token',
+      'client-123'
+    );
+    expect(persisted[0]?.refresh_token).toBe('externally-rotated-token');
+  });
+});


### PR DESCRIPTION
Sessions no longer lose their saved OAuth refresh token when a non-rotating server omits `refresh_token` from the refresh response. The bridge's persistence callback rebuilt the keychain record from the raw response, erasing the stored token, so the session required a new `mcpc login` once the access token expired.

- `OAuthTokenManager` now passes the effective refresh token (rotated or preserved) to the `onTokenRefresh` persistence callback, fixing the bridge and any future caller in one place
- Added unit tests for the token manager covering omitted, rotated, and externally rotated refresh tokens

Fixes #371

https://claude.ai/code/session_018RBge8dGQAm7PJ5ap6FY7M