### PR TITLE
fix(cli): hint when structured tool content is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Human-readable `tools-call` and `tasks-result` output now hints when structured data is hidden behind other content and points to `--json` to retrieve the full result. (#346)
 - `mcpc help tools/list` and other MCP method names now show the command's help instead of failing with "Unknown command" — they already worked as aliases everywhere else.
 - x402 payments now work against servers that only reveal a tool's price when it is called: the payment signed for such a challenge is attached to the retried call, which used to go out unpaid and return the payment-required result again. The signature stays scoped to the tools the server charges for, so calls to free tools never carry a payment.
 - Sessions no longer get stuck reconnecting forever after a server upgrades to MCP 2026-07-28: a reconnect replayed the stored session ID, which made the client skip protocol negotiation and the server reject every request. Stale session IDs are now dropped (2026-07-28 has no session resumption), and a session whose server no longer speaks its protocol version is marked expired with a hint to run `restart`.

--- a/README.md
+++ b/README.md
@@ -985,8 +985,9 @@ server's current tools.
 - **Safety annotations**: `read-only`, `destructive`, `idempotent`, and `open-world` hints are shown
   right next to each tool, so a human or an agent can tell a harmless query from a dangerous mutation
   before calling it.
-- **Structured output**: `structuredContent` is pretty-printed as JSON and output schemas are shown
-  with `--full`, so scripts can rely on machine-readable results, not just text.
+- **Structured output**: tool results show `structuredContent` as JSON when no other content remains
+  after removing duplicate text blocks. Otherwise a hint points to `--json`, which includes the full
+  result. Output schemas are shown with `tools-list --full` and `tools-get`.
 - **Rich result content**: text, images, audio, and [resource links or embedded resources](#resources)
   in tool results are all rendered (binary is summarized, never dumped to your terminal).
 - **Async tasks**: long-running tools can run in the background as [async tasks](#async-tasks); each

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -140,9 +140,14 @@ echo '{"query":"hello"}' | mcpc @apify tools-call search
 Add `--json` for machine-readable output: results on stdout, errors on stderr,
 shaped strictly per the MCP spec.
 
+Human-readable tool results omit text blocks that duplicate `structuredContent`.
+When other content remains, a hint points to `--json` for the structured data;
+otherwise it is printed directly. JSON output always includes the full result.
+
 ```bash
 mcpc --json @apify tools-list | jq -r '.[].name'
 mcpc --json @apify tools-call search query:="test" | jq -r '.content[0].text'
+mcpc --json @apify tools-call search query:="test" | jq '.structuredContent'
 
 # chain tools across calls/sessions
 mcpc --json @apify tools-call search-actors keywords:="scraper" \

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1319,9 +1319,8 @@ function findDuplicateTextBlocks(
  * 1. **Content:** — each content block rendered per its type (text blocks
  *    that duplicate `structuredContent` are omitted)
  * 2. **Structured content:** — `structuredContent` as syntax-highlighted JSON,
- *    shown only when there is no visible Content (otherwise it duplicates
- *    information already present and adds noise for LLM consumers; use
- *    `--json` to always get the full payload)
+ *    shown only when there is no visible Content. Otherwise a hint points to
+ *    `--json`, which always includes the full payload.
  * 3. **Metadata:** — `_meta` as syntax-highlighted JSON
  */
 export function formatCallToolResultHuman(result: CallToolResult): string {
@@ -1362,6 +1361,13 @@ export function formatCallToolResultHuman(result: CallToolResult): string {
     lines.push(chalk.bold('Structured content:'));
     const scJson = JSON.stringify(sc, null, 2);
     lines.push(process.stdout.isTTY ? highlightJson(scJson) : scJson);
+  } else if (hasStructuredContent) {
+    lines.push(
+      '',
+      chalk.dim(
+        'Structured content is also available. Use --json to see the structuredContent field.'
+      )
+    );
   }
 
   // Metadata section — syntax-highlighted JSON, shown last

--- a/test/unit/cli/output.test.ts
+++ b/test/unit/cli/output.test.ts
@@ -52,6 +52,7 @@ import {
   formatSkillDetail,
   formatSessionLine,
   formatHuman,
+  formatOutput,
   logTarget,
   formatToolCallExample,
   formatToolHints,
@@ -2350,6 +2351,7 @@ describe('formatCallToolResultHuman', () => {
     expect(output).toContain('Content:');
     expect(output).toContain('````');
     expect(output).toContain('Hello world');
+    expect(output).not.toContain('--json');
   });
 
   it('should format multiple text content blocks separately', () => {
@@ -2398,19 +2400,22 @@ describe('formatCallToolResultHuman', () => {
     expect(output).toContain('Structured content:');
     expect(output).toContain('"key"');
     expect(output).toContain('"value"');
+    expect(output).not.toContain('--json');
   });
 
-  it('should skip structuredContent when visible Content is present', () => {
+  it('should hint how to retrieve structuredContent when visible Content is present', () => {
     const result = {
       content: [{ type: 'text' as const, text: 'data' }],
       structuredContent: { key: 'value' },
     };
     const output = formatCallToolResultHuman(result);
-    // Content already conveys the result — Structured content is redundant
-    // verbose output and is suppressed (use --json for the full payload).
     expect(output).toContain('Content:');
     expect(output).toContain('data');
-    expect(output).not.toContain('Structured content');
+    expect(output).toContain(
+      'Structured content is also available. Use --json to see the structuredContent field.'
+    );
+    expect(output).not.toContain('"key"');
+    expect(output).not.toContain('"value"');
   });
 
   it('should not show structuredContent section when empty', () => {
@@ -2453,7 +2458,9 @@ describe('formatCallToolResultHuman', () => {
     const output = formatCallToolResultHuman(result);
     expect(output).toContain('Content:');
     expect(output).toContain('summary');
-    expect(output).not.toContain('Structured content');
+    expect(output).toContain('--json');
+    expect(output).toContain('structuredContent');
+    expect(output).not.toContain('Structured content:');
   });
 
   it('should treat a null structuredContent as absent (SEP-2106)', () => {
@@ -2477,6 +2484,7 @@ describe('formatCallToolResultHuman', () => {
     expect(output).not.toContain('Content:');
     expect(output).toContain('Structured content:');
     expect(output).toContain('"results"');
+    expect(output).not.toContain('--json');
   });
 
   it('should skip duplicate text block even when pretty-printed', () => {
@@ -2498,7 +2506,8 @@ describe('formatCallToolResultHuman', () => {
     const output = formatCallToolResultHuman(result);
     expect(output).toContain('Content:');
     expect(output).toContain('Human-readable summary');
-    expect(output).not.toContain('Structured content');
+    expect(output).toContain('--json');
+    expect(output).not.toContain('"results"');
   });
 
   it('should show structuredContent when there are no content blocks', () => {
@@ -2523,10 +2532,55 @@ describe('formatCallToolResultHuman', () => {
     };
     const output = formatCallToolResultHuman(result);
     // The first text block (non-matching) is kept; the JSON duplicate is omitted.
-    // Since visible Content remains, Structured content is suppressed too.
+    // Since visible Content remains, show a retrieval hint for the structured data.
     expect(output).toContain('Content:');
     expect(output).toContain('Summary');
-    expect(output).not.toContain('Structured content');
+    expect(output).toContain('--json');
+    expect(output).toContain('structuredContent');
+    expect(output).not.toContain('"key"');
+    expect(output.match(/````/g)).toHaveLength(2);
+  });
+
+  it.each([0, false, '', ['a', 'b']].map((structuredContent) => ({ structuredContent })))(
+    'should hint about non-object structuredContent $structuredContent alongside visible content',
+    ({ structuredContent }) => {
+      const output = formatCallToolResultHuman({
+        content: [{ type: 'text', text: 'Summary' }],
+        structuredContent,
+      });
+      expect(output).toContain('Summary');
+      expect(output).toContain('--json');
+      expect(output).toContain('structuredContent');
+      expect(output).not.toContain('Structured content:');
+    }
+  );
+
+  it('should hint about structuredContent alongside non-text content', () => {
+    const output = formatCallToolResultHuman({
+      content: [{ type: 'image', data: 'aGVsbG8=', mimeType: 'image/png' }],
+      structuredContent: { caption: 'An image' },
+    });
+    expect(output).toContain('[Image: image/png');
+    expect(output).toContain('--json');
+    expect(output).toContain('structuredContent');
+    expect(output).not.toContain('"caption"');
+  });
+
+  it('should preserve the full JSON result after hiding duplicate text in human output', () => {
+    const result = {
+      content: [
+        { type: 'text' as const, text: 'Summary' },
+        { type: 'text' as const, text: '{"answer":42}' },
+      ],
+      structuredContent: { answer: 42 },
+      _meta: { cost: 0.01 },
+      isError: true,
+    };
+    const expectedJson = JSON.stringify(result);
+    const human = formatCallToolResultHuman(result);
+    expect(human).toContain('--json');
+    expect(human).not.toContain('"answer"');
+    expect(JSON.parse(formatOutput(result, 'json'))).toEqual(JSON.parse(expectedJson));
   });
 
   it('should format resource_link content blocks', () => {
@@ -2626,11 +2680,12 @@ describe('formatCallToolResultHuman', () => {
     expect(output).toContain('Resource link');
     expect(output).toContain('Metadata:');
     expect(output).toContain('"cost"');
-    // Structured content is redundant when Content already conveys the result
-    expect(output).not.toContain('Structured content');
+    expect(output).toContain('--json');
+    expect(output).not.toContain('"parsed"');
 
-    // Correct ordering: Content → Metadata
-    expect(output.indexOf('Content:')).toBeLessThan(output.indexOf('Metadata:'));
+    // Correct ordering: Content → structured content hint → Metadata
+    expect(output.indexOf('Content:')).toBeLessThan(output.indexOf('--json'));
+    expect(output.indexOf('--json')).toBeLessThan(output.indexOf('Metadata:'));
   });
 
   it('should show Structured content and Metadata when content is empty', () => {


### PR DESCRIPTION
`tools-call` and `tasks-result` now show a concise `--json` hint when human output hides `structuredContent`. Existing duplicate-text filtering is retained; regression coverage, README, agent skill, and changelog are updated.

Reproduced on `eb954d6` with a local stdio tool returning a summary plus serialized structured data: human output showed only the summary; `--json` retained both fields.

Validation:
- `pnpm exec vitest run test/unit/cli/output.test.ts`: 189 passed, including checks that failed on the original formatter.
- `pnpm run lint` (0 errors, 6 existing warnings), `pnpm run build`, and `pnpm run check:reference` passed.
- `./test/e2e/run.sh --no-build --parallel 3 basic/help.test.sh basic/human-output.test.sh basic/output-invariants.test.sh` passed; local CLI JSON/verbose and skill checks passed under Node and Bun.
- `pnpm test`: 1,055 unit tests; E2E Node legacy 51 passed/1 skipped, Node modern 47/5, Bun legacy 51/1. All skips are existing protocol-specific exclusions.

Fixes #346
