### PR TITLE
Test Bun against multiple versions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,14 @@ jobs:
         run: ./test/e2e/run.sh --no-build --parallel 6 --server-protocol modern
 
   e2e-bun:
-    name: E2E tests (Bun)
+    name: E2E tests (Bun ${{ matrix.bun-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Previous stable line and the current one — bump when a new minor ships.
+        bun-version: [1.3.x, 1.4.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -108,8 +113,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Bun
+      - name: Install Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install pnpm and dependencies
         uses: apify/actions/pnpm-install@v1.1.2

--- a/.github/workflows/e2e-linux.yml
+++ b/.github/workflows/e2e-linux.yml
@@ -60,9 +60,14 @@ jobs:
         run: ./test/e2e/run.sh --no-build --parallel 6 --server-protocol modern
 
   e2e-linux-bun:
-    name: E2E tests (Linux, Bun)
+    name: E2E tests (Linux, Bun ${{ matrix.bun-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Previous stable line and the current one — bump when a new minor ships.
+        bun-version: [1.3.x, 1.4.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -72,8 +77,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Bun
+      - name: Install Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install pnpm and dependencies
         uses: apify/actions/pnpm-install@v1.1.2

--- a/.github/workflows/e2e-macos.yml
+++ b/.github/workflows/e2e-macos.yml
@@ -30,9 +30,14 @@ jobs:
         run: ./test/e2e/run.sh --no-build --parallel 4
 
   e2e-macos-bun:
-    name: E2E tests (macOS, Bun)
+    name: E2E tests (macOS, Bun ${{ matrix.bun-version }})
     runs-on: macos-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Previous stable line and the current one — bump when a new minor ships.
+        bun-version: [1.3.x, 1.4.x]
 
     steps:
       - uses: actions/checkout@v6
@@ -42,8 +47,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Bun
+      - name: Install Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install pnpm and dependencies
         uses: apify/actions/pnpm-install@v1.1.2

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -33,9 +33,14 @@ jobs:
         run: ./test/e2e/run.sh --no-build --parallel 1
 
   e2e-windows-bun:
-    name: E2E tests (Windows, Bun)
+    name: E2E tests (Windows, Bun ${{ matrix.bun-version }})
     runs-on: windows-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Previous stable line and the current one — bump when a new minor ships.
+        bun-version: [1.3.x, 1.4.x]
     defaults:
       run:
         shell: bash
@@ -48,8 +53,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Install Bun
+      - name: Install Bun ${{ matrix.bun-version }}
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.bun-version }}
 
       - name: Install pnpm and dependencies
         uses: apify/actions/pnpm-install@v1.1.2


### PR DESCRIPTION
Bun 1.4.0 shipped on 2026-08-20, but all Bun e2e jobs installed an unpinned `setup-bun` (implicitly "latest"), so only whichever version happened to be newest was ever tested. Add an explicit `bun-version` matrix (`1.3.x` + `1.4.x`) to the Bun e2e jobs in ci.yml and the Linux/macOS/Windows release-gate workflows, mirroring the existing Node.js version matrix.

The `.x` ranges resolve to the newest patch of each line automatically; bump the matrix when a new Bun minor ships.

https://claude.ai/code/session_01QnfdeKF1PDXuWsrQny6MJC