### PR TITLE
Stop opening the OAuth authorization URL through cmd.exe on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sessions no longer get stuck reconnecting forever after a server upgrades to MCP 2026-07-28: a reconnect replayed the stored session ID, which made the client skip protocol negotiation and the server reject every request. Stale session IDs are now dropped (2026-07-28 has no session resumption), and a session whose server no longer speaks its protocol version is marked expired with a hint to run `restart`.
 - Sessions no longer lose their saved OAuth refresh token when a server that does not rotate refresh tokens omits `refresh_token` from the refresh response. The bridge used to overwrite the stored token with nothing, so the session could not authenticate after the access token expired and required a new `mcpc login`.
 
+### Security
+
+- `mcpc login` no longer opens the authorization URL through `cmd.exe` on Windows. The URL comes from the authorization server, and `cmd.exe` treated `&`, `|`, `^` and `%VAR%` inside it as commands, so a malicious or compromised server could run arbitrary commands when you pressed Enter to open the browser (and even a benign URL was cut off at its first `&`). The browser is now launched without any shell on all platforms, and authorization URLs with a scheme other than `http:`/`https:` are refused.
+
 ## [0.6.0] - 2026-08-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -291,7 +291,7 @@ Implements [MCP security best practices](https://modelcontextprotocol.io/specifi
 - Input validation for session names, profile names, and URLs (strict regex, no path traversal)
 - URL normalization strips username, password, and hash
 - HTML output in OAuth callback is escaped to prevent XSS
-- Browser opening uses `execFile()` (not `exec()`) to avoid shell injection
+- Browser opening uses `execFile()` with a non-shell launcher on every platform (`open`, `rundll32 url.dll,FileProtocolHandler`, `xdg-open` — never `cmd.exe /c start`, which interprets `&`/`|`/`^`/`%VAR%` inside the server-supplied URL), and only `http:`/`https:` authorization URLs are opened
 
 **Filesystem security:**
 

--- a/docs/security-review-2026-09.md
+++ b/docs/security-review-2026-09.md
@@ -10,7 +10,7 @@ mcpc gets the big things right: credentials live in the OS keychain, headers tra
 
 The gaps cluster in five places:
 
-1. **A shell on the OAuth path on Windows.** The authorization URL, which the server controls, is handed to `cmd.exe /c start`. That is command injection on `mcpc login`.
+1. **A shell on the OAuth path on Windows** (fixed in #382). The authorization URL, which the server controls, is handed to `cmd.exe /c start`. That is command injection on `mcpc login`.
 2. **x402 pays whatever the server asks.** No spending cap, no asset allowlist, no expiry clamp, an automatic unlimited Permit2 approval for a server-chosen token, and payments are invisible outside debug logs. Once `--x402` is set on a session, every later agent tool call pays.
 3. **Config files are trusted more than they should be.** A bare `mcpc connect` reads project-directory configs, expands any `${VAR}` into headers or URLs, and connects HTTP entries without confirmation. A cloned repo can exfiltrate environment secrets.
 4. **The "no credentials in logs or argv" guarantee has holes.** Substituted headers are debug-printed, stdio `env`/`args` secrets go into bridge argv, the bridge log banner, `sessions.json` and `mcpc --json`, and the bridge log receives every debug line regardless of `--verbose`.
@@ -25,6 +25,8 @@ Severity scale: **High** = exploitable by a remote server or a malicious repo wi
 ## High
 
 ### H1. Windows browser launch goes through `cmd.exe` with a server-controlled URL
+
+**Status: fixed** in [#382](https://github.com/apify/mcpc/pull/382). The browser is now launched via `rundll32 url.dll,FileProtocolHandler` on Windows (no shell on any platform), non-`http(s)` authorization URLs are refused before they are shown or opened, and unit tests assert the launcher command is never a shell.
 
 - `src/lib/auth/oauth-flow.ts:423-427`: `execFile('cmd.exe', ['/c', 'start', '""', url])`.
 - The URL is built by the SDK from the authorization server's `authorization_endpoint` (`node_modules/@modelcontextprotocol/client/dist/index.mjs:1144`, `new URL(metadata.authorization_endpoint)` with no scheme check). The metadata comes from whatever server the user typed into `mcpc login`, or from the protected-resource metadata that server points to. Same code path for `login --grant id-jag`.

--- a/src/lib/auth/oauth-flow.ts
+++ b/src/lib/auth/oauth-flow.ts
@@ -404,31 +404,69 @@ async function findAvailablePort(ports: readonly number[]): Promise<number> {
 }
 
 /**
- * Open a URL in the default browser
- * Uses platform-specific commands
- * Returns true if the browser was opened successfully, false otherwise
+ * Reject authorization URLs that are not plain `http:`/`https:` before they are
+ * shown to the user or handed to the browser launcher.
+ *
+ * The URL comes from the authorization server's metadata, i.e. from whatever
+ * server the user typed into `mcpc login` (or a server it pointed to). The MCP
+ * security best practices require clients to only open `http://` and
+ * `https://` authorization URLs — anything else (`javascript:`, `file:`,
+ * custom app schemes) must never reach the OS URL handler.
  */
-async function tryOpenBrowser(url: string): Promise<boolean> {
+export function assertHttpAuthorizationUrl(url: URL): void {
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new AuthError(
+      `Authorization server returned an authorization URL with unsupported scheme "${url.protocol}" ` +
+        '(only http: and https: are allowed). Refusing to open it.'
+    );
+  }
+}
+
+/**
+ * Build the platform command that opens `url` in the default browser.
+ *
+ * Exported for tests. Two invariants are enforced here and guarded by unit
+ * tests, because the URL is server-controlled:
+ *
+ * - The URL must be `http:`/`https:` (see `assertHttpAuthorizationUrl`).
+ * - The command is never a shell. In particular, Windows must not use
+ *   `cmd.exe /c start`: libuv only quotes arguments containing whitespace or
+ *   double quotes, so `&`, `|`, `^` and `%VAR%` in a URL reach `cmd.exe`
+ *   unescaped and are interpreted as commands. `rundll32 url.dll,FileProtocolHandler`
+ *   hands the URL straight to the shell-execute API (the approach used by the
+ *   GitHub CLI and Go's `pkg/browser`), with no command interpreter in between.
+ */
+export function getBrowserOpenCommand(
+  url: URL,
+  platform: NodeJS.Platform = process.platform
+): { command: string; args: string[] } {
+  assertHttpAuthorizationUrl(url);
+  // WHATWG URL serialisation percent-encodes whitespace and double quotes, so the
+  // string is always a single, unambiguous argument for the launcher.
+  const target = url.toString();
+
+  if (platform === 'darwin') {
+    return { command: 'open', args: [target] };
+  }
+  if (platform === 'win32') {
+    return { command: 'rundll32', args: ['url.dll,FileProtocolHandler', target] };
+  }
+  return { command: 'xdg-open', args: [target] };
+}
+
+/**
+ * Open a URL in the default browser
+ * Uses platform-specific commands (see `getBrowserOpenCommand`)
+ * Returns true if the browser was opened successfully, false otherwise.
+ * Throws if the URL is not http(s) — that is a bad server, not a missing browser,
+ * so it must not fall back to "paste this URL into your browser".
+ */
+async function tryOpenBrowser(url: URL): Promise<boolean> {
+  const { command, args } = getBrowserOpenCommand(url);
+
   const { execFile } = await import('child_process');
   const { promisify } = await import('util');
   const execFileAsync = promisify(execFile);
-
-  const platform = process.platform;
-  let command: string;
-  let args: string[];
-
-  if (platform === 'darwin') {
-    command = 'open';
-    args = [url];
-  } else if (platform === 'win32') {
-    // On Windows, use cmd.exe /c start to open URLs.
-    // The empty "" is the window title argument required by 'start' when the target contains special characters.
-    command = 'cmd.exe';
-    args = ['/c', 'start', '""', url];
-  } else {
-    command = 'xdg-open';
-    args = [url];
-  }
 
   try {
     await execFileAsync(command, args);
@@ -569,6 +607,10 @@ export async function runInteractiveAuthorization(
       });
     });
 
+    // Refuse non-http(s) URLs before showing them — the user would otherwise
+    // be invited to paste them into a browser if the launcher fails.
+    assertHttpAuthorizationUrl(authorizationUrl);
+
     // Interactive chatter goes to stderr so stdout stays clean for --json output.
     console.error(`\nAuthorization URL: ${authorizationUrl.toString()}`);
     const confirmed = await waitForEnterKey(
@@ -579,7 +621,7 @@ export async function runInteractiveAuthorization(
     }
 
     console.error('Opening browser...');
-    const opened = await tryOpenBrowser(authorizationUrl.toString());
+    const opened = await tryOpenBrowser(authorizationUrl);
 
     const racers: Promise<CallbackResult>[] = [codePromise];
     if (opened) {
@@ -742,6 +784,10 @@ export async function performOAuthFlow(
         authorizationUrl.searchParams.set('state', randomBytes(16).toString('hex'));
       }
 
+      // Refuse non-http(s) URLs before showing them — the user would otherwise
+      // be invited to paste them into a browser if the launcher fails.
+      assertHttpAuthorizationUrl(authorizationUrl);
+
       logger.debug('Opening browser for authorization...');
       // Interactive chatter goes to stderr so stdout stays clean for --json output.
       console.error(`\nAuthorization URL: ${authorizationUrl.toString()}`);
@@ -755,7 +801,7 @@ export async function performOAuthFlow(
       }
 
       console.error('Opening browser...');
-      const opened = await tryOpenBrowser(authorizationUrl.toString());
+      const opened = await tryOpenBrowser(authorizationUrl);
 
       if (opened) {
         console.error('If the browser does not open automatically, please visit the URL above.');

--- a/test/unit/lib/auth/oauth-flow.test.ts
+++ b/test/unit/lib/auth/oauth-flow.test.ts
@@ -4,7 +4,11 @@
 
 import { OAuthError, OAuthErrorCode } from '@modelcontextprotocol/client';
 import { validateClientMetadataUrl } from '../../../../src/lib/auth/oauth-utils.js';
-import { explainOAuthRegistrationFailure } from '../../../../src/lib/auth/oauth-flow.js';
+import {
+  assertHttpAuthorizationUrl,
+  explainOAuthRegistrationFailure,
+  getBrowserOpenCommand,
+} from '../../../../src/lib/auth/oauth-flow.js';
 import { AuthError } from '../../../../src/lib/errors.js';
 
 describe('explainOAuthRegistrationFailure', () => {
@@ -191,5 +195,84 @@ describe('validateClientMetadataUrl', () => {
 
   it('accepts a URL with a query string', () => {
     expect(() => validateClientMetadataUrl('https://example.com/client.json?v=1')).not.toThrow();
+  });
+});
+
+describe('getBrowserOpenCommand', () => {
+  const platforms: NodeJS.Platform[] = ['darwin', 'win32', 'linux', 'freebsd', 'openbsd', 'sunos'];
+  // The authorization URL is server-controlled, so cmd.exe-style metacharacters are
+  // realistic input: `&` and `|` would be command separators under `cmd.exe /c start`.
+  const hostile = new URL('https://evil.example/authorize?client_id=1&calc|whoami^%PATH%#frag');
+
+  it.each(platforms)('never launches a shell or command interpreter on %s', (platform) => {
+    const { command } = getBrowserOpenCommand(hostile, platform);
+    expect(command).not.toMatch(/cmd(\.exe)?$/i);
+    expect(command).not.toMatch(/powershell|pwsh/i);
+    expect(command).not.toMatch(/(^|\/)(ba|z|da)?sh$/);
+    expect(command).not.toMatch(/^start$/i);
+  });
+
+  it.each(platforms)('passes the URL through verbatim as a single argument on %s', (platform) => {
+    const { args } = getBrowserOpenCommand(hostile, platform);
+    expect(args[args.length - 1]).toBe(hostile.toString());
+    expect(args.filter((a) => a.includes('evil.example'))).toHaveLength(1);
+  });
+
+  it('uses rundll32 url.dll,FileProtocolHandler on Windows', () => {
+    expect(getBrowserOpenCommand(new URL('https://auth.example/authorize'), 'win32')).toEqual({
+      command: 'rundll32',
+      args: ['url.dll,FileProtocolHandler', 'https://auth.example/authorize'],
+    });
+  });
+
+  it('uses open on macOS and xdg-open elsewhere', () => {
+    const url = new URL('https://auth.example/authorize?x=1');
+    expect(getBrowserOpenCommand(url, 'darwin')).toEqual({
+      command: 'open',
+      args: [url.toString()],
+    });
+    expect(getBrowserOpenCommand(url, 'linux')).toEqual({
+      command: 'xdg-open',
+      args: [url.toString()],
+    });
+  });
+
+  it('serialises whitespace and quotes so the argument cannot be split or re-quoted', () => {
+    const url = new URL('https://auth.example/authorize?redirect="x y"');
+    const { args } = getBrowserOpenCommand(url, 'win32');
+    expect(args[1]).not.toMatch(/[\s"]/);
+    expect(args[1]).toBe('https://auth.example/authorize?redirect=%22x%20y%22');
+  });
+
+  it.each(['http://127.0.0.1:8080/authorize', 'https://auth.example/authorize'])(
+    'accepts %s',
+    (url) => {
+      expect(() => getBrowserOpenCommand(new URL(url), 'linux')).not.toThrow();
+    }
+  );
+
+  it.each([
+    'javascript:alert(1)',
+    'file:///etc/passwd',
+    'ms-msdt:/id PCWDiagnostic',
+    'ftp://auth.example/authorize',
+    'mailto:victim@example.com',
+  ])('rejects the non-http(s) authorization URL %s on every platform', (url) => {
+    for (const platform of platforms) {
+      expect(() => getBrowserOpenCommand(new URL(url), platform)).toThrow(AuthError);
+    }
+  });
+});
+
+describe('assertHttpAuthorizationUrl', () => {
+  it('names the offending scheme and refuses to open it', () => {
+    expect(() => assertHttpAuthorizationUrl(new URL('javascript:alert(1)'))).toThrow(
+      /unsupported scheme "javascript:".*Refusing to open/
+    );
+  });
+
+  it('allows http and https', () => {
+    expect(() => assertHttpAuthorizationUrl(new URL('http://localhost/a'))).not.toThrow();
+    expect(() => assertHttpAuthorizationUrl(new URL('https://a.example/b'))).not.toThrow();
   });
 });


### PR DESCRIPTION
`mcpc login` handed the server-supplied authorization URL to `cmd.exe /c start` on Windows. libuv only quotes arguments with whitespace or double quotes, so `&`, `|`, `^` and `%VAR%` in the URL ran as commands once the user pressed Enter, and even a benign URL was cut off at its first `&`. The browser is now launched without any shell, and non-http(s) authorization URLs are refused.

- Windows uses `rundll32 url.dll,FileProtocolHandler <url>` (same approach as the GitHub CLI); macOS and Linux keep `open` / `xdg-open`.
- Authorization URLs with a scheme other than `http:`/`https:` are rejected in both login flows before they are printed or opened.
- The launcher command is built by a pure exported function with unit tests asserting no shell binary is ever used and hostile URLs pass through as one verbatim argument.
- Changelog `Security` entry and CLAUDE.md security note updated.

Not exercised on Windows itself; the reasoning follows libuv's quoting rules and the rundll32 precedent.

Fixes H1 in docs/security-review-2026-09.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbTS6Mvbo9t5115trQQm6j