### PR TITLE
fix(ipc): preserve UTF-8 across socket chunks

### DIFF
--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -78,6 +78,7 @@ import type { ProxyConfig } from '../lib/types.js';
 import type { X402PaymentCache } from '../lib/x402/fetch-middleware.js';
 import type { SignerWallet } from '../lib/x402/signer.js';
 import type { FetchLike } from '@modelcontextprotocol/client';
+import { IpcLineBuffer } from '../lib/ipc-line-buffer.js';
 
 // HTTP proxy and TLS settings are configured in main() after parsing --insecure flag
 
@@ -1245,10 +1246,10 @@ class BridgeProcess {
     logger.debug('New client connected');
     this.connections.add(socket);
 
-    let buffer = '';
+    const buffer = new IpcLineBuffer();
 
     socket.on('data', (data) => {
-      buffer += data.toString();
+      buffer.append(data);
 
       if (buffer.length > MAX_BUFFER_SIZE) {
         logger.error(`IPC buffer exceeded ${MAX_BUFFER_SIZE} bytes, destroying socket`);
@@ -1258,11 +1259,7 @@ class BridgeProcess {
       }
 
       // Process complete JSON messages (newline-delimited)
-      let newlineIndex: number;
-      while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
-        const line = buffer.slice(0, newlineIndex);
-        buffer = buffer.slice(newlineIndex + 1);
-
+      for (const line of buffer.drainLines()) {
         if (line.trim()) {
           this.handleMessage(socket, line).catch((error) => {
             logger.error('Error handling message:', error);

--- a/src/lib/bridge-client.ts
+++ b/src/lib/bridge-client.ts
@@ -21,6 +21,7 @@ import type { IpcMessage, TaskUpdate, X402WalletCredentials } from './types.js';
 import { createLogger } from './logger.js';
 import { NetworkError, ClientError, ServerError, AuthError, IpcTimeoutError } from './errors.js';
 import { generateRequestId, sleep } from './utils.js';
+import { IpcLineBuffer } from './ipc-line-buffer.js';
 
 const logger = createLogger('bridge-client');
 
@@ -64,7 +65,7 @@ const MAX_BUFFER_SIZE = 10 * 1024 * 1024;
 export class BridgeClient extends EventEmitter {
   private socket: Socket | null = null;
   private socketPath: string;
-  private buffer = '';
+  private buffer = new IpcLineBuffer();
   private pendingRequests = new Map<
     string,
     {
@@ -175,7 +176,7 @@ export class BridgeClient extends EventEmitter {
     if (!this.socket) return;
 
     this.socket.on('data', (data) => {
-      this.buffer += data.toString();
+      this.buffer.append(data);
 
       if (this.buffer.length > MAX_BUFFER_SIZE) {
         logger.error(`IPC buffer exceeded ${MAX_BUFFER_SIZE} bytes, destroying socket`);
@@ -185,11 +186,7 @@ export class BridgeClient extends EventEmitter {
       }
 
       // Process complete JSON messages (newline-delimited)
-      let newlineIndex: number;
-      while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
-        const line = this.buffer.slice(0, newlineIndex);
-        this.buffer = this.buffer.slice(newlineIndex + 1);
-
+      for (const line of this.buffer.drainLines()) {
         if (line.trim()) {
           try {
             const message = JSON.parse(line) as IpcMessage;
@@ -374,6 +371,6 @@ export class BridgeClient extends EventEmitter {
       this.socket = null;
     }
 
-    this.buffer = '';
+    this.buffer.clear();
   }
 }

--- a/src/lib/ipc-line-buffer.ts
+++ b/src/lib/ipc-line-buffer.ts
@@ -1,0 +1,38 @@
+import { StringDecoder } from 'node:string_decoder';
+
+/**
+ * Incrementally decodes UTF-8 IPC chunks and extracts newline-delimited frames.
+ *
+ * Buffer boundaries do not necessarily align with UTF-8 code points. Keeping one
+ * decoder per connection prevents a split multibyte character from being replaced
+ * before the complete JSON frame is assembled.
+ */
+export class IpcLineBuffer {
+  private decoder = new StringDecoder('utf8');
+  private buffer = '';
+
+  append(chunk: Buffer | string): void {
+    this.buffer += typeof chunk === 'string' ? chunk : this.decoder.write(chunk);
+  }
+
+  get length(): number {
+    return this.buffer.length;
+  }
+
+  drainLines(): string[] {
+    const lines: string[] = [];
+    let newlineIndex: number;
+
+    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+      lines.push(this.buffer.slice(0, newlineIndex));
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+    }
+
+    return lines;
+  }
+
+  clear(): void {
+    this.decoder = new StringDecoder('utf8');
+    this.buffer = '';
+  }
+}

--- a/test/unit/lib/bridge-client.test.ts
+++ b/test/unit/lib/bridge-client.test.ts
@@ -94,4 +94,28 @@ describe.skipIf(onWindows)('BridgeClient.connect retry', () => {
     // margin keeps this robust under parallel-suite CPU contention.
     expect(Date.now() - start).toBeLessThan(2500);
   });
+
+  it('preserves UTF-8 in a response split inside a multibyte character', async () => {
+    const p = sockPath();
+    const server = net.createServer((conn) => {
+      conn.once('data', (requestData) => {
+        const request = JSON.parse(requestData.toString().trim()) as { id: string };
+        const response = Buffer.from(
+          `${JSON.stringify({ type: 'response', id: request.id, result: 'ready 🚀' })}\n`
+        );
+        const emojiStart = response.indexOf(Buffer.from('🚀'));
+
+        conn.write(response.subarray(0, emojiStart + 2));
+        setTimeout(() => conn.write(response.subarray(emojiStart + 2)), 25);
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(p, resolve));
+
+    const client = new BridgeClient(p);
+    clients.push(client);
+    await client.connect();
+
+    await expect(client.request('status')).resolves.toBe('ready 🚀');
+  });
 });

--- a/test/unit/lib/ipc-line-buffer.test.ts
+++ b/test/unit/lib/ipc-line-buffer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { IpcLineBuffer } from '../../../src/lib/ipc-line-buffer.js';
+
+describe('IpcLineBuffer', () => {
+  it('preserves a multibyte UTF-8 character split across socket chunks', () => {
+    const input = '{"city":"München","status":"ready 🚀"}\n';
+    const encoded = Buffer.from(input);
+    const emojiStart = encoded.indexOf(Buffer.from('🚀'));
+    const buffer = new IpcLineBuffer();
+
+    buffer.append(encoded.subarray(0, emojiStart + 2));
+    expect(buffer.drainLines()).toEqual([]);
+
+    buffer.append(encoded.subarray(emojiStart + 2));
+    expect(buffer.drainLines()).toEqual([input.trimEnd()]);
+  });
+
+  it('drains complete lines and retains a trailing partial frame', () => {
+    const buffer = new IpcLineBuffer();
+
+    buffer.append(Buffer.from('{"id":1}\n{"id":'));
+    expect(buffer.drainLines()).toEqual(['{"id":1}']);
+
+    buffer.append(Buffer.from('2}\n'));
+    expect(buffer.drainLines()).toEqual(['{"id":2}']);
+  });
+});


### PR DESCRIPTION
## Summary

- decode IPC data incrementally per socket connection
- share the newline framing helper between the bridge and bridge client
- cover a multibyte UTF-8 code point split across socket chunks

## Why

Socket chunk boundaries can split a UTF-8 code point. Decoding each chunk independently replaces the partial bytes before the newline-delimited JSON frame is assembled, silently corrupting string values even though the JSON remains valid.

## Validation

- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` — 43 files, 1,081 tests passed
