### PR TITLE
fix(x402): refuse to sign when the 402 resource is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Confidential-client sessions now also refresh against authorization servers that accept only HTTP Basic client authentication. The refresh presents the client secret the way the login did and retries with the other form if the server rejects it. (#387)
 - Sessions no longer lose their saved OAuth refresh token when a server that does not rotate refresh tokens omits `refresh_token` from the refresh response. The bridge used to overwrite the stored token with nothing, so the session could not authenticate after the access token expired and required a new `mcpc login`.
 - Accented text, CJK characters, and emoji in large tool results are no longer corrupted in transit: a multibyte character that landed on a socket chunk boundary between the CLI and the bridge was replaced with `�`, and the JSON stayed valid so nothing reported an error. (#390)
+- x402 auto-pay no longer signs when the PAYMENT-REQUIRED `resource.url` is unreachable (timeout, DNS, or connection error). Ghost 402s used to settle against a dead host.
 
 ### Changed
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -152,6 +152,8 @@ Protocol version:
 x402 payments (experimental):
   --x402 pays for paid tool calls from the wallet set up with mcpc x402.
   Schemes: auto (default, prefers upto), upto, exact.
+  A 402 whose resource.url is unreachable (timeout, DNS, connection) is
+  refused — mcpc does not sign or settle against a dead host.
 
 Output:
   For a single server, shows session, server info, capabilities, and tools.

--- a/skills/mcpc/SKILL.md
+++ b/skills/mcpc/SKILL.md
@@ -253,7 +253,7 @@ mcpc @apify skills-get <name> --raw    # print the SKILL.md markdown (pipe to a 
 
 (`--no-profile`, `--stdio`, `--proxy`, and `-H` are options of `connect`, not global flags.)
 
-`mcpc` also has experimental `--x402` auto-payment for paid MCP tools — see `mcpc help x402`.
+`mcpc` also has experimental `--x402` auto-payment for paid MCP tools — see `mcpc help x402`. A 402 whose `resource.url` is unreachable is refused (no sign, no settle).
 
 ## Debugging
 

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1372,6 +1372,15 @@ class BridgeProcess {
       return { handled: false };
     }
 
+    const { probeHttpResource } = await import('../lib/x402/resource-probe.js');
+    const reachability = await probeHttpResource(parsed.resource?.url);
+    if (reachability === 'unreachable') {
+      logger.warn(
+        `x402 resource unreachable, refusing to sign: ${parsed.resource?.url ?? '<none>'}`
+      );
+      return { handled: false };
+    }
+
     logger.debug('Payment-required tool result received, signing fresh payment and retrying...');
 
     // The challenge is the only proof that this tool is paid on servers that advertise no

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -522,6 +522,8 @@ ${chalk.bold('Protocol version:')}
 ${chalk.bold('x402 payments (experimental):')}
   --x402 pays for paid tool calls from the wallet set up with mcpc x402.
   Schemes: auto (default, prefers upto), upto, exact.
+  A 402 whose resource.url is unreachable (timeout, DNS, connection) is
+  refused — mcpc does not sign or settle against a dead host.
 ${outputHelp([
   'For a single server, shows session, server info, capabilities, and tools.',
   'Bulk connects list every session with its state, then a summary.',

--- a/src/lib/x402/fetch-middleware.ts
+++ b/src/lib/x402/fetch-middleware.ts
@@ -4,7 +4,8 @@
  * Wraps the fetch function used by StreamableHTTPClientTransport to:
  * 1. Reuse a cached payment signature across calls to paid tools within a session
  * 2. Sign a fresh payment on the first call (or after cache invalidation)
- * 3. Handle HTTP 402 responses by parsing PAYMENT-REQUIRED, signing, and retrying once
+ * 3. Handle HTTP 402 responses by parsing PAYMENT-REQUIRED, probing
+ *    `resource.url` (fail closed if unreachable), signing, and retrying once
  *
  * Payment is injected in two places simultaneously (server decides which to use):
  * - HTTP header: PAYMENT-SIGNATURE (base64-encoded payment payload)
@@ -28,6 +29,7 @@ import {
   type SchemePreference,
 } from './signer.js';
 import { createLogger } from '../logger.js';
+import { probeHttpResource } from './resource-probe.js';
 
 const logger = createLogger('x402-middleware');
 
@@ -289,6 +291,14 @@ async function handle402Fallback(
     ({ header, accept } = parsePaymentRequired(paymentRequiredBase64, schemePreference));
   } catch (error) {
     logger.warn('Failed to parse PAYMENT-REQUIRED header:', error);
+    return response402;
+  }
+
+  const reachability = await probeHttpResource(header.resource?.url, {
+    alreadyReachedUrl: String(url),
+  });
+  if (reachability === 'unreachable') {
+    logger.warn(`x402 resource unreachable, refusing to sign: ${header.resource?.url ?? '<none>'}`);
     return response402;
   }
 

--- a/src/lib/x402/resource-probe.ts
+++ b/src/lib/x402/resource-probe.ts
@@ -1,0 +1,84 @@
+/**
+ * Liveness probe for an x402 PAYMENT-REQUIRED `resource.url`.
+ *
+ * HTTP 402 means "pay me" — not "I exist." Ghost bazaar URLs still return 402
+ * (or a cached PAYMENT-REQUIRED) while the host is gone. Signing before that
+ * check settles against a dead resource.
+ *
+ * Fail closed on timeout / DNS / connection errors. Any HTTP status, including
+ * 402, means a host answered and payment may proceed.
+ */
+
+export const X402_RESOURCE_PROBE_TIMEOUT_MS = 5_000;
+
+export type ResourceProbeResult = 'reachable' | 'unreachable' | 'skipped';
+
+export interface ProbeHttpResourceOptions {
+  /** Injected fetch (tests). Defaults to `globalThis.fetch`. */
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+  /**
+   * URL we already got an HTTP response from (the 402 itself). If it matches
+   * `resource.url`, skip the extra round-trip.
+   */
+  alreadyReachedUrl?: string;
+}
+
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function sameHttpTarget(left: string, right: string): boolean {
+  try {
+    const a = new URL(left);
+    const b = new URL(right);
+    return a.origin === b.origin && a.pathname === b.pathname;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Probe `resourceUrl` before signing an x402 payment.
+ *
+ * - `skipped` — no http(s) URL, or we already reached the same target
+ * - `reachable` — the host returned any HTTP status
+ * - `unreachable` — timeout, DNS, or connection failure; do not sign
+ */
+export async function probeHttpResource(
+  resourceUrl: string | undefined,
+  options: ProbeHttpResourceOptions = {}
+): Promise<ResourceProbeResult> {
+  if (!resourceUrl || !isHttpUrl(resourceUrl)) {
+    return 'skipped';
+  }
+  if (options.alreadyReachedUrl && sameHttpTarget(resourceUrl, options.alreadyReachedUrl)) {
+    return 'skipped';
+  }
+
+  const fetchFn = options.fetch ?? globalThis.fetch;
+  const timeoutMs = options.timeoutMs ?? X402_RESOURCE_PROBE_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetchFn(resourceUrl, {
+      method: 'GET',
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: { Accept: '*/*' },
+    });
+    // Status is irrelevant — 402/404/500 all mean a host answered.
+    await response.body?.cancel();
+    return 'reachable';
+  } catch {
+    return 'unreachable';
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/test/unit/lib/x402/fetch-middleware.test.ts
+++ b/test/unit/lib/x402/fetch-middleware.test.ts
@@ -276,6 +276,10 @@ describe('createX402FetchMiddleware HTTP 402 fallback', () => {
     JSON.stringify({ x402Version: 2, accepts: [EXACT_ACCEPT] })
   ).toString('base64');
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('remembers the charged tool, so the next call to it reuses the signature', async () => {
     const cache: X402PaymentCache = { signature: null };
     const baseFetch = vi
@@ -302,6 +306,70 @@ describe('createX402FetchMiddleware HTTP 402 fallback', () => {
     expect(baseFetch).toHaveBeenCalledTimes(3);
     const init = baseFetch.mock.calls[2]?.[1] as RequestInit;
     expect(new Headers(init.headers).get('PAYMENT-SIGNATURE')).toBe('mock-signature-base64');
+  });
+
+  it('does not sign when PAYMENT-REQUIRED resource.url is unreachable', async () => {
+    const headerWithGhost = Buffer.from(
+      JSON.stringify({
+        x402Version: 2,
+        accepts: [EXACT_ACCEPT],
+        resource: { url: 'https://ghost.test/v1/ping' },
+      })
+    ).toString('base64');
+    const cache: X402PaymentCache = { signature: null };
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response('', { status: 402, headers: { 'PAYMENT-REQUIRED': headerWithGhost } })
+      );
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('fetch failed')));
+    const fetchFn = createX402FetchMiddleware(baseFetch as never, {
+      wallet: WALLET,
+      getToolByName: () => undefined,
+      paymentCache: cache,
+    });
+
+    const response = await fetchFn('https://example.test/mcp', {
+      method: 'POST',
+      body: toolsCallBody('paid-tool'),
+    });
+
+    expect(response.status).toBe(402);
+    expect(mockSignPayment).not.toHaveBeenCalled();
+    expect(cache.signature).toBeNull();
+    expect(baseFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('signs after a reachable resource.url probe', async () => {
+    const headerWithLive = Buffer.from(
+      JSON.stringify({
+        x402Version: 2,
+        accepts: [EXACT_ACCEPT],
+        resource: { url: 'https://live.test/v1/ping' },
+      })
+    ).toString('base64');
+    const cache: X402PaymentCache = { signature: null };
+    const baseFetch = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response('', { status: 402, headers: { 'PAYMENT-REQUIRED': headerWithLive } })
+      )
+      .mockResolvedValue(new Response('', { status: 200 }));
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 402 })));
+    const fetchFn = createX402FetchMiddleware(baseFetch as never, {
+      wallet: WALLET,
+      getToolByName: () => undefined,
+      paymentCache: cache,
+    });
+
+    const response = await fetchFn('https://example.test/mcp', {
+      method: 'POST',
+      body: toolsCallBody('paid-tool'),
+    });
+
+    expect(response.status).toBe(200);
+    expect(mockSignPayment).toHaveBeenCalledTimes(1);
+    expect(baseFetch).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/test/unit/lib/x402/resource-probe.test.ts
+++ b/test/unit/lib/x402/resource-probe.test.ts
@@ -1,0 +1,72 @@
+import {
+  probeHttpResource,
+  X402_RESOURCE_PROBE_TIMEOUT_MS,
+} from '../../../../src/lib/x402/resource-probe.js';
+
+function jsonResponse(status: number): Response {
+  return new Response('ok', { status });
+}
+
+describe('probeHttpResource', () => {
+  it('skips when resource URL is missing', async () => {
+    const fetchFn = vi.fn();
+    await expect(probeHttpResource(undefined, { fetch: fetchFn })).resolves.toBe('skipped');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('skips non-http resource URLs', async () => {
+    const fetchFn = vi.fn();
+    await expect(probeHttpResource('mcp://tool/paid', { fetch: fetchFn })).resolves.toBe('skipped');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('skips when the resource is the URL we already got a 402 from', async () => {
+    const fetchFn = vi.fn();
+    await expect(
+      probeHttpResource('https://mcp.apify.com/mcp?session=1', {
+        fetch: fetchFn,
+        alreadyReachedUrl: 'https://mcp.apify.com/mcp',
+      })
+    ).resolves.toBe('skipped');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('treats HTTP 402 as reachable (a host answered)', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(402));
+    await expect(probeHttpResource('https://ghost.test/v1/ping', { fetch: fetchFn })).resolves.toBe(
+      'reachable'
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats HTTP 200 as reachable', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(200));
+    await expect(probeHttpResource('https://live.test/pay', { fetch: fetchFn })).resolves.toBe(
+      'reachable'
+    );
+  });
+
+  it('returns unreachable on DNS / connection failure', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError('fetch failed'));
+    await expect(probeHttpResource('https://dead.test/pay', { fetch: fetchFn })).resolves.toBe(
+      'unreachable'
+    );
+  });
+
+  it('returns unreachable when the probe times out', async () => {
+    const fetchFn = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          reject(new DOMException('The operation was aborted.', 'AbortError'));
+        });
+      });
+    });
+    await expect(
+      probeHttpResource('https://hang.test/pay', { fetch: fetchFn, timeoutMs: 20 })
+    ).resolves.toBe('unreachable');
+  });
+
+  it('exposes a 5s default probe budget', () => {
+    expect(X402_RESOURCE_PROBE_TIMEOUT_MS).toBe(5_000);
+  });
+});


### PR DESCRIPTION
## Summary

HTTP 402 is not proof the paid host is alive. Ghost bazaar URLs still return a `PAYMENT-REQUIRED` (or a cached one) after the origin is gone, and mcpc signed anyway.

This probes `resource.url` **before** `signPayment`:

- timeout / DNS / connection failure → fail closed (pass the 402 through, do not sign, do not settle)
- any HTTP status, including 402 → a host answered, payment may proceed
- missing / non-http `resource.url`, or the same target we already got the 402 from → skip the extra round-trip

Same guard on the tool-result retry path in the bridge.

No new flags. No vendor default. Useful even if you strip the probe later.

The probe uses GET (body cancelled), not HEAD: live hosts that omit HEAD can hang until timeout, which would fail-closed on a reachable resource.

## Test plan

- [x] `vitest run test/unit/lib/x402` — 53 passed (probe skip/reachable/unreachable/timeout + middleware refuses to sign on ghost URL, still signs when the probe answers). Re-run locally after the follow-up commit, same 53.
- [ ] `pnpm run test:unit` on CI (first-time contributor — Actions is waiting for workflow approval)
- [ ] Confirm a live paid tool (e.g. mcp.apify.com with `--x402`) still settles
- [ ] Confirm a 402 whose `resource.url` does not resolve does **not** produce a PAYMENT-SIGNATURE