### PR TITLE
Improve hint message for fetching tool details

### DIFF
--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -552,6 +552,7 @@ function formatToolsCompact(tools: Tool[], options?: FormatOptions): string {
   lines.push(
     `Before calling a tool, get its full details and schema by running: \`mcpc ${session}tools-get <name>\``
   );
+  lines.push(`To get full details for all tools, run: \`mcpc ${session}tools-list --full\``);
 
   return lines.join('\n');
 }

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -550,7 +550,7 @@ function formatToolsCompact(tools: Tool[], options?: FormatOptions): string {
   const session = options?.sessionName ? `${options.sessionName} ` : '';
   lines.push('');
   lines.push(
-    `For full tool details and schema, run \`mcpc ${session}tools-list --full\` or \`mcpc ${session}tools-get <name>\``
+    `Before calling a tool, get its full details and schema by running: \`mcpc ${session}tools-get <name>\``
   );
 
   return lines.join('\n');

--- a/test/e2e/suites/basic/human-output.test.sh
+++ b/test/e2e/suites/basic/human-output.test.sh
@@ -51,10 +51,10 @@ assert_success
 assert_contains "$STDOUT" "* \`"
 test_pass
 
-test_case "tools-list compact shows hint about --full"
+test_case "tools-list compact shows hint to fetch tool details"
 run_mcpc "$SESSION" tools-list
 assert_success
-assert_contains "$STDOUT" "--full"
+assert_contains "$STDOUT" "Before calling a tool"
 assert_contains "$STDOUT" "tools-get"
 test_pass
 
@@ -86,7 +86,7 @@ test_pass
 test_case "tools-list --full does NOT show hint"
 run_mcpc "$SESSION" tools-list --full
 assert_success
-assert_not_contains "$STDOUT" "Use \`tools-list --full\`"
+assert_not_contains "$STDOUT" "Before calling a tool"
 test_pass
 
 # =============================================================================

--- a/test/e2e/suites/basic/human-output.test.sh
+++ b/test/e2e/suites/basic/human-output.test.sh
@@ -56,6 +56,7 @@ run_mcpc "$SESSION" tools-list
 assert_success
 assert_contains "$STDOUT" "Before calling a tool"
 assert_contains "$STDOUT" "tools-get"
+assert_contains "$STDOUT" "tools-list --full"
 test_pass
 
 test_case "tools-list compact does NOT show Input section"

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -510,6 +510,7 @@ describe('formatTools', () => {
       const output = formatTools(sampleTools);
       expect(output).toContain('Before calling a tool');
       expect(output).toContain('tools-get <name>');
+      expect(output).toContain('tools-list --full');
     });
 
     it('should NOT show detailed input schema', () => {

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -506,9 +506,9 @@ describe('formatTools', () => {
       expect(output).toContain('[destructive]');
     });
 
-    it('should show hint about --full flag', () => {
+    it('should show hint to fetch tool details before calling', () => {
       const output = formatTools(sampleTools);
-      expect(output).toContain('tools-list --full');
+      expect(output).toContain('Before calling a tool');
       expect(output).toContain('tools-get <name>');
     });
 
@@ -545,9 +545,9 @@ describe('formatTools', () => {
       );
     });
 
-    it('should NOT show hint about --full flag', () => {
+    it('should NOT show hint about fetching tool details', () => {
       const output = formatTools(sampleTools, { full: true });
-      expect(output).not.toContain('tools-list --full');
+      expect(output).not.toContain('Before calling a tool');
     });
   });
 


### PR DESCRIPTION
Some AI agents saw the compact tool list hint as optional and called tools without fetching their schemas first. The hint (shown by `connect`, session info, and compact `tools-list`) now instructs: "Before calling a tool, get its full details and schema by running: `mcpc @session tools-get <name>`", with a second line pointing at `tools-list --full` for all-tool details.

- Reworded the hint in `formatToolsCompact` (`src/cli/output.ts`)
- Updated the unit and e2e tests asserting the old wording

https://claude.ai/code/session_016MJhXzu2yyHHZvHYWEtuzV