### PR TITLE
docs: document npx fallback for mcpc skill

### DIFF
--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mcpc
 description: Use the mcpc CLI to work with MCP (Model Context Protocol) servers from the shell - connect to a server as a persistent session, then list and call tools, read resources, get prompts, and run async tasks. Use --json for scripting and code mode. Reach for this whenever interacting with MCP servers, calling MCP tools, or accessing MCP resources programmatically.
-allowed-tools: Bash(mcpc:*), Read, Grep
+allowed-tools: Bash(mcpc:*), Bash(npx @apify/mcpc:*), Read, Grep
 ---
 
 # mcpc: MCP command-line client
@@ -9,6 +9,16 @@ allowed-tools: Bash(mcpc:*), Read, Grep
 `mcpc` maps every MCP operation to a shell command. For agents this is often more
 efficient than function calling: discover the right tool on demand, then generate
 shell commands (ideally with `--json`) instead of carrying tool definitions in context.
+
+The examples below use `mcpc` as a command on `PATH`. If it is not installed globally
+or otherwise available, use the published package through `npx` instead:
+
+```bash
+npx @apify/mcpc@latest --help
+```
+
+After checking the help, prefix the commands below with `npx @apify/mcpc`
+(for example, `npx @apify/mcpc connect ...`).
 
 ## Mental model
 

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -14,7 +14,7 @@ The examples below use `mcpc` as a command on `PATH`. If it is not installed glo
 or otherwise available, use the published package through `npx` instead:
 
 ```bash
-npx @apify/mcpc@latest --help
+npx -y @apify/mcpc@latest --help
 ```
 
 After checking the help, prefix the commands below with `npx @apify/mcpc`


### PR DESCRIPTION
## Summary

- Document the `npx @apify/mcpc@latest --help` fallback when `mcpc` is not available on `PATH`.
- Explain how to prefix the remaining examples with `npx @apify/mcpc@latest`.
- Allow the npx invocation in the skill's `allowed-tools` metadata.

## Validation

- `npx @apify/mcpc@latest --help`
- `git diff --check`